### PR TITLE
Align Confluence v2 API usage: inline body + server-side space lookup

### DIFF
--- a/src/confluence_export/cli.py
+++ b/src/confluence_export/cli.py
@@ -498,9 +498,14 @@ def _cmd_refresh(client: ConfluenceClient, cache: CacheStore, config: Config, sp
 def _resolve_space(client: ConfluenceClient, space_key: str) -> Space:
     """Find a space by key (case-insensitive)."""
     print(f"Resolving space '{space_key}'...", file=sys.stderr, flush=True)
-    spaces = client.get_spaces()
+    # Try server-side filter first — O(1) round trip vs. paging every space.
+    space = client.get_space_by_key(space_key)
+    if space is not None:
+        return space
+    # Fall back to a full list so that callers who typed a different case
+    # than the canonical key still resolve.
     key_upper = space_key.upper()
-    for s in spaces:
+    for s in client.get_spaces():
         if s.key.upper() == key_upper:
             return s
     print(f"Error: space '{space_key}' not found.", file=sys.stderr)

--- a/src/confluence_export/client.py
+++ b/src/confluence_export/client.py
@@ -139,9 +139,19 @@ class ConfluenceClient:
         return [Space.from_api(r) for r in results]
 
     def get_pages_in_space(self, space_id: str) -> list[Page]:
+        # body-format=storage returns the body inline with every page, so the
+        # exporter doesn't need an N+1 round trip to fetch each body later.
         path = f"/wiki/api/v2/spaces/{space_id}/pages"
-        results = self._paginate(path, {"limit": "250"})
+        results = self._paginate(path, {"limit": "250", "body-format": "storage"})
         return [Page.from_api(r) for r in results]
+
+    def get_space_by_key(self, key: str) -> Space | None:
+        """Look up a single space by key using the server-side `keys` filter."""
+        data = self._get("/wiki/api/v2/spaces", {"keys": key, "limit": "1"})
+        results = data.get("results", [])
+        if not results:
+            return None
+        return Space.from_api(results[0])
 
     def get_page_by_id(self, page_id: str) -> Page:
         data = self._get(f"/wiki/api/v2/pages/{page_id}", {"body-format": "storage"})
@@ -161,6 +171,11 @@ class ConfluenceClient:
 
     def get_user_info(self, account_id: str) -> dict | None:
         """Resolve an Atlassian account ID to user info (v1 API).
+
+        The v2 API has no GET-by-accountId — the v2 equivalent is
+        POST /wiki/api/v2/users-bulk with an accountIds array, which is
+        awkward for the single-ID + cache pattern we use here. v1 remains
+        supported and is the canonical single-user lookup path.
 
         Returns dict with 'displayName' and optionally 'email', or None on failure.
         """

--- a/src/confluence_export/types.py
+++ b/src/confluence_export/types.py
@@ -92,7 +92,7 @@ class Page:
         )
 
     def to_dict(self) -> dict:
-        return {
+        d: dict = {
             "id": self.id,
             "title": self.title,
             "spaceId": self.space_id,
@@ -115,6 +115,9 @@ class Page:
                 "tinyui": self.tinyui,
             },
         }
+        if self.body_storage:
+            d["body"] = {"storage": {"value": self.body_storage}}
+        return d
 
     @classmethod
     def from_dict(cls, data: dict) -> Page:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -65,6 +65,23 @@ class TestCacheStore:
             assert result.space.key == "TEST"
             client.get_pages_in_space.assert_not_called()
 
+    def test_save_and_load_preserves_body_storage(self, tmp_path):
+        with patch("confluence_export.cache.cache_dir", return_value=tmp_path):
+            store = CacheStore()
+            cs = CachedSpace(
+                space=_make_space(),
+                pages=[Page(id="p1", title="Page", space_id="1",
+                            body_storage="<p>cached body</p>",
+                            version=Version(number=2))],
+                attachments={},
+                updated_at="2025-01-01T00:00:00Z",
+            )
+            store.save(cs)
+
+            loaded = store.load("TEST")
+            assert loaded is not None
+            assert loaded.pages[0].body_storage == "<p>cached body</p>"
+
     def test_ensure_loaded_refresh(self, tmp_path):
         with patch("confluence_export.cache.cache_dir", return_value=tmp_path):
             store = CacheStore()

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -33,7 +33,16 @@ def _config(base_url="https://x.atlassian.net", api_token="tok"):
 
 def _mock_client(spaces=None):
     mock = MagicMock()
-    mock.get_spaces.return_value = spaces if spaces is not None else [_space()]
+    space_list = spaces if spaces is not None else [_space()]
+    mock.get_spaces.return_value = space_list
+
+    def _by_key(key: str):
+        for s in space_list:
+            if s.key.upper() == key.upper():
+                return s
+        return None
+
+    mock.get_space_by_key.side_effect = _by_key
     mock._get.return_value = {"results": []}
     return mock
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -213,6 +213,27 @@ class TestApiMethodsExtra:
             pages = client.get_pages_in_space("space1")
             assert len(pages) == 1
             mock.assert_called_once()
+            _, params = mock.call_args.args
+            assert params["body-format"] == "storage"
+
+    def test_get_space_by_key_found(self):
+        client = _make_client()
+        with patch.object(client, "_get") as mock:
+            mock.return_value = {
+                "results": [{"id": "1", "key": "ENG", "name": "Engineering"}]
+            }
+            space = client.get_space_by_key("ENG")
+            assert space is not None
+            assert space.key == "ENG"
+            mock.assert_called_once_with(
+                "/wiki/api/v2/spaces", {"keys": "ENG", "limit": "1"}
+            )
+
+    def test_get_space_by_key_not_found(self):
+        client = _make_client()
+        with patch.object(client, "_get") as mock:
+            mock.return_value = {"results": []}
+            assert client.get_space_by_key("NOPE") is None
 
     def test_get_attachments(self):
         client = _make_client()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -68,6 +68,19 @@ class TestPage:
         assert p2.title == p.title
         assert p2.version.number == 3
 
+    def test_round_trip_preserves_body_storage(self):
+        p = Page(id="1", title="Test", space_id="s1",
+                 body_storage="<p>Hello <strong>world</strong></p>")
+        d = p.to_dict()
+        assert d["body"]["storage"]["value"] == "<p>Hello <strong>world</strong></p>"
+        p2 = Page.from_dict(d)
+        assert p2.body_storage == p.body_storage
+
+    def test_to_dict_omits_body_when_empty(self):
+        p = Page(id="1", title="Test", space_id="s1", body_storage="")
+        d = p.to_dict()
+        assert "body" not in d
+
 
 class TestAttachment:
     def test_from_api(self):
@@ -112,3 +125,17 @@ class TestCachedSpace:
         assert len(cs2.pages) == 1
         assert len(cs2.attachments["p1"]) == 1
         assert cs2.updated_at == "2025-01-01T00:00:00Z"
+
+    def test_round_trip_preserves_page_bodies(self):
+        space = Space(id="1", key="TEST", name="Test")
+        with_body = Page(id="p1", title="Has Body", space_id="1",
+                         body_storage="<p>content</p>",
+                         version=Version(number=1))
+        without_body = Page(id="p2", title="No Body", space_id="1",
+                            status="folder", version=Version(number=1))
+        cs = CachedSpace(space=space, pages=[with_body, without_body],
+                         attachments={}, updated_at="2025-01-01T00:00:00Z")
+        d = cs.to_dict()
+        cs2 = CachedSpace.from_dict(d)
+        assert cs2.pages[0].body_storage == "<p>content</p>"
+        assert cs2.pages[1].body_storage == ""


### PR DESCRIPTION
Two alignments with the documented v2 API capabilities:

- GET /spaces/{id}/pages now passes body-format=storage so every page
  comes back with its body inline, removing the N+1 follow-up
  get_page_by_id round trip in exporter._prefetch_bodies.
- Add ConfluenceClient.get_space_by_key() backed by GET /spaces?keys=...
  and use it from _resolve_space so key lookup is one round trip instead
  of paging every space on the tenant. Falls back to the full list to
  preserve case-insensitive matching.

Also expands the get_user_info docstring to document why the v1 user
endpoint is used intentionally (v2 has no GET-by-accountId; users-bulk
POST is a poor fit for the cached single-ID lookup).