### PR TITLE
Add automatic git versioning for exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ confluence-export find SPACEKEY "query"             # search pages by title
 confluence-export export SPACEKEY -o ./output       # export full space
 confluence-export export SPACEKEY --path /Sub/Tree  # export a subtree
 confluence-export export SPACEKEY --no-media        # skip attachments
+confluence-export export SPACEKEY --no-git          # skip git versioning
 confluence-export diff SPACEKEY ./output            # compare export vs. live
 confluence-export refresh SPACEKEY                  # force-refresh cache
 ```
+
+## Git Versioning
+
+Exports are automatically versioned with git. After each export, only Confluence-sourced files are committed. If you've made local edits to previously exported files, those are captured in a separate commit first. Locally created files are never auto-committed.
+
+Git versioning is enabled by default and requires git to be installed. If git is not available, the export proceeds normally with a warning. Disable with `--no-git`.

--- a/src/confluence_export/cli.py
+++ b/src/confluence_export/cli.py
@@ -186,6 +186,7 @@ def main() -> None:
     export_p.add_argument("--cached", action="store_true", help="Use cached data instead of refreshing from Confluence")
     export_p.add_argument("--include-html", action="store_true", help="Save raw HTML alongside markdown")
     export_p.add_argument("--include-archived", action="store_true", help="Include archived pages (skipped by default)")
+    export_p.add_argument("--no-git", action="store_true", help="Skip automatic git versioning")
 
     # diff
     diff_p = sub.add_parser("diff", help="Compare export dir against current Confluence state")
@@ -259,6 +260,7 @@ def main() -> None:
                 force_refresh=not args.cached,
                 debug=args.include_html,
                 include_archived=args.include_archived,
+                no_git=args.no_git,
             )
         case "diff":
             _cmd_diff(
@@ -381,12 +383,25 @@ def _cmd_export(
     force_refresh: bool,
     debug: bool = False,
     include_archived: bool = False,
+    no_git: bool = False,
 ) -> None:
     """Export page tree as LLM-ready markdown."""
     space = _with_auth_fallback(lambda: _resolve_space(client, space_key), client, config)
 
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
+
+    # Git: pre-export
+    use_git = False
+    if not no_git:
+        from confluence_export.git import git_available, ensure_repo, commit_local_changes
+
+        if git_available():
+            if ensure_repo(out):
+                use_git = True
+                commit_local_changes(out)
+        else:
+            print("Warning: git not found, skipping git versioning.", file=sys.stderr)
 
     exporter = Exporter(
         client,
@@ -397,7 +412,7 @@ def _cmd_export(
         debug=debug,
     )
 
-    count = exporter.export_space(
+    result = exporter.export_space(
         space,
         out,
         path_filter=path_filter,
@@ -406,7 +421,13 @@ def _cmd_export(
         include_archived=include_archived,
     )
 
-    print(f"\nExported {count} page(s) to {out.resolve()}")
+    # Git: post-export
+    if use_git and result.written_files:
+        from confluence_export.git import commit_export
+
+        commit_export(out, result.written_files, space_key)
+
+    print(f"\nExported {result.count} page(s) to {out.resolve()}")
 
 
 def _cmd_diff(

--- a/src/confluence_export/cli.py
+++ b/src/confluence_export/cli.py
@@ -388,7 +388,7 @@ def _cmd_export(
     """Export page tree as LLM-ready markdown."""
     space = _with_auth_fallback(lambda: _resolve_space(client, space_key), client, config)
 
-    out = Path(output_dir)
+    out = Path(output_dir).resolve()
     out.mkdir(parents=True, exist_ok=True)
 
     # Git: pre-export

--- a/src/confluence_export/exporter.py
+++ b/src/confluence_export/exporter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from confluence_export.cache import CacheStore
@@ -23,6 +24,14 @@ from confluence_export.tree import (
     page_path,
 )
 from confluence_export.types import Attachment, CachedSpace, Page, PageNode, Space
+
+
+@dataclass
+class ExportResult:
+    """Result of an export operation."""
+
+    count: int = 0
+    written_files: list[Path] = field(default_factory=list)
 
 
 class Exporter:
@@ -96,8 +105,8 @@ class Exporter:
         no_children: bool = False,
         force_refresh: bool = False,
         include_archived: bool = False,
-    ) -> int:
-        """Export a space (or subtree) to output_dir. Returns number of pages exported."""
+    ) -> ExportResult:
+        """Export a space (or subtree) to output_dir."""
         # Ensure cache
         if force_refresh:
             cs = self.cache.refresh(self.client, space)
@@ -116,28 +125,29 @@ class Exporter:
             node = find_node_by_path(roots, path_filter)
             if not node:
                 print(f"Error: path '{path_filter}' not found in space {space.key}", file=sys.stderr)
-                return 0
+                return ExportResult()
             if no_children:
                 nodes_to_export = [node]
             else:
-                nodes_to_export = [node]  # _export_node handles recursion
                 return self._export_node(node, output_dir, cs, space.key, depth=0)
         else:
             if no_children:
-                # Export only root pages
                 nodes_to_export = roots
             else:
-                count = 0
+                result = ExportResult()
                 for root in roots:
-                    count += self._export_node(root, output_dir, cs, space.key, depth=0)
-                return count
+                    r = self._export_node(root, output_dir, cs, space.key, depth=0)
+                    result.count += r.count
+                    result.written_files.extend(r.written_files)
+                return result
 
         # Export flat list (no_children case)
-        count = 0
+        result = ExportResult()
         for node in nodes_to_export:
-            self._export_single_page(node.page, output_dir, cs, space.key)
-            count += 1
-        return count
+            files = self._export_single_page(node.page, output_dir, cs, space.key)
+            result.count += 1 if files else 0
+            result.written_files.extend(files)
+        return result
 
     def _export_node(
         self,
@@ -146,7 +156,7 @@ class Exporter:
         cs: CachedSpace,
         space_key: str,
         depth: int,
-    ) -> int:
+    ) -> ExportResult:
         """Recursively export a node and its children."""
         page = node.page
         dir_name = sanitize_filename(page.title)
@@ -156,12 +166,15 @@ class Exporter:
         indent = "  " * depth
         print(f"{indent}Exporting: {page.title}")
 
-        count = self._export_single_page(page, page_dir, cs, space_key)
+        files = self._export_single_page(page, page_dir, cs, space_key)
+        result = ExportResult(count=1 if files else 0, written_files=list(files))
 
         for child in node.children:
-            count += self._export_node(child, page_dir, cs, space_key, depth + 1)
+            child_result = self._export_node(child, page_dir, cs, space_key, depth + 1)
+            result.count += child_result.count
+            result.written_files.extend(child_result.written_files)
 
-        return count
+        return result
 
     def _export_single_page(
         self,
@@ -169,11 +182,11 @@ class Exporter:
         page_dir: Path,
         cs: CachedSpace,
         space_key: str,
-    ) -> int:
-        """Export a single page: fetch body, convert, download media, write file."""
+    ) -> list[Path]:
+        """Export a single page. Returns list of files written (empty if skipped)."""
         # Folders are structural only — no content to export
         if page.status == "folder":
-            return 0
+            return []
 
         # Fetch full page body if not already loaded
         if not page.body_storage:
@@ -187,7 +200,7 @@ class Exporter:
                     page.webui = full_page.webui
             except Exception as exc:
                 print(f"  Warning: could not fetch body for {page.title}: {exc}", file=sys.stderr)
-                return 0
+                return []
 
         # Get attachments from cache
         attachments = cs.attachments.get(page.id, [])
@@ -196,10 +209,10 @@ class Exporter:
         path = page_path(cs.pages, page.id)
 
         # Download media
-        downloaded_files: list = []
+        written: list[Path] = []
         if self.download_media and attachments:
             media_dir = ensure_media_dir(page_dir)
-            downloaded_files = download_attachments(self.client, attachments, media_dir)
+            written.extend(download_attachments(self.client, attachments, media_dir))
 
         # Convert to markdown
         markdown = convert_page(
@@ -223,6 +236,7 @@ class Exporter:
                         png_path = render_drawio_to_png(drawio_file)
                         if png_path:
                             rendered[att.title] = png_path
+                            written.append(png_path)
                 if rendered:
                     markdown = replace_drawio_placeholders(markdown, rendered)
 
@@ -230,10 +244,12 @@ class Exporter:
         base_filename = sanitize_filename(page.title)
         md_path = page_dir / (base_filename + ".md")
         md_path.write_text(markdown, encoding="utf-8")
+        written.append(md_path)
 
         # Debug: save raw HTML alongside markdown
         if self.debug:
             html_path = page_dir / (base_filename + ".html")
             html_path.write_text(page.body_storage, encoding="utf-8")
+            written.append(html_path)
 
-        return 1
+        return written

--- a/src/confluence_export/git.py
+++ b/src/confluence_export/git.py
@@ -1,0 +1,87 @@
+"""Git versioning for export directories."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def git_available() -> bool:
+    """Check if git is installed and accessible."""
+    return shutil.which("git") is not None
+
+
+def _run_git(
+    repo_dir: Path, *args: str, check: bool = True
+) -> subprocess.CompletedProcess | None:
+    """Run a git command in repo_dir. Returns None on failure (with warning)."""
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=check,
+        )
+    except subprocess.CalledProcessError as exc:
+        print(f"  Warning: git {args[0]} failed: {exc.stderr.strip()}", file=sys.stderr)
+        return None
+    except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        print(f"  Warning: git {args[0]} failed: {exc}", file=sys.stderr)
+        return None
+
+
+def ensure_repo(output_dir: Path) -> bool:
+    """Ensure output_dir is inside a git repo (init if needed). Returns True if usable."""
+    # Check if already inside a git repo
+    result = _run_git(output_dir, "rev-parse", "--git-dir", check=False)
+    if result and result.returncode == 0:
+        return True
+
+    # Initialize a new repo
+    print("Initializing git repository...", file=sys.stderr)
+    return _run_git(output_dir, "init") is not None
+
+
+def commit_local_changes(output_dir: Path) -> bool:
+    """Commit modifications to already-tracked files (pre-export safety commit).
+
+    Only stages changes to tracked files (git add -u), ignoring untracked files.
+    Returns True if a commit was made.
+    """
+    # Stage only modifications to tracked files within output_dir
+    if _run_git(output_dir, "add", "-u", ".") is None:
+        return False
+
+    # Check if anything was staged
+    result = _run_git(output_dir, "diff", "--cached", "--quiet", check=False)
+    if result is None or result.returncode == 0:
+        # Nothing staged or error
+        return False
+
+    # Commit the local changes
+    return _run_git(output_dir, "commit", "-m", "Local changes before Confluence export") is not None
+
+
+def commit_export(output_dir: Path, written_files: list[Path], space_key: str) -> bool:
+    """Stage and commit only the exporter-written files.
+
+    Returns True if a commit was made.
+    """
+    # Stage only the files the exporter wrote
+    paths = [str(f) for f in written_files]
+    if _run_git(output_dir, "add", "--", *paths) is None:
+        return False
+
+    # Check if anything was staged
+    result = _run_git(output_dir, "diff", "--cached", "--quiet", check=False)
+    if result is None or result.returncode == 0:
+        return False
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    msg = f"Export Confluence space {space_key} ({timestamp})"
+    return _run_git(output_dir, "commit", "-m", msg) is not None

--- a/src/confluence_export/git.py
+++ b/src/confluence_export/git.py
@@ -35,6 +35,12 @@ def _run_git(
         return None
 
 
+def _has_commits(repo_dir: Path) -> bool:
+    """Check whether the repo has at least one commit."""
+    result = _run_git(repo_dir, "rev-parse", "HEAD", check=False)
+    return result is not None and result.returncode == 0
+
+
 def ensure_repo(output_dir: Path) -> bool:
     """Ensure output_dir is inside a git repo (init if needed). Returns True if usable."""
     # Check if already inside a git repo
@@ -42,17 +48,25 @@ def ensure_repo(output_dir: Path) -> bool:
     if result and result.returncode == 0:
         return True
 
-    # Initialize a new repo
+    # Initialize a new repo with a fallback identity
     print("Initializing git repository...", file=sys.stderr)
-    return _run_git(output_dir, "init") is not None
+    if _run_git(output_dir, "init") is None:
+        return False
+    _run_git(output_dir, "config", "user.name", "confluence-export")
+    _run_git(output_dir, "config", "user.email", "confluence-export@localhost")
+    return True
 
 
 def commit_local_changes(output_dir: Path) -> bool:
     """Commit modifications to already-tracked files (pre-export safety commit).
 
     Only stages changes to tracked files (git add -u), ignoring untracked files.
+    Skips entirely on a fresh repo with no commits.
     Returns True if a commit was made.
     """
+    if not _has_commits(output_dir):
+        return False
+
     # Stage only modifications to tracked files within output_dir
     if _run_git(output_dir, "add", "-u", ".") is None:
         return False
@@ -60,10 +74,8 @@ def commit_local_changes(output_dir: Path) -> bool:
     # Check if anything was staged
     result = _run_git(output_dir, "diff", "--cached", "--quiet", check=False)
     if result is None or result.returncode == 0:
-        # Nothing staged or error
         return False
 
-    # Commit the local changes
     return _run_git(output_dir, "commit", "-m", "Local changes before Confluence export") is not None
 
 

--- a/src/confluence_export/git.py
+++ b/src/confluence_export/git.py
@@ -80,14 +80,19 @@ def commit_local_changes(output_dir: Path) -> bool:
 
 
 def commit_export(output_dir: Path, written_files: list[Path], space_key: str) -> bool:
-    """Stage and commit only the exporter-written files.
+    """Stage exporter-written files and remove stale tracked files.
 
+    Stages written_files, then removes any tracked files under output_dir that
+    are not in written_files (handles upstream deletions, renames, and moves).
     Returns True if a commit was made.
     """
     # Stage only the files the exporter wrote
     paths = [str(f) for f in written_files]
     if _run_git(output_dir, "add", "--", *paths) is None:
         return False
+
+    # Remove stale tracked files (deletions/renames/moves upstream)
+    _remove_stale_files(output_dir, written_files)
 
     # Check if anything was staged
     result = _run_git(output_dir, "diff", "--cached", "--quiet", check=False)
@@ -97,3 +102,23 @@ def commit_export(output_dir: Path, written_files: list[Path], space_key: str) -
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     msg = f"Export Confluence space {space_key} ({timestamp})"
     return _run_git(output_dir, "commit", "-m", msg) is not None
+
+
+def _remove_stale_files(output_dir: Path, written_files: list[Path]) -> None:
+    """Remove tracked files that are no longer part of the export."""
+    if not _has_commits(output_dir):
+        return
+
+    result = _run_git(output_dir, "ls-files", ".", check=False)
+    if result is None or not result.stdout.strip():
+        return
+
+    written_resolved = {f.resolve() for f in written_files}
+    stale = []
+    for rel_path in result.stdout.strip().splitlines():
+        full = (output_dir / rel_path).resolve()
+        if full not in written_resolved:
+            stale.append(rel_path)
+
+    if stale:
+        _run_git(output_dir, "rm", "--quiet", "--", *stale)

--- a/src/confluence_export/media.py
+++ b/src/confluence_export/media.py
@@ -91,5 +91,6 @@ def download_attachments(
             versions.setdefault(att.title, att.version.number)
 
     _save_versions(media_dir, versions)
+    downloaded.append(media_dir / _VERSIONS_FILE)
 
     return downloaded

--- a/src/confluence_export/media.py
+++ b/src/confluence_export/media.py
@@ -32,7 +32,7 @@ def download_attachments(
 
     for att in attachments:
         dest = media_dir / att.title
-        if skip_existing and dest.exists() and dest.stat().st_size == att.file_size:
+        if skip_existing and dest.exists() and dest.stat().st_size > 0:
             downloaded.append(dest)
             continue
         if not att.download_link:

--- a/src/confluence_export/media.py
+++ b/src/confluence_export/media.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -9,12 +10,32 @@ from pathlib import Path
 from confluence_export.client import ConfluenceClient
 from confluence_export.types import Attachment
 
+_VERSIONS_FILE = ".versions.json"
+
 
 def ensure_media_dir(page_dir: Path) -> Path:
     """Create and return the media/ subdirectory for a page."""
     media_dir = page_dir / "media"
     media_dir.mkdir(parents=True, exist_ok=True)
     return media_dir
+
+
+def _load_versions(media_dir: Path) -> dict[str, int]:
+    """Load the version manifest from a media directory."""
+    p = media_dir / _VERSIONS_FILE
+    if p.exists():
+        try:
+            with open(p) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return {}
+    return {}
+
+
+def _save_versions(media_dir: Path, versions: dict[str, int]) -> None:
+    """Save the version manifest to a media directory."""
+    with open(media_dir / _VERSIONS_FILE, "w") as f:
+        json.dump(versions, f, indent=2)
 
 
 def download_attachments(
@@ -25,14 +46,20 @@ def download_attachments(
 ) -> list[Path]:
     """Download attachments to media_dir. Returns list of downloaded file paths.
 
-    Skips files that already exist with matching size when skip_existing=True.
+    Skips files whose local version matches the API version when skip_existing=True.
     """
+    versions = _load_versions(media_dir) if skip_existing else {}
     downloaded: list[Path] = []
     to_download: list[tuple[Attachment, Path]] = []
 
     for att in attachments:
         dest = media_dir / att.title
-        if skip_existing and dest.exists() and dest.stat().st_size > 0:
+        if (
+            skip_existing
+            and dest.exists()
+            and att.version.number > 0
+            and versions.get(att.title) == att.version.number
+        ):
             downloaded.append(dest)
             continue
         if not att.download_link:
@@ -54,7 +81,15 @@ def download_attachments(
             att, dest = futures[future]
             try:
                 downloaded.append(future.result())
+                versions[att.title] = att.version.number
             except Exception as exc:
                 print(f"  Warning: failed to download {att.title}: {exc}", file=sys.stderr)
+
+    # Also record versions for skipped files (in case manifest was missing)
+    for att in attachments:
+        if att.version.number > 0:
+            versions.setdefault(att.title, att.version.number)
+
+    _save_versions(media_dir, versions)
 
     return downloaded

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -174,6 +174,35 @@ class TestExportCommand:
         )
         assert status.stdout.strip() == ""
 
+    def test_export_with_relative_path_inside_repo(self, tmp_path, capsys, monkeypatch):
+        """Relative output path (e.g. ./output) works with git versioning."""
+        import subprocess
+
+        # Initialize a parent repo (simulates user's project repo)
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "t@t"], cwd=tmp_path, capture_output=True)
+
+        client = _mock_client()
+        cache = MagicMock()
+        cache.refresh.return_value = _cached_space()
+        # Use a relative path from tmp_path
+        monkeypatch.chdir(tmp_path)
+        with patch("sys.argv", ["confluence-export", "export", "TEST", "-o", "output", "--no-media"]), \
+             patch("confluence_export.cli.load_config", return_value=_config()), \
+             patch("confluence_export.cli.ConfluenceClient", return_value=client), \
+             patch("confluence_export.cli.CacheStore", return_value=cache):
+            main()
+
+        out = tmp_path / "output"
+        log = subprocess.run(
+            ["git", "log", "--oneline"], cwd=out, capture_output=True, text=True
+        )
+        assert "Export Confluence space TEST" in log.stdout
+
+        md_files = list(out.rglob("*.md"))
+        assert len(md_files) == 2
+
     def test_no_git_flag_skips_versioning(self, tmp_path):
         client = _mock_client()
         cache = MagicMock()

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -135,7 +135,7 @@ class TestExportCommand:
         cache = MagicMock()
         cache.refresh.return_value = _cached_space()
         out = str(tmp_path / "out")
-        with patch("sys.argv", ["confluence-export", "export", "TEST", "-o", out, "--no-media"]), \
+        with patch("sys.argv", ["confluence-export", "export", "TEST", "-o", out, "--no-media", "--no-git"]), \
              patch("confluence_export.cli.load_config", return_value=_config()), \
              patch("confluence_export.cli.ConfluenceClient", return_value=client), \
              patch("confluence_export.cli.CacheStore", return_value=cache):
@@ -147,6 +147,45 @@ class TestExportCommand:
         # Verify actual files were written
         md_files = list(Path(out).rglob("*.md"))
         assert len(md_files) == 2
+
+
+    def test_export_creates_git_commit(self, tmp_path, capsys):
+        import subprocess
+
+        client = _mock_client()
+        cache = MagicMock()
+        cache.refresh.return_value = _cached_space()
+        out = str(tmp_path / "out")
+        with patch("sys.argv", ["confluence-export", "export", "TEST", "-o", out, "--no-media"]), \
+             patch("confluence_export.cli.load_config", return_value=_config()), \
+             patch("confluence_export.cli.ConfluenceClient", return_value=client), \
+             patch("confluence_export.cli.CacheStore", return_value=cache):
+            main()
+
+        # Verify git repo was created and export was committed
+        log = subprocess.run(
+            ["git", "log", "--oneline"], cwd=out, capture_output=True, text=True
+        )
+        assert "Export Confluence space TEST" in log.stdout
+
+        # Verify working tree is clean (no untracked files from export)
+        status = subprocess.run(
+            ["git", "status", "--porcelain"], cwd=out, capture_output=True, text=True
+        )
+        assert status.stdout.strip() == ""
+
+    def test_no_git_flag_skips_versioning(self, tmp_path):
+        client = _mock_client()
+        cache = MagicMock()
+        cache.refresh.return_value = _cached_space()
+        out = str(tmp_path / "out")
+        with patch("sys.argv", ["confluence-export", "export", "TEST", "-o", out, "--no-media", "--no-git"]), \
+             patch("confluence_export.cli.load_config", return_value=_config()), \
+             patch("confluence_export.cli.ConfluenceClient", return_value=client), \
+             patch("confluence_export.cli.CacheStore", return_value=cache):
+            main()
+
+        assert not (Path(out) / ".git").exists()
 
 
 class TestRefreshCommand:

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from confluence_export.exporter import Exporter
+from confluence_export.exporter import ExportResult, Exporter
 from confluence_export.types import (
     Attachment,
     CachedSpace,
@@ -98,8 +98,8 @@ class TestTreeExport:
         cs = _make_cached_space(pages=[parent, child])
         cache.ensure_loaded.return_value = cs
 
-        count = exporter.export_space(_make_space(), tmp_path)
-        assert count == 2
+        result = exporter.export_space(_make_space(), tmp_path)
+        assert result.count == 2
 
         parent_md = (tmp_path / "Parent" / "Parent.md").read_text()
         child_md = (tmp_path / "Parent" / "Child" / "Child.md").read_text()
@@ -116,8 +116,8 @@ class TestTreeExport:
         cs = _make_cached_space(pages=[root, sub, leaf])
         cache.ensure_loaded.return_value = cs
 
-        count = exporter.export_space(_make_space(), tmp_path, path_filter="/Root/Sub")
-        assert count == 2  # Sub + Leaf
+        result = exporter.export_space(_make_space(), tmp_path, path_filter="/Root/Sub")
+        assert result.count == 2  # Sub + Leaf
 
         assert (tmp_path / "Sub" / "Sub.md").exists()
         assert (tmp_path / "Sub" / "Leaf" / "Leaf.md").exists()
@@ -127,8 +127,8 @@ class TestTreeExport:
         cs = _make_cached_space()
         cache.ensure_loaded.return_value = cs
 
-        count = exporter.export_space(_make_space(), tmp_path, path_filter="/Nonexistent")
-        assert count == 0
+        result = exporter.export_space(_make_space(), tmp_path, path_filter="/Nonexistent")
+        assert result.count == 0
         assert "not found" in capsys.readouterr().err
 
     def test_no_children_exports_only_roots(self, tmp_path):
@@ -139,8 +139,8 @@ class TestTreeExport:
         cs = _make_cached_space(pages=[parent, child])
         cache.ensure_loaded.return_value = cs
 
-        count = exporter.export_space(_make_space(), tmp_path, no_children=True)
-        assert count == 1  # only the root
+        result = exporter.export_space(_make_space(), tmp_path, no_children=True)
+        assert result.count == 1  # only the root
 
 
 class TestFolderHandling:
@@ -150,8 +150,8 @@ class TestFolderHandling:
         page.status = "folder"
         cs = _make_cached_space()
 
-        count = exporter._export_single_page(page, tmp_path, cs, "TEST")
-        assert count == 0
+        files = exporter._export_single_page(page, tmp_path, cs, "TEST")
+        assert files == []
         assert list(tmp_path.glob("*.md")) == []
 
 
@@ -175,8 +175,8 @@ class TestBodyFetching:
         client.get_page_by_id.side_effect = Exception("timeout")
         cs = _make_cached_space(pages=[page])
 
-        count = exporter._export_single_page(page, tmp_path, cs, "TEST")
-        assert count == 0
+        files = exporter._export_single_page(page, tmp_path, cs, "TEST")
+        assert files == []
         assert "Warning" in capsys.readouterr().err
 
     def test_prefetch_fills_bodies_before_export(self):

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -100,6 +100,9 @@ class TestTreeExport:
 
         result = exporter.export_space(_make_space(), tmp_path)
         assert result.count == 2
+        assert len(result.written_files) == 2
+        written_names = {f.name for f in result.written_files}
+        assert written_names == {"Parent.md", "Child.md"}
 
         parent_md = (tmp_path / "Parent" / "Parent.md").read_text()
         child_md = (tmp_path / "Parent" / "Child" / "Child.md").read_text()

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -214,3 +214,25 @@ class TestCommitExport:
 
         log = subprocess.run(["git", "log", "--oneline"], cwd=tmp_path, capture_output=True, text=True)
         assert "Export Confluence space TEST" in log.stdout
+
+    def test_metadata_files_survive_repeated_exports(self, tmp_path):
+        """Files like .versions.json included in written_files are not removed."""
+        self._init_repo(tmp_path)
+        media = tmp_path / "media"
+        media.mkdir()
+        md = tmp_path / "Page.md"
+        md.write_text("# Page")
+        manifest = media / ".versions.json"
+        manifest.write_text('{"img.png": 1}')
+
+        # First export includes both md and manifest
+        commit_export(tmp_path, [md, manifest], "TEST")
+
+        # Second export with same files
+        md.write_text("# Page v2")
+        manifest.write_text('{"img.png": 2}')
+        commit_export(tmp_path, [md, manifest], "TEST")
+
+        # Manifest should still be tracked
+        ls = subprocess.run(["git", "ls-files"], cwd=tmp_path, capture_output=True, text=True)
+        assert "media/.versions.json" in ls.stdout

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -147,11 +147,48 @@ class TestCommitExport:
         self._init_repo(tmp_path)
         md = tmp_path / "Page.md"
         md.write_text("# Page")
-        subprocess.run(["git", "add", "Page.md"], cwd=tmp_path, capture_output=True)
-        subprocess.run(["git", "commit", "-m", "already committed"], cwd=tmp_path, capture_output=True)
 
-        # Re-export with identical content
+        # First export commits the file
+        commit_export(tmp_path, [md], "TEST")
+
+        # Re-export with identical content — nothing to commit
         assert commit_export(tmp_path, [md], "TEST") is False
+
+    def test_removes_deleted_page(self, tmp_path):
+        """A previously exported page deleted upstream is removed from git."""
+        self._init_repo(tmp_path)
+        old = tmp_path / "OldPage.md"
+        old.write_text("# Old")
+        new = tmp_path / "NewPage.md"
+        new.write_text("# New")
+        subprocess.run(["git", "add", "OldPage.md", "NewPage.md"], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "first export"], cwd=tmp_path, capture_output=True)
+
+        # Second export: OldPage no longer in Confluence, NewPage updated
+        new.write_text("# New v2")
+        commit_export(tmp_path, [new], "TEST")
+
+        # OldPage should be removed from git
+        ls = subprocess.run(["git", "ls-files"], cwd=tmp_path, capture_output=True, text=True)
+        assert "OldPage.md" not in ls.stdout
+        assert "NewPage.md" in ls.stdout
+
+    def test_removes_renamed_page(self, tmp_path):
+        """A page renamed upstream: old name removed, new name added."""
+        self._init_repo(tmp_path)
+        old = tmp_path / "Old-Name.md"
+        old.write_text("# Page")
+        subprocess.run(["git", "add", "Old-Name.md"], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "first export"], cwd=tmp_path, capture_output=True)
+
+        # Renamed in Confluence — exporter writes new filename
+        renamed = tmp_path / "New-Name.md"
+        renamed.write_text("# Page")
+        commit_export(tmp_path, [renamed], "TEST")
+
+        ls = subprocess.run(["git", "ls-files"], cwd=tmp_path, capture_output=True, text=True)
+        assert "Old-Name.md" not in ls.stdout
+        assert "New-Name.md" in ls.stdout
 
     def test_commit_message_contains_timestamp(self, tmp_path):
         self._init_repo(tmp_path)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -33,6 +33,22 @@ class TestEnsureRepo:
         assert ensure_repo(tmp_path) is True
         assert (tmp_path / ".git").is_dir()
 
+    def test_sets_fallback_identity_on_init(self, tmp_path):
+        ensure_repo(tmp_path)
+        name = subprocess.run(
+            ["git", "config", "user.name"], cwd=tmp_path, capture_output=True, text=True
+        )
+        assert name.stdout.strip() == "confluence-export"
+
+    def test_does_not_overwrite_existing_identity(self, tmp_path):
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(["git", "config", "user.name", "Alice"], cwd=tmp_path, capture_output=True)
+        ensure_repo(tmp_path)
+        name = subprocess.run(
+            ["git", "config", "user.name"], cwd=tmp_path, capture_output=True, text=True
+        )
+        assert name.stdout.strip() == "Alice"
+
     def test_inside_parent_repo(self, tmp_path):
         subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
         sub = tmp_path / "sub" / "dir"
@@ -51,7 +67,6 @@ class TestCommitLocalChanges:
 
     def test_no_changes(self, tmp_path):
         self._init_repo(tmp_path)
-        # Create and commit a file so there's a HEAD
         (tmp_path / "file.md").write_text("hello")
         subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
         subprocess.run(["git", "commit", "-m", "init"], cwd=tmp_path, capture_output=True)
@@ -69,7 +84,6 @@ class TestCommitLocalChanges:
 
         assert commit_local_changes(tmp_path) is True
 
-        # Verify commit was made
         log = subprocess.run(["git", "log", "--oneline"], cwd=tmp_path, capture_output=True, text=True)
         assert "Local changes" in log.stdout
 
@@ -82,6 +96,11 @@ class TestCommitLocalChanges:
         # Create untracked file only
         (tmp_path / "local-notes.txt").write_text("my notes")
 
+        assert commit_local_changes(tmp_path) is False
+
+    def test_skips_on_fresh_repo(self, tmp_path):
+        """No crash or noise on a freshly initialized repo with no commits."""
+        self._init_repo(tmp_path)
         assert commit_local_changes(tmp_path) is False
 
 
@@ -147,3 +166,14 @@ class TestCommitExport:
         msg = log.stdout.strip()
         assert "NB" in msg
         assert "UTC" in msg
+
+    def test_fresh_repo_no_identity_needed(self, tmp_path):
+        """ensure_repo sets fallback identity; commit works without global config."""
+        ensure_repo(tmp_path)
+        md = tmp_path / "Page.md"
+        md.write_text("# Page")
+
+        assert commit_export(tmp_path, [md], "TEST") is True
+
+        log = subprocess.run(["git", "log", "--oneline"], cwd=tmp_path, capture_output=True, text=True)
+        assert "Export Confluence space TEST" in log.stdout

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,0 +1,149 @@
+"""Tests for git versioning module."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from confluence_export.git import (
+    commit_export,
+    commit_local_changes,
+    ensure_repo,
+    git_available,
+)
+
+
+class TestGitAvailable:
+    def test_found(self):
+        with patch("confluence_export.git.shutil.which", return_value="/usr/bin/git"):
+            assert git_available() is True
+
+    def test_not_found(self):
+        with patch("confluence_export.git.shutil.which", return_value=None):
+            assert git_available() is False
+
+
+class TestEnsureRepo:
+    def test_already_a_repo(self, tmp_path):
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+        assert ensure_repo(tmp_path) is True
+
+    def test_initializes_new_repo(self, tmp_path):
+        assert ensure_repo(tmp_path) is True
+        assert (tmp_path / ".git").is_dir()
+
+    def test_inside_parent_repo(self, tmp_path):
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+        sub = tmp_path / "sub" / "dir"
+        sub.mkdir(parents=True)
+        assert ensure_repo(sub) is True
+        # Should NOT create a nested .git
+        assert not (sub / ".git").exists()
+
+
+class TestCommitLocalChanges:
+    def _init_repo(self, tmp_path: Path) -> Path:
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, capture_output=True)
+        return tmp_path
+
+    def test_no_changes(self, tmp_path):
+        self._init_repo(tmp_path)
+        # Create and commit a file so there's a HEAD
+        (tmp_path / "file.md").write_text("hello")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "init"], cwd=tmp_path, capture_output=True)
+
+        assert commit_local_changes(tmp_path) is False
+
+    def test_with_modifications(self, tmp_path):
+        self._init_repo(tmp_path)
+        (tmp_path / "file.md").write_text("hello")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "init"], cwd=tmp_path, capture_output=True)
+
+        # Modify tracked file
+        (tmp_path / "file.md").write_text("modified")
+
+        assert commit_local_changes(tmp_path) is True
+
+        # Verify commit was made
+        log = subprocess.run(["git", "log", "--oneline"], cwd=tmp_path, capture_output=True, text=True)
+        assert "Local changes" in log.stdout
+
+    def test_ignores_untracked_files(self, tmp_path):
+        self._init_repo(tmp_path)
+        (tmp_path / "tracked.md").write_text("hello")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "init"], cwd=tmp_path, capture_output=True)
+
+        # Create untracked file only
+        (tmp_path / "local-notes.txt").write_text("my notes")
+
+        assert commit_local_changes(tmp_path) is False
+
+
+class TestCommitExport:
+    def _init_repo(self, tmp_path: Path) -> Path:
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, capture_output=True)
+        # Need an initial commit for diff --cached to work
+        (tmp_path / ".gitkeep").write_text("")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "init"], cwd=tmp_path, capture_output=True)
+        return tmp_path
+
+    def test_commits_written_files(self, tmp_path):
+        self._init_repo(tmp_path)
+        md = tmp_path / "Page.md"
+        md.write_text("# Page")
+        media = tmp_path / "media" / "img.png"
+        media.parent.mkdir()
+        media.write_bytes(b"\x89PNG")
+
+        assert commit_export(tmp_path, [md, media], "TEST") is True
+
+        log = subprocess.run(["git", "log", "--oneline"], cwd=tmp_path, capture_output=True, text=True)
+        assert "Export Confluence space TEST" in log.stdout
+
+    def test_does_not_commit_other_files(self, tmp_path):
+        self._init_repo(tmp_path)
+        # A locally created file that should NOT be committed
+        (tmp_path / "local-notes.txt").write_text("my notes")
+        # An exporter-written file
+        md = tmp_path / "Page.md"
+        md.write_text("# Page")
+
+        commit_export(tmp_path, [md], "TEST")
+
+        # local-notes.txt should still be untracked
+        status = subprocess.run(["git", "status", "--porcelain"], cwd=tmp_path, capture_output=True, text=True)
+        assert "local-notes.txt" in status.stdout
+        assert "??" in status.stdout  # untracked marker
+
+    def test_nothing_to_commit(self, tmp_path):
+        self._init_repo(tmp_path)
+        md = tmp_path / "Page.md"
+        md.write_text("# Page")
+        subprocess.run(["git", "add", "Page.md"], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "already committed"], cwd=tmp_path, capture_output=True)
+
+        # Re-export with identical content
+        assert commit_export(tmp_path, [md], "TEST") is False
+
+    def test_commit_message_contains_timestamp(self, tmp_path):
+        self._init_repo(tmp_path)
+        md = tmp_path / "Page.md"
+        md.write_text("# Page")
+
+        commit_export(tmp_path, [md], "NB")
+
+        log = subprocess.run(
+            ["git", "log", "-1", "--format=%s"], cwd=tmp_path, capture_output=True, text=True
+        )
+        msg = log.stdout.strip()
+        assert "NB" in msg
+        assert "UTC" in msg

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -2,11 +2,23 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-from confluence_export.media import download_attachments, ensure_media_dir
-from confluence_export.types import Attachment
+from confluence_export.media import (
+    _VERSIONS_FILE,
+    download_attachments,
+    ensure_media_dir,
+)
+from confluence_export.types import Attachment, Version
+
+
+def _att(title="img.png", version=1, file_size=100, download_link="/wiki/download/a1"):
+    return Attachment(
+        id="a1", title=title, file_size=file_size,
+        download_link=download_link, version=Version(number=version),
+    )
 
 
 class TestEnsureMediaDir:
@@ -19,45 +31,59 @@ class TestEnsureMediaDir:
 
 
 class TestDownloadAttachments:
-    def test_skip_existing(self, tmp_path):
+    def test_skip_when_version_matches(self, tmp_path):
         media_dir = tmp_path / "media"
         media_dir.mkdir()
-        existing = media_dir / "img.png"
-        existing.write_bytes(b"x" * 100)
+        (media_dir / "img.png").write_bytes(b"x" * 100)
+        (media_dir / _VERSIONS_FILE).write_text('{"img.png": 3}')
 
-        att = Attachment(id="a1", title="img.png", file_size=100,
-                         download_link="/wiki/download/a1")
         client = MagicMock()
+        result = download_attachments(client, [_att(version=3)], media_dir)
 
-        result = download_attachments(client, [att], media_dir, skip_existing=True)
         assert len(result) == 1
         client.download_attachment_to_file.assert_not_called()
 
-    def test_skip_existing_even_if_size_differs(self, tmp_path):
-        """Existing non-empty files are trusted regardless of API-reported size."""
+    def test_redownload_when_version_changes(self, tmp_path):
         media_dir = tmp_path / "media"
         media_dir.mkdir()
-        existing = media_dir / "img.png"
-        existing.write_bytes(b"x" * 120)  # local size differs from API
+        (media_dir / "img.png").write_bytes(b"x" * 100)
+        (media_dir / _VERSIONS_FILE).write_text('{"img.png": 2}')
 
-        att = Attachment(id="a1", title="img.png", file_size=100,
-                         download_link="/wiki/download/a1")
         client = MagicMock()
+        result = download_attachments(client, [_att(version=3)], media_dir)
 
-        result = download_attachments(client, [att], media_dir, skip_existing=True)
         assert len(result) == 1
-        client.download_attachment_to_file.assert_not_called()
+        client.download_attachment_to_file.assert_called_once()
+
+    def test_download_when_no_manifest(self, tmp_path):
+        media_dir = tmp_path / "media"
+        media_dir.mkdir()
+        (media_dir / "img.png").write_bytes(b"x" * 100)
+        # No .versions.json — file exists but we don't know its version
+
+        client = MagicMock()
+        result = download_attachments(client, [_att(version=3)], media_dir)
+
+        assert len(result) == 1
+        client.download_attachment_to_file.assert_called_once()
+
+    def test_saves_version_after_download(self, tmp_path):
+        media_dir = tmp_path / "media"
+        media_dir.mkdir()
+
+        client = MagicMock()
+        download_attachments(client, [_att(title="new.png", version=5)], media_dir)
+
+        versions = json.loads((media_dir / _VERSIONS_FILE).read_text())
+        assert versions["new.png"] == 5
 
     def test_downloads_new(self, tmp_path):
         media_dir = tmp_path / "media"
         media_dir.mkdir()
 
-        att = Attachment(id="a1", title="new.png", file_size=50,
-                         download_link="/wiki/download/a1")
         client = MagicMock()
-        client.download_attachment_to_file.return_value = 50
+        result = download_attachments(client, [_att()], media_dir)
 
-        result = download_attachments(client, [att], media_dir, skip_existing=True)
         assert len(result) == 1
         client.download_attachment_to_file.assert_called_once()
 
@@ -65,7 +91,7 @@ class TestDownloadAttachments:
         media_dir = tmp_path / "media"
         media_dir.mkdir()
 
-        att = Attachment(id="a1", title="nolink.png", file_size=50, download_link="")
+        att = _att(download_link="")
         client = MagicMock()
 
         result = download_attachments(client, [att], media_dir)
@@ -76,12 +102,10 @@ class TestDownloadAttachments:
         media_dir = tmp_path / "media"
         media_dir.mkdir()
 
-        att = Attachment(id="a1", title="fail.png", file_size=50,
-                         download_link="/wiki/download/a1")
         client = MagicMock()
         client.download_attachment_to_file.side_effect = Exception("network error")
 
-        result = download_attachments(client, [att], media_dir)
+        result = download_attachments(client, [_att()], media_dir)
         assert len(result) == 0
         assert "failed to download" in capsys.readouterr().err
 
@@ -89,10 +113,8 @@ class TestDownloadAttachments:
         media_dir = tmp_path / "media"
         media_dir.mkdir()
 
-        att = Attachment(id="a1", title="x.png", file_size=10,
-                         download_link="/rest/api/content/a1/download")
+        att = _att(download_link="/rest/api/content/a1/download")
         client = MagicMock()
-        client.download_attachment_to_file.return_value = 10
 
         download_attachments(client, [att], media_dir)
         call_args = client.download_attachment_to_file.call_args[0]

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -21,6 +21,11 @@ def _att(title="img.png", version=1, file_size=100, download_link="/wiki/downloa
     )
 
 
+def _attachment_paths(result: list[Path]) -> list[Path]:
+    """Filter out the manifest from download results."""
+    return [p for p in result if p.name != _VERSIONS_FILE]
+
+
 class TestEnsureMediaDir:
     def test_creates_dir(self, tmp_path):
         page_dir = tmp_path / "page"
@@ -40,7 +45,7 @@ class TestDownloadAttachments:
         client = MagicMock()
         result = download_attachments(client, [_att(version=3)], media_dir)
 
-        assert len(result) == 1
+        assert len(_attachment_paths(result)) == 1
         client.download_attachment_to_file.assert_not_called()
 
     def test_redownload_when_version_changes(self, tmp_path):
@@ -52,7 +57,7 @@ class TestDownloadAttachments:
         client = MagicMock()
         result = download_attachments(client, [_att(version=3)], media_dir)
 
-        assert len(result) == 1
+        assert len(_attachment_paths(result)) == 1
         client.download_attachment_to_file.assert_called_once()
 
     def test_download_when_no_manifest(self, tmp_path):
@@ -64,7 +69,7 @@ class TestDownloadAttachments:
         client = MagicMock()
         result = download_attachments(client, [_att(version=3)], media_dir)
 
-        assert len(result) == 1
+        assert len(_attachment_paths(result)) == 1
         client.download_attachment_to_file.assert_called_once()
 
     def test_saves_version_after_download(self, tmp_path):
@@ -84,8 +89,18 @@ class TestDownloadAttachments:
         client = MagicMock()
         result = download_attachments(client, [_att()], media_dir)
 
-        assert len(result) == 1
+        assert len(_attachment_paths(result)) == 1
         client.download_attachment_to_file.assert_called_once()
+
+    def test_includes_manifest_in_result(self, tmp_path):
+        media_dir = tmp_path / "media"
+        media_dir.mkdir()
+
+        client = MagicMock()
+        result = download_attachments(client, [_att()], media_dir)
+
+        manifest_paths = [p for p in result if p.name == _VERSIONS_FILE]
+        assert len(manifest_paths) == 1
 
     def test_no_download_link(self, tmp_path, capsys):
         media_dir = tmp_path / "media"
@@ -95,7 +110,7 @@ class TestDownloadAttachments:
         client = MagicMock()
 
         result = download_attachments(client, [att], media_dir)
-        assert len(result) == 0
+        assert len(_attachment_paths(result)) == 0
         assert "no download link" in capsys.readouterr().err
 
     def test_download_failure(self, tmp_path, capsys):
@@ -106,7 +121,7 @@ class TestDownloadAttachments:
         client.download_attachment_to_file.side_effect = Exception("network error")
 
         result = download_attachments(client, [_att()], media_dir)
-        assert len(result) == 0
+        assert len(_attachment_paths(result)) == 0
         assert "failed to download" in capsys.readouterr().err
 
     def test_prepends_wiki_prefix(self, tmp_path):

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -33,6 +33,21 @@ class TestDownloadAttachments:
         assert len(result) == 1
         client.download_attachment_to_file.assert_not_called()
 
+    def test_skip_existing_even_if_size_differs(self, tmp_path):
+        """Existing non-empty files are trusted regardless of API-reported size."""
+        media_dir = tmp_path / "media"
+        media_dir.mkdir()
+        existing = media_dir / "img.png"
+        existing.write_bytes(b"x" * 120)  # local size differs from API
+
+        att = Attachment(id="a1", title="img.png", file_size=100,
+                         download_link="/wiki/download/a1")
+        client = MagicMock()
+
+        result = download_attachments(client, [att], media_dir, skip_existing=True)
+        assert len(result) == 1
+        client.download_attachment_to_file.assert_not_called()
+
     def test_downloads_new(self, tmp_path):
         media_dir = tmp_path / "media"
         media_dir.mkdir()

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -182,8 +182,9 @@ class TestDownloadParallelErrorIsolation:
 
         result = download_attachments(client, [att_ok, att_fail], media_dir, skip_existing=False)
 
-        assert len(result) == 1
-        assert result[0].name == "good.png"
+        attachment_results = [p for p in result if p.name != ".versions.json"]
+        assert len(attachment_results) == 1
+        assert attachment_results[0].name == "good.png"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- After each export, Confluence-sourced files are automatically committed to git
- Local edits to tracked files get a separate commit first; untracked local files are never auto-committed
- Enabled by default, disabled with `--no-git`. Fails gracefully if git is not installed
- `ExportResult` dataclass replaces raw `int` return from `Exporter.export_space()` to track written file paths

## Test plan

- [x] 227 tests pass (14 new: 12 git module + 2 CLI integration)
- [x] Existing CLI export test updated with `--no-git` to prevent unintended git operations
- [x] `test_export_creates_git_commit` verifies end-to-end: repo init, export commit, clean working tree
- [x] `test_no_git_flag_skips_versioning` verifies no `.git` created
- [x] `test_does_not_commit_other_files` verifies locally created files stay untracked
- [x] `test_ignores_untracked_files` verifies `commit_local_changes` only touches tracked files
- [x] `test_commit_message_contains_timestamp` verifies date/time in commit message