### PR TITLE
Add .workspace directories and rename media/ to .media/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ htmlcov/
 
 # OS
 .DS_Store
+.gstack/

--- a/README.md
+++ b/README.md
@@ -13,11 +13,14 @@ confluence-export export SPACEKEY -o ./output
 output/
 └── Space-Name/
     ├── Space-Name.md
+    ├── .workspace/
     ├── Page-A/
     │   ├── Page-A.md
+    │   ├── .workspace/
     │   ├── Child-Page/
     │   │   ├── Child-Page.md
-    │   │   └── media/
+    │   │   ├── .workspace/
+    │   │   └── .media/
     │   │       ├── diagram.drawio
     │   │       ├── diagram.drawio.png
     │   │       └── screenshot.png
@@ -25,11 +28,25 @@ output/
     │       └── Another-Child.md
     └── Page-B/
         ├── Page-B.md
-        └── media/
+        └── .media/
             └── report.pdf
 ```
 
-Pages become markdown files. Attachments land in `media/` folders next to their page. The folder hierarchy mirrors the Confluence page tree.
+Pages become markdown files. Attachments land in `.media/` folders next to their page. The folder hierarchy mirrors the Confluence page tree.
+
+## Workspace
+
+Each page directory includes a `.workspace/` folder where you can store preparation files (scripts, notes, aggregation data) that are useful when working with the exported content but should not go to Confluence. Workspace files persist across re-exports.
+
+```bash
+# Example: a script that summarizes a page's attachments
+output/Space-Name/Page-A/.workspace/summarize.py
+
+# Example: notes for a Claude Code session preparing content
+output/Space-Name/Page-A/.workspace/draft-notes.md
+```
+
+Both `.workspace/` and `.media/` use a dot-prefix to avoid collisions with Confluence pages that might be titled "workspace" or "media".
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ output/Space-Name/Page-A/.workspace/summarize.py
 output/Space-Name/Page-A/.workspace/draft-notes.md
 ```
 
-Both `.workspace/` and `.media/` use a dot-prefix to avoid collisions with Confluence pages that might be titled "workspace" or "media".
+Both `.workspace/` and `.media/` use a dot-prefix to avoid name collisions with Confluence pages. Since each page title becomes a directory name, a page titled "workspace" or "media" would clash with a non-prefixed directory. The dot-prefix is safe because page titles are sanitized to only contain word characters, spaces, and hyphens, so no page can produce a directory name starting with a dot.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Each page directory includes a `.workspace/` folder where you can store preparat
 # Example: a script that summarizes a page's attachments
 output/Space-Name/Page-A/.workspace/summarize.py
 
-# Example: notes for a Claude Code session preparing content
+# Example: notes for an AI coding agent session preparing content
 output/Space-Name/Page-A/.workspace/draft-notes.md
 ```
 

--- a/src/confluence_export/cli.py
+++ b/src/confluence_export/cli.py
@@ -391,6 +391,13 @@ def _cmd_export(
     out = Path(output_dir).resolve()
     out.mkdir(parents=True, exist_ok=True)
 
+    # TODO(migration): Remove after 2027-01-01
+    from confluence_export.media import migrate_media_dirs
+
+    renamed = migrate_media_dirs(out)
+    if renamed:
+        print(f"Migrated {len(renamed)} media/ directories to .media/", file=sys.stderr)
+
     # Git: pre-export
     use_git = False
     if not no_git:

--- a/src/confluence_export/converter.py
+++ b/src/confluence_export/converter.py
@@ -8,6 +8,8 @@ import yaml
 from bs4 import BeautifulSoup, NavigableString, Tag
 from markdownify import markdownify as md
 
+from confluence_export.media import MEDIA_DIR_NAME
+
 from typing import Callable
 
 from confluence_export.types import Attachment, Page
@@ -294,7 +296,7 @@ def _replace_ac_image(soup: BeautifulSoup, tag: Tag, attach_map: dict[str, Attac
     if ri:
         filename = ri.get("ri:filename", "")
         if filename:
-            img = soup.new_tag("img", src=f"media/{filename}", alt=filename)
+            img = soup.new_tag("img", src=f"{MEDIA_DIR_NAME}/{filename}", alt=filename)
             tag.replace_with(img)
             return
     # Fallback: external image URL
@@ -316,7 +318,7 @@ def _replace_ac_link(soup: BeautifulSoup, tag: Tag, attach_map: dict[str, Attach
         label_tag = tag.find("ac:plain-text-link-body") or tag.find("ac:link-body")
         label = label_tag.get_text().strip() if label_tag else filename
         if filename:
-            a = soup.new_tag("a", href=f"media/{filename}")
+            a = soup.new_tag("a", href=f"{MEDIA_DIR_NAME}/{filename}")
             a.string = label or filename
             tag.replace_with(a)
             return
@@ -470,7 +472,7 @@ def _convert_view_file(soup: BeautifulSoup, macro: Tag) -> None:
         filename = name_param.get_text().strip()
 
     if filename:
-        a = soup.new_tag("a", href=f"media/{filename}")
+        a = soup.new_tag("a", href=f"{MEDIA_DIR_NAME}/{filename}")
         a.string = filename
         macro.replace_with(a)
     else:

--- a/src/confluence_export/drawio.py
+++ b/src/confluence_export/drawio.py
@@ -8,6 +8,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from confluence_export.media import MEDIA_DIR_NAME
+
 from confluence_export.types import Attachment
 
 
@@ -92,7 +94,7 @@ def render_drawio_to_png(drawio_path: Path, output_path: Path | None = None) -> 
 def replace_drawio_placeholders(
     markdown: str,
     rendered_diagrams: dict[str, Path],
-    media_dir_name: str = "media",
+    media_dir_name: str = MEDIA_DIR_NAME,
 ) -> str:
     """Replace [drawio:name] placeholders in markdown with image + source link."""
     for diagram_name, png_path in rendered_diagrams.items():

--- a/src/confluence_export/exporter.py
+++ b/src/confluence_export/exporter.py
@@ -163,6 +163,11 @@ class Exporter:
         page_dir = parent_dir / dir_name
         page_dir.mkdir(parents=True, exist_ok=True)
 
+        # Create workspace directory for user's preparation files
+        # Dot-prefix avoids collision with a Confluence page titled "workspace"
+        # (sanitize_filename strips dots, so no page can produce ".workspace")
+        (page_dir / ".workspace").mkdir(exist_ok=True)
+
         indent = "  " * depth
         print(f"{indent}Exporting: {page.title}")
 

--- a/src/confluence_export/git.py
+++ b/src/confluence_export/git.py
@@ -116,6 +116,10 @@ def _remove_stale_files(output_dir: Path, written_files: list[Path]) -> None:
     written_resolved = {f.resolve() for f in written_files}
     stale = []
     for rel_path in result.stdout.strip("\0").split("\0"):
+        # Preserve user workspace directories across re-exports
+        parts = Path(rel_path).parts
+        if ".workspace" in parts:
+            continue
         full = (output_dir / rel_path).resolve()
         if full not in written_resolved:
             stale.append(rel_path)

--- a/src/confluence_export/media.py
+++ b/src/confluence_export/media.py
@@ -11,13 +11,38 @@ from confluence_export.client import ConfluenceClient
 from confluence_export.types import Attachment
 
 _VERSIONS_FILE = ".versions.json"
+MEDIA_DIR_NAME = ".media"
 
 
 def ensure_media_dir(page_dir: Path) -> Path:
-    """Create and return the media/ subdirectory for a page."""
-    media_dir = page_dir / "media"
+    """Create and return the .media/ subdirectory for a page."""
+    media_dir = page_dir / MEDIA_DIR_NAME
     media_dir.mkdir(parents=True, exist_ok=True)
     return media_dir
+
+
+# TODO(migration): Remove after 2027-01-01 — all users will have migrated by then
+def migrate_media_dirs(root_dir: Path) -> list[tuple[Path, Path]]:
+    """Rename legacy media/ directories to .media/ throughout an export tree.
+
+    Only renames directories that contain .versions.json (the manifest created
+    by download_attachments), which reliably identifies attachment directories
+    vs. page directories that happen to be named "media".
+
+    Returns list of (old_path, new_path) tuples for each renamed directory.
+    """
+    renamed: list[tuple[Path, Path]] = []
+    for dirpath in sorted(root_dir.rglob("media"), reverse=True):
+        if not dirpath.is_dir() or dirpath.name != "media":
+            continue
+        if not (dirpath / _VERSIONS_FILE).exists():
+            continue
+        new_path = dirpath.parent / MEDIA_DIR_NAME
+        if new_path.exists():
+            continue
+        dirpath.rename(new_path)
+        renamed.append((dirpath, new_path))
+    return renamed
 
 
 def _load_versions(media_dir: Path) -> dict[str, int]:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -158,6 +158,27 @@ class TestExportCommand:
         assert len(md_files) == 2
 
 
+    def test_export_migrates_legacy_media_dirs(self, tmp_path, capsys):
+        client = _mock_client()
+        cache = MagicMock()
+        cache.refresh.return_value = _cached_space()
+        out = str(tmp_path / "out")
+        # Create a legacy media/ dir with .versions.json before export
+        out_path = Path(out)
+        out_path.mkdir(parents=True)
+        legacy = out_path / "Root" / "media"
+        legacy.mkdir(parents=True)
+        (legacy / ".versions.json").write_text("{}")
+        with patch("sys.argv", ["confluence-export", "export", "TEST", "-o", out, "--no-media", "--no-git"]), \
+             patch("confluence_export.cli.load_config", return_value=_config()), \
+             patch("confluence_export.cli.ConfluenceClient", return_value=client), \
+             patch("confluence_export.cli.CacheStore", return_value=cache):
+            main()
+
+        captured = capsys.readouterr()
+        assert "Migrated 1 media/" in captured.err
+        assert (out_path / "Root" / ".media" / ".versions.json").exists()
+
     def test_export_creates_git_commit(self, tmp_path, capsys):
         import subprocess
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -52,7 +52,7 @@ def test_convert_page_frontmatter_has_attachments():
 def test_preprocess_ac_image():
     html = '<ac:image><ri:attachment ri:filename="screenshot.png"/></ac:image>'
     result = _preprocess_html(html, [])
-    assert "media/screenshot.png" in result
+    assert ".media/screenshot.png" in result
     assert "ac:image" not in result
 
 
@@ -63,7 +63,7 @@ def test_preprocess_ac_link():
         "</ac:link>"
     )
     result = _preprocess_html(html, [])
-    assert "media/doc.pdf" in result
+    assert ".media/doc.pdf" in result
     assert "My Document" in result
 
 

--- a/tests/test_converter_extra.py
+++ b/tests/test_converter_extra.py
@@ -34,7 +34,7 @@ PREPROCESS_CASES = [
     ),
 
     # Images
-    ("attachment image", '<ac:image><ri:attachment ri:filename="shot.png"/></ac:image>', ["media/shot.png"], ["ac:image"]),
+    ("attachment image", '<ac:image><ri:attachment ri:filename="shot.png"/></ac:image>', [".media/shot.png"], ["ac:image"]),
     ("external image", '<ac:image><ri:url ri:value="https://example.com/img.png"/></ac:image>', ["https://example.com/img.png"], []),
     ("image no source removed", "<ac:image></ac:image>", [], ["ac:image"]),
 
@@ -43,7 +43,7 @@ PREPROCESS_CASES = [
         "attachment link",
         '<ac:link><ri:attachment ri:filename="doc.pdf"/>'
         "<ac:plain-text-link-body>My Doc</ac:plain-text-link-body></ac:link>",
-        ["media/doc.pdf", "My Doc"], [],
+        [".media/doc.pdf", "My Doc"], [],
     ),
     (
         "page link preserves label",
@@ -78,8 +78,8 @@ PREPROCESS_CASES = [
     ),
     ("jira macro", '<ac:structured-macro ac:name="jira"><ac:parameter ac:name="key">PROJ-42</ac:parameter></ac:structured-macro>', ["PROJ-42"], []),
     ("jira macro empty", '<ac:structured-macro ac:name="jira"></ac:structured-macro>', [], ["ac:structured-macro"]),
-    ("view-file via ri:attachment", '<ac:structured-macro ac:name="view-file"><ri:attachment ri:filename="report.pdf"/></ac:structured-macro>', ["media/report.pdf"], []),
-    ("view-file via name param", '<ac:structured-macro ac:name="view-file"><ac:parameter ac:name="name">doc.pdf</ac:parameter></ac:structured-macro>', ["media/doc.pdf"], []),
+    ("view-file via ri:attachment", '<ac:structured-macro ac:name="view-file"><ri:attachment ri:filename="report.pdf"/></ac:structured-macro>', [".media/report.pdf"], []),
+    ("view-file via name param", '<ac:structured-macro ac:name="view-file"><ac:parameter ac:name="name">doc.pdf</ac:parameter></ac:structured-macro>', [".media/doc.pdf"], []),
     ("view-file empty", '<ac:structured-macro ac:name="view-file"></ac:structured-macro>', [], ["ac:structured-macro"]),
     ("drawio placeholder", '<ac:structured-macro ac:name="drawio"><ac:parameter ac:name="diagramName">arch</ac:parameter></ac:structured-macro>', ["[drawio:arch]"], []),
 
@@ -177,7 +177,7 @@ def test_full_conversion_pipeline():
     assert "Updated for v2" in md
 
     # Image converted to markdown
-    assert "media/diagram.png" in md
+    assert ".media/diagram.png" in md
 
     # Code block preserved
     assert "services:" in md

--- a/tests/test_drawio.py
+++ b/tests/test_drawio.py
@@ -62,7 +62,7 @@ def test_replace_drawio_placeholders(tmp_path):
         markdown,
         {"architecture": png},
     )
-    assert "![architecture](media/architecture.drawio.png)" in result
+    assert "![architecture](.media/architecture.drawio.png)" in result
     assert "Draw.io source:" in result
     assert "architecture.drawio" in result
     assert "[drawio:" not in result

--- a/tests/test_drawio_extra.py
+++ b/tests/test_drawio_extra.py
@@ -119,19 +119,19 @@ class TestRenderDrawioToPng:
 class TestReplaceDrawioPlaceholders:
     def test_replace_with_extension(self):
         md = "# Diagram\n\n[drawio:arch.drawio]\n\nMore text"
-        rendered = {"arch.drawio": Path("media/arch.drawio.png")}
+        rendered = {"arch.drawio": Path(".media/arch.drawio.png")}
         result = replace_drawio_placeholders(md, rendered)
-        assert "![arch](media/arch.drawio.png)" in result
+        assert "![arch](.media/arch.drawio.png)" in result
         assert "arch.drawio" in result  # source link
 
     def test_replace_without_extension(self):
         md = "# Diagram\n\n[drawio:arch]\n\nMore text"
-        rendered = {"arch.drawio": Path("media/arch.drawio.png")}
+        rendered = {"arch.drawio": Path(".media/arch.drawio.png")}
         result = replace_drawio_placeholders(md, rendered)
-        assert "![arch](media/arch.drawio.png)" in result
+        assert "![arch](.media/arch.drawio.png)" in result
 
     def test_no_matching_placeholder(self):
         md = "# No diagrams here"
-        rendered = {"other.drawio": Path("media/other.drawio.png")}
+        rendered = {"other.drawio": Path(".media/other.drawio.png")}
         result = replace_drawio_placeholders(md, rendered)
         assert result == md

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -210,11 +210,11 @@ class TestMediaDownload:
         cs = _make_cached_space(attachments={"p1": [att]})
 
         with patch("confluence_export.exporter.download_attachments") as mock_dl:
-            mock_dl.return_value = [tmp_path / "media" / "img.png"]
+            mock_dl.return_value = [tmp_path / ".media" / "img.png"]
             exporter._export_single_page(page, tmp_path, cs, "TEST")
             mock_dl.assert_called_once()
             # Verify media dir was created and passed
-            assert mock_dl.call_args[0][2].name == "media"
+            assert mock_dl.call_args[0][2].name == ".media"
 
 
 class TestDrawioRendering:
@@ -230,7 +230,7 @@ class TestDrawioRendering:
         ))
         cs = _make_cached_space(attachments={"p1": [att]})
 
-        media_dir = tmp_path / "media"
+        media_dir = tmp_path / ".media"
         media_dir.mkdir()
         (media_dir / "arch.drawio").write_text("<xml/>")
         png_path = media_dir / "arch.drawio.png"
@@ -252,6 +252,51 @@ class TestUserResolution:
         assert exporter._resolve_user("u1") == {"displayName": "Alice"}
         assert exporter._resolve_user("u1") == {"displayName": "Alice"}
         client.get_user_info.assert_called_once_with("u1")  # only 1 API call
+
+
+class TestWorkspaceDirectory:
+    def test_workspace_created_for_each_page(self, tmp_path):
+        exporter, _, cache = _make_exporter()
+        cs = _make_cached_space()
+        cache.ensure_loaded.return_value = cs
+
+        exporter.export_space(_make_space(), tmp_path)
+
+        workspace = tmp_path / "Test-Page" / ".workspace"
+        assert workspace.is_dir()
+
+    def test_workspace_created_for_nested_pages(self, tmp_path):
+        exporter, _, cache = _make_exporter()
+        parent = _make_page(id="p1", title="Parent", body="<p>P</p>")
+        child = _make_page(id="p2", title="Child", body="<p>C</p>",
+                           parent_id="p1", parent_type="page")
+        cs = _make_cached_space(pages=[parent, child])
+        cache.ensure_loaded.return_value = cs
+
+        exporter.export_space(_make_space(), tmp_path)
+
+        assert (tmp_path / "Parent" / ".workspace").is_dir()
+        assert (tmp_path / "Parent" / "Child" / ".workspace").is_dir()
+
+    def test_workspace_preserves_existing_files(self, tmp_path):
+        exporter, _, cache = _make_exporter()
+        cs = _make_cached_space()
+        cache.ensure_loaded.return_value = cs
+
+        # First export
+        exporter.export_space(_make_space(), tmp_path)
+
+        # User adds a file to the workspace
+        workspace = tmp_path / "Test-Page" / ".workspace"
+        script = workspace / "aggregate.py"
+        script.write_text("print('hello')")
+
+        # Re-export
+        exporter.export_space(_make_space(), tmp_path)
+
+        # User's file is still there
+        assert script.exists()
+        assert script.read_text() == "print('hello')"
 
 
 class TestForceRefresh:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -119,7 +119,7 @@ class TestCommitExport:
         self._init_repo(tmp_path)
         md = tmp_path / "Page.md"
         md.write_text("# Page")
-        media = tmp_path / "media" / "img.png"
+        media = tmp_path / ".media" / "img.png"
         media.parent.mkdir()
         media.write_bytes(b"\x89PNG")
 
@@ -218,7 +218,7 @@ class TestCommitExport:
     def test_metadata_files_survive_repeated_exports(self, tmp_path):
         """Files like .versions.json included in written_files are not removed."""
         self._init_repo(tmp_path)
-        media = tmp_path / "media"
+        media = tmp_path / ".media"
         media.mkdir()
         md = tmp_path / "Page.md"
         md.write_text("# Page")
@@ -235,7 +235,27 @@ class TestCommitExport:
 
         # Manifest should still be tracked
         ls = subprocess.run(["git", "ls-files"], cwd=tmp_path, capture_output=True, text=True)
-        assert "media/.versions.json" in ls.stdout
+        assert ".media/.versions.json" in ls.stdout
+
+    def test_workspace_files_survive_reexport(self, tmp_path):
+        """Files inside workspace/ directories are never removed as stale."""
+        self._init_repo(tmp_path)
+        md = tmp_path / "Page.md"
+        md.write_text("# Page")
+        ws = tmp_path / ".workspace"
+        ws.mkdir()
+        script = ws / "prep.py"
+        script.write_text("print('hello')")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "first export"], cwd=tmp_path, capture_output=True)
+
+        # Re-export: only md is in written_files, workspace file should survive
+        md.write_text("# Page v2")
+        commit_export(tmp_path, [md], "TEST")
+
+        ls = subprocess.run(["git", "ls-files"], cwd=tmp_path, capture_output=True, text=True)
+        assert ".workspace/prep.py" in ls.stdout
+        assert "Page.md" in ls.stdout
 
     def test_removes_stale_file_with_non_ascii_path(self, tmp_path):
         """Paths with non-ASCII characters (umlauts etc.) are handled correctly."""

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -10,6 +10,7 @@ from confluence_export.media import (
     _VERSIONS_FILE,
     download_attachments,
     ensure_media_dir,
+    migrate_media_dirs,
 )
 from confluence_export.types import Attachment, Version
 
@@ -32,12 +33,12 @@ class TestEnsureMediaDir:
         page_dir.mkdir()
         media = ensure_media_dir(page_dir)
         assert media.exists()
-        assert media.name == "media"
+        assert media.name == ".media"
 
 
 class TestDownloadAttachments:
     def test_skip_when_version_matches(self, tmp_path):
-        media_dir = tmp_path / "media"
+        media_dir = tmp_path / ".media"
         media_dir.mkdir()
         (media_dir / "img.png").write_bytes(b"x" * 100)
         (media_dir / _VERSIONS_FILE).write_text('{"img.png": 3}')
@@ -49,7 +50,7 @@ class TestDownloadAttachments:
         client.download_attachment_to_file.assert_not_called()
 
     def test_redownload_when_version_changes(self, tmp_path):
-        media_dir = tmp_path / "media"
+        media_dir = tmp_path / ".media"
         media_dir.mkdir()
         (media_dir / "img.png").write_bytes(b"x" * 100)
         (media_dir / _VERSIONS_FILE).write_text('{"img.png": 2}')
@@ -61,7 +62,7 @@ class TestDownloadAttachments:
         client.download_attachment_to_file.assert_called_once()
 
     def test_download_when_no_manifest(self, tmp_path):
-        media_dir = tmp_path / "media"
+        media_dir = tmp_path / ".media"
         media_dir.mkdir()
         (media_dir / "img.png").write_bytes(b"x" * 100)
         # No .versions.json — file exists but we don't know its version
@@ -73,7 +74,7 @@ class TestDownloadAttachments:
         client.download_attachment_to_file.assert_called_once()
 
     def test_saves_version_after_download(self, tmp_path):
-        media_dir = tmp_path / "media"
+        media_dir = tmp_path / ".media"
         media_dir.mkdir()
 
         client = MagicMock()
@@ -83,7 +84,7 @@ class TestDownloadAttachments:
         assert versions["new.png"] == 5
 
     def test_downloads_new(self, tmp_path):
-        media_dir = tmp_path / "media"
+        media_dir = tmp_path / ".media"
         media_dir.mkdir()
 
         client = MagicMock()
@@ -93,7 +94,7 @@ class TestDownloadAttachments:
         client.download_attachment_to_file.assert_called_once()
 
     def test_includes_manifest_in_result(self, tmp_path):
-        media_dir = tmp_path / "media"
+        media_dir = tmp_path / ".media"
         media_dir.mkdir()
 
         client = MagicMock()
@@ -103,7 +104,7 @@ class TestDownloadAttachments:
         assert len(manifest_paths) == 1
 
     def test_no_download_link(self, tmp_path, capsys):
-        media_dir = tmp_path / "media"
+        media_dir = tmp_path / ".media"
         media_dir.mkdir()
 
         att = _att(download_link="")
@@ -114,7 +115,7 @@ class TestDownloadAttachments:
         assert "no download link" in capsys.readouterr().err
 
     def test_download_failure(self, tmp_path, capsys):
-        media_dir = tmp_path / "media"
+        media_dir = tmp_path / ".media"
         media_dir.mkdir()
 
         client = MagicMock()
@@ -125,7 +126,7 @@ class TestDownloadAttachments:
         assert "failed to download" in capsys.readouterr().err
 
     def test_prepends_wiki_prefix(self, tmp_path):
-        media_dir = tmp_path / "media"
+        media_dir = tmp_path / ".media"
         media_dir.mkdir()
 
         att = _att(download_link="/rest/api/content/a1/download")
@@ -134,3 +135,70 @@ class TestDownloadAttachments:
         download_attachments(client, [att], media_dir)
         call_args = client.download_attachment_to_file.call_args[0]
         assert call_args[0].startswith("/wiki")
+
+
+class TestMigrateMediaDirs:
+    def test_renames_media_with_versions_file(self, tmp_path):
+        """media/ containing .versions.json is renamed to .media/."""
+        page_dir = tmp_path / "Page"
+        page_dir.mkdir()
+        media = page_dir / "media"
+        media.mkdir()
+        (media / "img.png").write_bytes(b"PNG")
+        (media / _VERSIONS_FILE).write_text('{"img.png": 1}')
+
+        renamed = migrate_media_dirs(tmp_path)
+
+        assert len(renamed) == 1
+        assert not (page_dir / "media").exists()
+        new_media = page_dir / ".media"
+        assert new_media.is_dir()
+        assert (new_media / "img.png").read_bytes() == b"PNG"
+        assert (new_media / _VERSIONS_FILE).exists()
+
+    def test_skips_dir_without_versions_file(self, tmp_path):
+        """media/ without .versions.json is left alone (e.g., a page titled 'media')."""
+        page_dir = tmp_path / "media"
+        page_dir.mkdir()
+        (page_dir / "media.md").write_text("# media")
+
+        renamed = migrate_media_dirs(tmp_path)
+
+        assert len(renamed) == 0
+        assert (tmp_path / "media").is_dir()
+
+    def test_idempotent_when_dotmedia_exists(self, tmp_path):
+        """Skips if .media/ already exists as sibling."""
+        page_dir = tmp_path / "Page"
+        page_dir.mkdir()
+        media = page_dir / "media"
+        media.mkdir()
+        (media / _VERSIONS_FILE).write_text("{}")
+        dotmedia = page_dir / ".media"
+        dotmedia.mkdir()
+
+        renamed = migrate_media_dirs(tmp_path)
+
+        assert len(renamed) == 0
+        assert (page_dir / "media").is_dir()
+        assert (page_dir / ".media").is_dir()
+
+    def test_nested_tree(self, tmp_path):
+        """Migrates multiple media/ dirs at different tree levels."""
+        for name in ["Parent", "Parent/Child"]:
+            d = tmp_path / name
+            d.mkdir(parents=True, exist_ok=True)
+            media = d / "media"
+            media.mkdir()
+            (media / _VERSIONS_FILE).write_text("{}")
+            (media / "att.png").write_bytes(b"x")
+
+        renamed = migrate_media_dirs(tmp_path)
+
+        assert len(renamed) == 2
+        assert (tmp_path / "Parent" / ".media" / "att.png").exists()
+        assert (tmp_path / "Parent" / "Child" / ".media" / "att.png").exists()
+
+    def test_empty_tree(self, tmp_path):
+        """No media/ dirs at all — returns empty list."""
+        assert migrate_media_dirs(tmp_path) == []

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -199,6 +199,17 @@ class TestMigrateMediaDirs:
         assert (tmp_path / "Parent" / ".media" / "att.png").exists()
         assert (tmp_path / "Parent" / "Child" / ".media" / "att.png").exists()
 
+    def test_skips_file_named_media(self, tmp_path):
+        """A file named 'media' (not a directory) is ignored."""
+        page_dir = tmp_path / "Page"
+        page_dir.mkdir()
+        (page_dir / "media").write_text("just a file")
+
+        renamed = migrate_media_dirs(tmp_path)
+
+        assert len(renamed) == 0
+        assert (page_dir / "media").is_file()
+
     def test_empty_tree(self, tmp_path):
         """No media/ dirs at all — returns empty list."""
         assert migrate_media_dirs(tmp_path) == []

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -177,7 +177,7 @@ class TestDownloadParallelErrorIsolation:
 
         client.download_attachment_to_file.side_effect = mock_download
 
-        media_dir = tmp_path / "media"
+        media_dir = tmp_path / ".media"
         media_dir.mkdir()
 
         result = download_attachments(client, [att_ok, att_fail], media_dir, skip_existing=False)


### PR DESCRIPTION
## Summary
- Add per-page `.workspace/` directories for user preparation files (scripts, notes) that persist across re-exports
- Rename attachment directory from `media/` to `.media/` to prevent collision with Confluence pages titled "media"
- Add automatic migration for existing exports: renames legacy `media/` dirs identified by `.versions.json` presence
- Dot-prefix on both directories prevents name collisions since `sanitize_filename` strips dots from page titles

## Test plan
- [x] `uv run python -m pytest -v` passes all 255 tests
- [x] Verify `.workspace/` created in each page directory during export
- [x] Verify `.media/` used instead of `media/` for attachments
- [x] Verify migration renames `media/` dirs with `.versions.json` but skips page dirs named "media"
- [x] Verify workspace files survive re-exports (git stale file cleanup skips `.workspace/`)