### PR TITLE
Add CME transformation parity tests

### DIFF
--- a/.dev-loop/PLAN.md
+++ b/.dev-loop/PLAN.md
@@ -1,0 +1,21 @@
+# Dev Loop Plan — CME transformation tests
+
+## Goal
+Port confluence-markdown-exporter markdown transformation behavior checks into conex on a feature branch, without copying CME's unrelated CLI/config/API tests.
+
+## Subproblems
+
+1. Add CME-derived transformation parity tests — DONE
+   - Added `tests/test_cme_transform_parity.py` covering anchor slugging, rendered emoji images, unicode whitespace, template placeholder escaping, and PlantUML storage macros.
+   - Validation: `uv run --extra dev pytest tests/test_cme_transform_parity.py -q` → 45 passed, 2 xfailed.
+   - Not doing: full CME CLI/config/auth parity.
+
+2. Keep CI green while documenting gaps — DONE
+   - Added `docs/cme-markdown-transformation-gaps.md`.
+   - Gaps are explicit xfails: wiki-style links and rendered-HTML PlantUML via `editor2`.
+   - Validation: full `uv run --extra dev pytest -q` → 319 passed, 2 xfailed.
+   - Not doing: broad exporter rewrite.
+
+3. Review and final verification — DONE
+   - Review recorded in `.dev-loop/REVIEW.md`.
+   - Diff is focused on converter parity helpers, CME-derived tests, and the gap report.

--- a/.dev-loop/PROMPT.md
+++ b/.dev-loop/PROMPT.md
@@ -1,0 +1,19 @@
+We are in ~/repos/conex on feature branch feature/cme-transform-tests-*. Milan asked: "takeover the tests of confluence-markdown-exporter and apply them on conex; generate a list of markdown transformation gaps where confluence-markdown-exporter is arguably better."
+
+Context:
+- CME cloned at /tmp/cme-compare.
+- Relevant CME tests: /tmp/cme-compare/tests/unit/test_confluence.py, test_emoticon_conversion.py, test_nbsp_fix.py, test_template_placeholders.py, test_plantuml_conversion.py.
+- Conex converter: src/confluence_export/converter.py.
+- Existing tests: tests/test_converter.py, tests/test_converter_extra.py, tests/test_drawio*.py.
+
+Task:
+1. Add a focused CME-derived parity test file in conex, e.g. tests/test_cme_transform_parity.py.
+2. Port transformation tests, adapting to conex APIs. Include exact/source notes in comments/docstrings.
+3. For behavior conex already supports or can support with small robust changes, implement the minimal converter fix.
+4. For behavior that is larger/not currently supported, mark tests xfail with clear reason. Do not make CI red just to document gaps.
+5. Add a markdown gap report, e.g. docs/cme-markdown-transformation-gaps.md, listing where CME is better and whether each gap is now tested, xfailed, or fixed.
+6. Keep this narrow: no CME CLI/config/API tests, no full architecture rewrite.
+7. Run `uv run --extra dev pytest tests/test_cme_transform_parity.py -q` and then full `uv run --extra dev pytest -q`.
+8. Update .dev-loop/PLAN.md with what changed.
+
+Simplicity/robustness: minimal regex/helpers are fine; avoid a new abstraction layer. Preserve conex's LLM-first frontmatter/page-tree/git model.

--- a/.dev-loop/REVIEW.md
+++ b/.dev-loop/REVIEW.md
@@ -1,0 +1,19 @@
+# Review — CME transformation tests
+
+## Findings
+
+- Scope stayed focused on markdown transformations, not CME CLI/config/API tests.
+- Added CME-derived tests for emoji img tags, unicode whitespace, template placeholder escaping, anchor normalization, and PlantUML.
+- CI remains green by marking two product-scope gaps as xfail: wiki-link mode and rendered-HTML PlantUML lookup via `editor2`.
+- Converter changes are post/pre-processing helpers around the existing markdownify pipeline; no broad architecture rewrite.
+- Gap report added at `docs/cme-markdown-transformation-gaps.md`.
+
+## Validation
+
+- `uv run --extra dev pytest tests/test_cme_transform_parity.py -q` → 45 passed, 2 xfailed.
+- `uv run --extra dev pytest -q` → 319 passed, 2 xfailed.
+
+## Notes
+
+- The Claude worker partially completed the implementation but hung without final output; Sihly inspected, completed missing documentation, and ran validation directly.
+- Follow-up product decision: whether conex should ever support configurable wiki/ADO link modes, or keep that as CME territory.

--- a/docs/cme-markdown-transformation-gaps.md
+++ b/docs/cme-markdown-transformation-gaps.md
@@ -1,0 +1,136 @@
+# CME markdown transformation gap report
+
+This report compares conex against `Spenhouet/confluence-markdown-exporter` (CME) from the narrow perspective of Markdown transformation fidelity.
+
+CME is a broad Confluence-to-Markdown migration tool. Conex should not copy its entire CLI/config/export surface; the useful benchmark is the transformation behavior that makes exported Markdown render correctly in GitHub, Obsidian, ADO, and similar readers.
+
+## Summary
+
+| Area | Status in this branch | Why CME is/was better |
+|---|---|---|
+| Rendered `<img class="emoticon">` emoji | Fixed + tested | CME handled rendered Confluence emoji images; conex previously focused on storage `<ac:emoticon>` tags. |
+| Unicode whitespace inside inline formatting | Fixed + tested | CME normalizes `&nbsp;`, EM SPACE, THIN SPACE before markdown conversion so `word<em>&nbsp;text</em>` does not collapse into `word*text*`. |
+| Template placeholder escaping | Fixed + tested | CME escapes text placeholders like `<TOPIC>` / `<medical device>` so Obsidian does not treat them as unknown HTML tags. |
+| Fragment anchor normalization | Fixed + tested | CME converts Confluence anchors such as `#1.-Request-Service` to GitHub-style `#1-request-service`. |
+| PlantUML macro JSON → fenced block | Fixed for storage XML + tested | CME supports PlantUML and emits fenced `plantuml` blocks. Conex now supports the storage-XML form it normally receives. |
+| Wiki-style links | Gap, xfailed test | CME can generate `[[Page Title]]`/`[[#Heading]]` links via config; conex has no link-style configuration. |
+| Rendered-HTML PlantUML lookup via `editor2` | Gap, xfailed test | CME can resolve rendered `<div data-macro-name="plantuml" data-macro-id="...">` back to `page.editor2`; conex currently consumes storage XML directly. |
+| Target-specific page/attachment path/link templates | Not ported | CME has rich config for Obsidian/ADO/relative/absolute/wiki paths. Conex intentionally keeps its page-directory + `.media/` layout. |
+| Jira enrichment | Not ported | CME can enrich Jira issue links with Jira metadata; conex currently renders Jira macros as issue keys. |
+| Confluence Server/Data Center rendered quirks | Not ported | CME supports more URL/API modes and rendered HTML cases. Conex is Confluence Cloud/storage-XML oriented today. |
+
+## Tests added
+
+`tests/test_cme_transform_parity.py` ports the transformation-focused CME tests from:
+
+- `tests/unit/test_emoticon_conversion.py`
+- `tests/unit/test_nbsp_fix.py`
+- `tests/unit/test_template_placeholders.py`
+- `tests/unit/test_confluence.py::TestAnchorLinkConversion`
+- `tests/unit/test_plantuml_conversion.py`
+
+The suite adapts CME's `Page.Converter.convert(html)` style to conex's pipeline:
+
+1. `_preprocess_html(html, attachments)`
+2. `markdownify(...)`
+3. conex post-processing helpers
+
+## Fixed in this branch
+
+### 1. Rendered emoji images
+
+Added support for rendered Confluence emoji images such as:
+
+```html
+<img class="emoticon emoticon-tick" data-emoji-id="atlassian-check_mark" data-emoji-fallback=":check_mark:" />
+```
+
+Resolution order follows CME: direct Unicode fallback, hex codepoint ID, Atlassian ID map, shortname fallback.
+
+### 2. Unicode whitespace preservation
+
+Added `_normalize_unicode_whitespace()` and apply it to text nodes outside `<pre>` before markdownify. This preserves spacing around inline formatting while leaving normal newlines/tabs alone.
+
+### 3. Template placeholder escaping
+
+Added `_escape_template_placeholders()` post-processing. It escapes likely placeholders while preserving real HTML tags and anything inside inline/fenced code.
+
+Examples:
+
+```markdown
+<TOPIC>                 → \<TOPIC\>
+<medical device>        → \<medical device\>
+text<br/>more text      → text<br/>more text
+Use `<TOPIC>` here      → unchanged inside inline code
+```
+
+### 4. Anchor normalization
+
+Added `_normalize_anchor_links()` post-processing for fragment-only links.
+
+```markdown
+[request service](#1.-Request-Service) → [request service](#1-request-service)
+```
+
+### 5. PlantUML storage macro conversion
+
+Added `_convert_plantuml()` for storage XML:
+
+```xml
+<ac:structured-macro ac:name="plantuml">
+  <ac:plain-text-body><![CDATA[{"umlDefinition":"@startuml\n...\n@enduml"}]]></ac:plain-text-body>
+</ac:structured-macro>
+```
+
+It emits:
+
+````markdown
+```plantuml
+@startuml
+...
+@enduml
+```
+````
+
+Invalid/missing content emits an HTML comment instead of silently dropping the macro.
+
+## Gaps intentionally left open
+
+### Wiki-style links
+
+CME can output wiki links for Obsidian:
+
+```markdown
+[[Page Title]]
+![[image.png|alt text]]
+[[#Heading]]
+```
+
+Conex currently has a fixed LLM-ready markdown style and no `page_href` / `attachment_href` config. Adding this would be a product decision, not a small converter parity fix.
+
+### Rendered-HTML PlantUML via `editor2`
+
+CME can take rendered HTML like:
+
+```html
+<div data-macro-name="plantuml" data-macro-id="abc"></div>
+```
+
+and look up the actual PlantUML JSON in a separate `page.editor2` XML field. Conex normally fetches storage XML, where the macro body is inline, so adding this would require carrying an additional rendered/editor2 representation through the data model.
+
+### Target-specific path/link templates
+
+CME has configurable page and attachment path templates plus relative/absolute/wiki href modes. Conex's current differentiated value is the stable page-as-directory tree:
+
+```text
+Page/
+  Page.md
+  .media/
+  .workspace/
+```
+
+That should remain the default. If compatibility export modes become important, add them explicitly rather than weakening the LLM/workspace layout.
+
+## Recommendation
+
+Keep using CME as the transformation-fidelity benchmark. Conex should selectively absorb small, robust conversion fixes like the ones above, but stay focused on the agent/workbench model: frontmatter, page-tree directories, `.media/`, `.workspace/`, git versioning, and diff/re-export loops.

--- a/src/confluence_export/converter.py
+++ b/src/confluence_export/converter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 
 import yaml
@@ -47,6 +48,176 @@ _EMOTICON_MAP = {
     "warning": "\u26a0\ufe0f",
 }
 
+# Atlassian-shipped emoji codepoints used by `data-emoji-id="atlassian-..."`
+# in rendered Confluence HTML. Mirrors CME's _ATLASSIAN_EMOTICONS map.
+_ATLASSIAN_EMOJI_BY_ID = {
+    "atlassian-check_mark": "\u2705",
+    "atlassian-cross_mark": "\u274c",
+    "atlassian-warning": "\u26a0\ufe0f",
+    "atlassian-info": "\u2139\ufe0f",
+    "atlassian-thumbsup": "\U0001f44d",
+    "atlassian-thumbsdown": "\U0001f44e",
+    "atlassian-smile": "\U0001f642",
+    "atlassian-sad": "\U0001f641",
+    "atlassian-tongue": "\U0001f61b",
+    "atlassian-biggrin": "\U0001f601",
+    "atlassian-wink": "\U0001f609",
+}
+
+# Known HTML element names — ports CME's _HTML_ELEMENTS list. Used by
+# _escape_template_placeholders() to decide whether <foo> in markdown text is
+# a real HTML tag (preserve) or a template placeholder like <TOPIC> (escape).
+_HTML_ELEMENT_NAMES = frozenset(
+    {
+        "a", "abbr", "acronym", "address", "area", "article", "aside", "audio",
+        "b", "base", "bdi", "bdo", "blockquote", "body", "br", "button",
+        "canvas", "caption", "cite", "code", "col", "colgroup", "data",
+        "datalist", "dd", "del", "details", "dfn", "dialog", "div", "dl", "dt",
+        "em", "embed", "fieldset", "figcaption", "figure", "footer", "form",
+        "h1", "h2", "h3", "h4", "h5", "h6", "head", "header", "hgroup", "hr",
+        "html", "i", "iframe", "img", "input", "ins", "kbd", "keygen", "label",
+        "legend", "li", "link", "main", "map", "mark", "menu", "menuitem",
+        "meta", "meter", "nav", "noscript", "object", "ol", "optgroup",
+        "option", "output", "p", "picture", "pre", "progress", "q", "rp", "rt",
+        "ruby", "s", "samp", "script", "section", "select", "small", "source",
+        "span", "strong", "style", "sub", "summary", "sup", "table", "tbody",
+        "td", "template", "textarea", "tfoot", "th", "thead", "time", "title",
+        "tr", "track", "u", "ul", "var", "video", "wbr",
+    }
+)
+
+_ANGLE_BRACKET_RE = re.compile(r"<([^<>\n]*)>")
+_CODE_FENCE_RE = re.compile(r"^(`{3,}|~{3,})")
+_INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
+_FRAGMENT_LINK_RE = re.compile(r"(\]\(#)([^)\s]+)(\))")
+_MAX_UNICODE_CODEPOINT = 0x10FFFF
+
+
+def _normalize_unicode_whitespace(text: str) -> str:
+    """Replace Unicode whitespace (nbsp, EM SPACE, THIN SPACE, ...) with regular space.
+
+    Mirrors CME's Page.Converter._normalize_unicode_whitespace. Confluence
+    storage HTML often contains \\xa0 inside inline formatting like
+    <em>&nbsp;text</em>; markdownify's chomp() drops these characters
+    entirely, producing "word*text*" instead of "word *text*".
+
+    Newlines, tabs, and carriage returns are preserved (semantic).
+    """
+    if not text:
+        return text
+    chars = []
+    for ch in text:
+        if ch.isspace() and ch not in " \n\r\t":
+            chars.append(" ")
+        else:
+            chars.append(ch)
+    return "".join(chars)
+
+
+def _escape_template_placeholders(text: str) -> str:
+    r"""Escape ``<placeholder>`` patterns so Obsidian renders them as text.
+
+    Mirrors CME's Page.Converter._escape_template_placeholders. Confluence
+    templates often contain markers like ``<medical device>`` or ``<TOPIC>``
+    that Obsidian otherwise eats as unknown HTML tags. Real HTML elements
+    (``<br/>``, ``</div>``, ``<!-- ... -->``) and content inside fenced or
+    inline code blocks are left alone.
+    """
+
+    def _escape_if_placeholder(m: re.Match) -> str:
+        inner = m.group(1)
+        if inner.startswith("!"):
+            return m.group(0)
+        stripped = inner.strip().lstrip("/")
+        tag_name = re.split(r"[\s/]", stripped)[0].lower() if stripped else ""
+        if tag_name in _HTML_ELEMENT_NAMES:
+            return m.group(0)
+        return f"\\<{inner}\\>"
+
+    lines = text.split("\n")
+    result: list[str] = []
+    in_fence = False
+    for line in lines:
+        if _CODE_FENCE_RE.match(line):
+            in_fence = not in_fence
+            result.append(line)
+            continue
+        if in_fence:
+            result.append(line)
+            continue
+        parts = _INLINE_CODE_RE.split(line)
+        codes = _INLINE_CODE_RE.findall(line)
+        processed: list[str] = []
+        for i, part in enumerate(parts):
+            processed.append(_ANGLE_BRACKET_RE.sub(_escape_if_placeholder, part))
+            if i < len(codes):
+                processed.append(codes[i])
+        result.append("".join(processed))
+    return "\n".join(result)
+
+
+def _normalize_anchor_slug(slug: str) -> str:
+    """Normalize a heading anchor slug to GitHub-style: lowercase, dashes only.
+
+    Confluence emits anchor hrefs like ``#1.-Request-Service``. GitHub /
+    Obsidian markdown renderers expect ``#1-request-service``. CME does this
+    in convert_a; we do it as a post-pass on the rendered markdown.
+    """
+    s = slug.lower()
+    s = re.sub(r"[^\w-]+", "", s)
+    s = re.sub(r"_+", "_", s)
+    s = re.sub(r"-+", "-", s)
+    return s.strip("-")
+
+
+def _pre_code_language(pre_el: Tag) -> str:
+    """Extract the language from a ``<pre><code class="language-X">`` block.
+
+    markdownify's ``convert_pre`` invokes the callback on the ``<pre>`` tag;
+    we look at its first ``<code>`` child for ``language-*`` to render fenced
+    blocks as ```` ```python ```` instead of bare ```` ``` ````.
+    """
+    code = pre_el.find("code") if isinstance(pre_el, Tag) else None
+    if not isinstance(code, Tag):
+        return ""
+    classes = code.get("class") or []
+    for cls in classes:
+        if cls.startswith("language-"):
+            return cls[len("language-") :]
+    return ""
+
+
+def _normalize_anchor_links(markdown: str) -> str:
+    """Apply _normalize_anchor_slug to fragment-only links in markdown text.
+
+    Skips fenced and inline code regions to avoid mangling literal examples.
+    """
+    lines = markdown.split("\n")
+    out: list[str] = []
+    in_fence = False
+    for line in lines:
+        if _CODE_FENCE_RE.match(line):
+            in_fence = not in_fence
+            out.append(line)
+            continue
+        if in_fence:
+            out.append(line)
+            continue
+        parts = _INLINE_CODE_RE.split(line)
+        codes = _INLINE_CODE_RE.findall(line)
+        rebuilt: list[str] = []
+        for i, part in enumerate(parts):
+            rebuilt.append(
+                _FRAGMENT_LINK_RE.sub(
+                    lambda m: f"{m.group(1)}{_normalize_anchor_slug(m.group(2))}{m.group(3)}",
+                    part,
+                )
+            )
+            if i < len(codes):
+                rebuilt.append(codes[i])
+        out.append("".join(rebuilt))
+    return "\n".join(out)
+
 
 def sanitize_filename(title: str) -> str:
     """Convert a page title to a safe directory/file name."""
@@ -78,10 +249,13 @@ def convert_page(
         heading_style="ATX",
         bullets="*",
         strip=["script", "style"],
+        code_language_callback=_pre_code_language,
     )
 
     # Clean up excessive whitespace
     markdown = re.sub(r"\n{3,}", "\n\n", markdown)
+    markdown = _normalize_anchor_links(markdown)
+    markdown = _escape_template_placeholders(markdown)
     markdown = markdown.strip()
 
     # Build frontmatter
@@ -225,6 +399,14 @@ def _preprocess_html(
         else:
             user_tag.replace_with(f"@{name}")
 
+    # --- Rendered emoticon img tags (e.g. <img class="emoticon" data-emoji-id="..."/>) ---
+    # These appear when a page is fetched as rendered HTML rather than storage
+    # XML. Mirrors CME's _convert_emoticon resolution order.
+    for img_tag in list(soup.find_all("img")):
+        emoji = _resolve_emoticon_img(img_tag)
+        if emoji is not None:
+            img_tag.replace_with(emoji)
+
     # --- ac:image ---
     for img_tag in list(soup.find_all("ac:image")):
         _replace_ac_image(soup, img_tag, attach_map)
@@ -242,6 +424,8 @@ def _preprocess_html(
             _convert_code_block(soup, macro)
         elif macro_name in ("drawio", "inc-drawio"):
             _convert_drawio_placeholder(soup, macro)
+        elif macro_name == "plantuml":
+            _convert_plantuml(soup, macro)
         elif macro_name == "profile":
             _convert_profile(soup, macro, user_resolver)
         elif macro_name == "status":
@@ -281,6 +465,16 @@ def _preprocess_html(
     # --- Clean up any remaining ac:/ri: tags by unwrapping ---
     for tag in list(soup.find_all(lambda t: t.name and (t.name.startswith("ac:") or t.name.startswith("ri:")))):
         tag.unwrap()
+
+    # Replace Unicode whitespace (nbsp, EM SPACE, ...) with regular spaces in
+    # all text nodes outside <pre>. markdownify's chomp() drops these, which
+    # collapses spacing around inline emphasis (CME parity fix).
+    for s in list(soup.find_all(string=True)):
+        if any(p.name == "pre" for p in s.parents if p is not None and p.name):
+            continue
+        normalized = _normalize_unicode_whitespace(str(s))
+        if normalized != str(s):
+            s.replace_with(NavigableString(normalized))
 
     return str(soup)
 
@@ -482,6 +676,80 @@ def _convert_drawio_placeholder(soup: BeautifulSoup, macro: Tag) -> None:
     placeholder = soup.new_tag("p")
     placeholder.string = f"[drawio:{diagram_name}]"
     macro.replace_with(placeholder)
+
+
+def _convert_plantuml(soup: BeautifulSoup, macro: Tag) -> None:
+    """Convert a PlantUML structured macro to a fenced ```plantuml code block.
+
+    Mirrors CME's Page.Converter.convert_plantuml. Confluence stores the UML
+    text as JSON (``{"umlDefinition": "@startuml\\n..."}``) inside
+    ``<ac:plain-text-body>``. CME reads this from a separate ``editor2`` XML
+    field; conex receives storage HTML directly so we read the body in place.
+    On missing/empty/invalid content we emit an HTML comment so the reader
+    knows something was lost rather than dropping silently.
+    """
+    body = macro.find("ac:plain-text-body")
+    if not body:
+        macro.replace_with(NavigableString("\n<!-- PlantUML diagram (no content found) -->\n\n"))
+        return
+    cdata_content = body.get_text(strip=True)
+    if not cdata_content:
+        macro.replace_with(NavigableString("\n<!-- PlantUML diagram (empty content) -->\n\n"))
+        return
+    try:
+        data = json.loads(cdata_content)
+    except json.JSONDecodeError:
+        macro.replace_with(NavigableString("\n<!-- PlantUML diagram (invalid JSON) -->\n\n"))
+        return
+    uml = data.get("umlDefinition", "") if isinstance(data, dict) else ""
+    if not uml:
+        macro.replace_with(NavigableString("\n<!-- PlantUML diagram (no UML definition) -->\n\n"))
+        return
+    pre = soup.new_tag("pre")
+    code = soup.new_tag("code", attrs={"class": "language-plantuml"})
+    code.string = uml
+    pre.append(code)
+    macro.replace_with(pre)
+
+
+def _resolve_emoticon_img(img: Tag) -> str | None:
+    """Resolve a rendered ``<img class="emoticon" ...>`` tag to a Unicode emoji.
+
+    Mirrors CME's Page.Converter._convert_emoticon. Resolution order:
+
+    1. ``data-emoji-fallback`` if it is direct Unicode (not a ``:shortname:``).
+    2. ``data-emoji-id`` parsed as ``-`` separated hex codepoints (e.g.
+       ``1f6e0`` or ``1f1e6-1f1e8`` for flags).
+    3. ``data-emoji-id`` looked up in the Atlassian-shipped emoji map (e.g.
+       ``atlassian-check_mark``).
+    4. ``data-emoji-shortname`` (returned as ``:short:``).
+    5. ``data-emoji-fallback`` even if it's a shortname.
+    6. None — the caller leaves the original ``<img>`` alone.
+    """
+    classes = img.get("class") or []
+    if "emoticon" not in classes:
+        return None
+    fallback = str(img.get("data-emoji-fallback", ""))
+    if fallback and not fallback.startswith(":"):
+        return fallback
+    emoji_id = str(img.get("data-emoji-id", ""))
+    if emoji_id:
+        try:
+            codepoints = [int(cp, 16) for cp in emoji_id.split("-")]
+            if codepoints and all(0 <= cp <= _MAX_UNICODE_CODEPOINT for cp in codepoints):
+                return "".join(chr(cp) for cp in codepoints)
+        except (OverflowError, ValueError):
+            pass
+        if emoji_id in _ATLASSIAN_EMOJI_BY_ID:
+            return _ATLASSIAN_EMOJI_BY_ID[emoji_id]
+    shortname = str(img.get("data-emoji-shortname", ""))
+    if shortname:
+        return shortname
+    if fallback:
+        return fallback
+    # Not a resolvable emoticon — leave the img tag alone (e.g. it was just
+    # tagged "emoticon" but has a real src to a custom emoji image).
+    return None
 
 
 def _convert_dynamic_macro_placeholder(

--- a/tests/test_cme_transform_parity.py
+++ b/tests/test_cme_transform_parity.py
@@ -1,0 +1,403 @@
+"""CME-derived markdown transformation parity tests.
+
+Ports the transformation-focused test cases from confluence-markdown-exporter
+(CME) and adapts them to conex's API. Each case below cites its source file in
+CME (cloned at /tmp/cme-compare during development) so future drift can be
+traced back.
+
+Conex differs from CME in shape:
+
+* CME exposes a ``Page.Converter`` instance that subclasses markdownify's
+  converter; tests call ``converter.convert(html)`` or
+  ``converter._helper(...)`` directly.
+* Conex preprocesses Confluence storage HTML in ``_preprocess_html`` and runs
+  markdownify with a fixed configuration. Helpers like
+  ``_normalize_unicode_whitespace`` and ``_escape_template_placeholders`` are
+  module-level functions.
+
+To keep tests readable we provide a small ``_render(html)`` adapter that runs
+the full conex transformation (preprocess + markdownify + post-pass), so tests
+can compare end-to-end behavior similarly to CME's ``converter.convert(html)``.
+
+Tests for behavior that conex currently does not implement are marked
+``xfail`` with a clear reason in the ``docs/cme-markdown-transformation-gaps.md``
+report rather than failing CI.
+"""
+
+from __future__ import annotations
+
+import pytest
+from markdownify import markdownify as md
+
+from confluence_export.converter import (
+    _escape_template_placeholders,
+    _normalize_anchor_links,
+    _normalize_anchor_slug,
+    _normalize_unicode_whitespace,
+    _pre_code_language,
+    _preprocess_html,
+)
+
+
+def _render(html: str) -> str:
+    """Run the full conex HTML→markdown pipeline (mimics CME's converter.convert)."""
+    processed = _preprocess_html(html, [])
+    out = md(
+        processed,
+        heading_style="ATX",
+        bullets="*",
+        strip=["script", "style"],
+        code_language_callback=_pre_code_language,
+    )
+    out = _normalize_anchor_links(out)
+    out = _escape_template_placeholders(out)
+    return out
+
+
+# =============================================================================
+# Source: tests/unit/test_emoticon_conversion.py (CME)
+# Conex stores Confluence emoticons as <ac:emoticon ac:name="..."/>. CME deals
+# with rendered <img class="emoticon"> tags. We added _resolve_emoticon_img so
+# the same rendered-HTML inputs work in conex too.
+# =============================================================================
+class TestEmoticonImgConversion:
+    def test_atlassian_check_mark(self) -> None:
+        html = (
+            '<img class="emoticon emoticon-tick"'
+            ' data-emoji-id="atlassian-check_mark"'
+            ' data-emoji-fallback=":check_mark:"'
+            ' data-emoji-shortname=":check_mark:"'
+            ' alt="(tick)" />'
+        )
+        assert _render(html).strip() == "\u2705"
+
+    def test_atlassian_cross_mark(self) -> None:
+        html = (
+            '<img class="emoticon emoticon-cross"'
+            ' data-emoji-id="atlassian-cross_mark"'
+            ' data-emoji-fallback=":cross_mark:"'
+            ' alt="(error)" />'
+        )
+        assert _render(html).strip() == "\u274c"
+
+    def test_unicode_emoji_by_hex_id(self) -> None:
+        html = (
+            '<img class="emoticon emoticon-blue-star"'
+            ' data-emoji-id="1f6e0"'
+            ' data-emoji-fallback="\U0001f6e0\ufe0f"'
+            ' data-emoji-shortname=":tools:"'
+            ' alt="(blue star)" />'
+        )
+        # CME prefers the direct Unicode fallback when present and not a :shortname:
+        assert _render(html).strip() == "\U0001f6e0\ufe0f"
+
+    def test_unicode_emoji_fallback_direct(self) -> None:
+        html = (
+            '<img class="emoticon"'
+            ' data-emoji-id="1f600"'
+            ' data-emoji-fallback="\U0001f600"'
+            ' alt="smile" />'
+        )
+        assert _render(html).strip() == "\U0001f600"
+
+    def test_custom_emoji_uuid_falls_back_to_shortname(self) -> None:
+        html = (
+            '<img class="emoticon emoticon-blue-star"'
+            ' data-emoji-id="fb5b359f-23fa-44bd-872b-676e207eaaef"'
+            ' data-emoji-fallback=":alert-1:"'
+            ' data-emoji-shortname=":alert-1:"'
+            ' alt="(blue star)" />'
+        )
+        assert _render(html).strip() == ":alert-1:"
+
+    def test_non_emoticon_img_unchanged(self) -> None:
+        html = '<img src="http://example.com/image.png" alt="photo" />'
+        result = _render(html).strip()
+        assert "emoticon" not in result
+        assert "example.com" in result
+
+    def test_emoticon_inline_in_text(self) -> None:
+        html = (
+            'Status: <img class="emoticon emoticon-tick"'
+            ' data-emoji-id="atlassian-check_mark"'
+            ' data-emoji-fallback=":check_mark:"'
+            ' alt="(tick)" /> Done'
+        )
+        result = _render(html).strip()
+        assert "\u2705" in result
+        assert "Done" in result
+
+
+# =============================================================================
+# Source: tests/unit/test_nbsp_fix.py (CME)
+# =============================================================================
+class TestUnicodeWhitespacePreservation:
+    def test_em_with_leading_nbsp(self) -> None:
+        assert _render("<em>&nbsp;text</em>").strip() == "*text*"
+        with_context = _render("word<em>&nbsp;text</em>").strip()
+        assert "word *text*" in with_context or "word  *text*" in with_context
+
+    def test_em_with_trailing_nbsp(self) -> None:
+        assert _render("<em>text&nbsp;</em>").strip() == "*text*"
+        with_context = _render("<em>text&nbsp;</em>word").strip()
+        assert "*text* word" in with_context or "*text*  word" in with_context
+
+    def test_em_with_both_nbsp(self) -> None:
+        result = _render("word<em>&nbsp;text&nbsp;</em>end").strip()
+        assert "*text*" in result
+        assert "word *text* end" in result or "word  *text*  end" in result
+
+    def test_strong_with_leading_nbsp(self) -> None:
+        result = _render("word<strong>&nbsp;text</strong>").strip()
+        assert "**text**" in result
+        assert "word **text**" in result or "word  **text**" in result
+
+    def test_strong_with_trailing_nbsp(self) -> None:
+        result = _render("<strong>text&nbsp;</strong>word").strip()
+        assert "**text**" in result
+        assert "**text** word" in result or "**text**  word" in result
+
+    def test_code_with_leading_nbsp(self) -> None:
+        result = _render("word<code>&nbsp;text</code>").strip()
+        assert "`text`" in result
+        assert "word `text`" in result or "word  `text`" in result
+
+    def test_code_with_trailing_nbsp(self) -> None:
+        result = _render("<code>text&nbsp;</code>word").strip()
+        assert "`text`" in result
+        assert "`text` word" in result or "`text`  word" in result
+
+    def test_i_tag_with_nbsp(self) -> None:
+        result = _render("word<i>&nbsp;text</i>").strip()
+        assert "*text*" in result
+        assert "word *text*" in result or "word  *text*" in result
+
+    def test_b_tag_with_nbsp(self) -> None:
+        result = _render("word<b>&nbsp;text</b>").strip()
+        assert "**text**" in result
+        assert "word **text**" in result or "word  **text**" in result
+
+    def test_real_world_confluence_example(self) -> None:
+        result = _render("property<em>&nbsp;JungerRoot</em> .").strip()
+        assert "property*JungerRoot*" not in result, "Space was lost!"
+        assert "*JungerRoot*" in result
+        assert "property" in result
+
+    def test_multiple_nbsp_in_sequence(self) -> None:
+        result = _render("word<em>&nbsp;&nbsp;text</em>").strip()
+        # Multiple nbsp should remain spacing of some kind around emphasis
+        assert "*text*" in result or "* text*" in result
+
+    def test_mixed_whitespace(self) -> None:
+        result = _render("see <em>figure 1</em> below").strip()
+        assert "see *figure 1* below" in result
+
+    def test_normalize_helper_function(self) -> None:
+        assert "\xa0" in "\xa0text\xa0"
+        normalized = _normalize_unicode_whitespace("\xa0text\xa0")
+        assert "\xa0" not in normalized
+        assert normalized.strip() == "text"
+        assert normalized.startswith(" ")
+        assert normalized.endswith(" ")
+
+    def test_unicode_em_space(self) -> None:
+        normalized = _normalize_unicode_whitespace("\u2003text")
+        assert "\u2003" not in normalized
+        assert normalized.strip() == "text"
+        assert normalized.startswith(" ")
+
+    def test_unicode_thin_space(self) -> None:
+        normalized = _normalize_unicode_whitespace("text\u2009end")
+        assert "\u2009" not in normalized
+        assert normalized == "text end"
+
+    def test_preserves_newlines_and_tabs(self) -> None:
+        text = "text\nwith\nnewlines"
+        assert _normalize_unicode_whitespace(text) == text
+
+    def test_no_modification_when_no_unicode_whitespace(self) -> None:
+        text = "normal text"
+        assert _normalize_unicode_whitespace(text) == text
+
+
+# =============================================================================
+# Source: tests/unit/test_template_placeholders.py (CME)
+# =============================================================================
+class TestTemplatePlaceholderEscaping:
+    def test_multi_word_placeholder_escaped(self) -> None:
+        result = _escape_template_placeholders("Replace <medical device> here.")
+        assert result == "Replace \\<medical device\\> here."
+
+    def test_allcaps_placeholder_escaped(self) -> None:
+        result = _escape_template_placeholders("Page: Literature Search Report: <TOPIC>")
+        assert result == "Page: Literature Search Report: \\<TOPIC\\>"
+
+    def test_complex_placeholder_escaped(self) -> None:
+        text = "the <(e.g., clinical performance or state of the art)> of <medical device>."
+        result = _escape_template_placeholders(text)
+        assert "\\<(e.g., clinical performance or state of the art)\\>" in result
+        assert "\\<medical device\\>" in result
+
+    def test_placeholder_with_slash_in_name_escaped(self) -> None:
+        result = _escape_template_placeholders("the <medical device/equivalent device> here")
+        assert "\\<medical device/equivalent device\\>" in result
+
+    def test_fake_closing_tag_placeholder_escaped(self) -> None:
+        result = _escape_template_placeholders("use the </insert excerpt> function")
+        assert "\\</insert excerpt\\>" in result
+
+    def test_br_tag_preserved(self) -> None:
+        result = _escape_template_placeholders("text<br/>more text")
+        assert result == "text<br/>more text"
+
+    def test_br_with_space_preserved(self) -> None:
+        result = _escape_template_placeholders("text<br />more text")
+        assert result == "text<br />more text"
+
+    def test_br_uppercase_preserved(self) -> None:
+        result = _escape_template_placeholders("text<BR/>more text")
+        assert result == "text<BR/>more text"
+
+    def test_closing_html_tag_preserved(self) -> None:
+        result = _escape_template_placeholders("</div>")
+        assert result == "</div>"
+
+    def test_inline_code_not_modified(self) -> None:
+        result = _escape_template_placeholders("Use `<TOPIC>` here.")
+        assert result == "Use `<TOPIC>` here."
+
+    def test_fenced_code_block_not_modified(self) -> None:
+        text = "before\n```\n<TOPIC>\n<medical device>\n```\nafter"
+        result = _escape_template_placeholders(text)
+        assert "<TOPIC>" in result
+        assert "<medical device>" in result
+        assert "\\<TOPIC\\>" not in result
+
+    def test_tilde_fenced_code_block_not_modified(self) -> None:
+        text = "before\n~~~\n<TOPIC>\n~~~\nafter"
+        result = _escape_template_placeholders(text)
+        assert "<TOPIC>" in result
+
+    def test_text_outside_code_block_still_escaped(self) -> None:
+        text = "Replace <TOPIC> here.\n```\n<TOPIC>\n```\nAlso <medical device>."
+        result = _escape_template_placeholders(text)
+        lines = result.split("\n")
+        assert "\\<TOPIC\\>" in lines[0]
+        assert "<TOPIC>" in lines[2]
+        assert "\\<medical device\\>" in lines[4]
+
+
+# =============================================================================
+# Source: tests/unit/test_confluence.py::TestAnchorLinkConversion (CME)
+# Conex normalizes anchor slugs as a markdown post-pass; CME does it inside
+# convert_a. Behavior should match for fragment-only links with default
+# (non-wiki) settings.
+# =============================================================================
+class TestAnchorLinkConversion:
+    def test_anchor_uses_href_not_link_text(self) -> None:
+        html = '<a href="#1.-Request-Service">request service</a>'
+        assert _render(html).strip() == "[request service](#1-request-service)"
+
+    def test_anchor_plain_heading(self) -> None:
+        html = '<a href="#My-Heading">My Heading</a>'
+        assert _render(html).strip() == "[My Heading](#my-heading)"
+
+    def test_anchor_with_numbers_and_punctuation(self) -> None:
+        html = '<a href="#2.-Setup-Steps">setup steps</a>'
+        assert _render(html).strip() == "[setup steps](#2-setup-steps)"
+
+    def test_normalize_anchor_slug_helper(self) -> None:
+        assert _normalize_anchor_slug("1.-Request-Service") == "1-request-service"
+        assert _normalize_anchor_slug("My-Heading") == "my-heading"
+        assert _normalize_anchor_slug("--leading-trailing--") == "leading-trailing"
+
+    @pytest.mark.xfail(
+        reason=(
+            "Wiki-style anchor links ([[#Heading]]) need a configurable "
+            "page_href setting; conex has no equivalent today. Tracked in "
+            "docs/cme-markdown-transformation-gaps.md (Wiki-style links)."
+        ),
+        strict=True,
+    )
+    def test_wiki_anchor_uses_link_text(self) -> None:
+        html = '<a href="#1.-Request-Service">Request Service</a>'
+        # If a wiki mode were configured the expected output would be:
+        assert _render(html).strip() == "[[#Request Service]]"
+
+
+# =============================================================================
+# Source: tests/unit/test_plantuml_conversion.py (CME)
+# CME pulls the JSON from a separate ``page.editor2`` field; conex receives
+# storage HTML that already contains ``<ac:plain-text-body>``, so we read the
+# JSON in place. The behavior on the JSON payload itself matches.
+# =============================================================================
+class TestPlantUMLConversion:
+    def test_convert_plantuml_basic(self) -> None:
+        html = (
+            '<ac:structured-macro ac:name="plantuml" ac:macro-id="m1">'
+            '<ac:parameter ac:name="fileName">plantuml_test</ac:parameter>'
+            '<ac:plain-text-body>'
+            r'<![CDATA[{"umlDefinition":"@startuml\nAlice -> Bob: Hello\n@enduml"}]]>'
+            "</ac:plain-text-body>"
+            "</ac:structured-macro>"
+        )
+        result = _render(html)
+        assert "```plantuml" in result
+        assert "@startuml" in result
+        assert "Alice -> Bob: Hello" in result
+        assert "@enduml" in result
+
+    def test_convert_plantuml_complex_diagram(self) -> None:
+        uml = (
+            "@startuml\\nskinparam backgroundColor white\\ntitle Test Diagram\\n\\n"
+            "|Actor|\\nstart\\n:Action 1;\\n:Action 2;\\nstop\\n@enduml"
+        )
+        html = (
+            '<ac:structured-macro ac:name="plantuml" ac:macro-id="m2">'
+            '<ac:plain-text-body>'
+            f'<![CDATA[{{"umlDefinition":"{uml}"}}]]>'
+            "</ac:plain-text-body>"
+            "</ac:structured-macro>"
+        )
+        result = _render(html)
+        assert "```plantuml" in result
+        assert "@startuml" in result
+        assert "skinparam backgroundColor white" in result
+        assert "title Test Diagram" in result
+        assert "@enduml" in result
+
+    def test_convert_plantuml_invalid_json(self) -> None:
+        html = (
+            '<ac:structured-macro ac:name="plantuml" ac:macro-id="m3">'
+            '<ac:plain-text-body><![CDATA[{invalid json}]]></ac:plain-text-body>'
+            "</ac:structured-macro>"
+        )
+        result = _render(html)
+        assert "PlantUML diagram" in result
+        assert "invalid JSON" in result
+
+    def test_convert_plantuml_empty_body(self) -> None:
+        html = (
+            '<ac:structured-macro ac:name="plantuml" ac:macro-id="m4">'
+            '<ac:plain-text-body></ac:plain-text-body>'
+            "</ac:structured-macro>"
+        )
+        result = _render(html)
+        assert "PlantUML diagram" in result
+        assert "empty content" in result
+
+    @pytest.mark.xfail(
+        reason=(
+            "CME also resolves the macro from a separate editor2 XML field by "
+            "matching data-macro-id (rendered-HTML pages). Conex consumes "
+            "storage XML directly, so this code path is not implemented. "
+            "Tracked in docs/cme-markdown-transformation-gaps.md."
+        ),
+        strict=True,
+    )
+    def test_convert_plantuml_no_macro_id(self) -> None:
+        # In CME, this test exercises the rendered <div data-macro-name="plantuml">
+        # path with no macro-id, expecting the "no macro-id found" comment.
+        html = '<div data-macro-name="plantuml"></div>'
+        result = _render(html)
+        assert "no macro-id found" in result


### PR DESCRIPTION
## Summary

Ports the markdown transformation-focused tests from `Spenhouet/confluence-markdown-exporter` (CME) into conex and uses them as a parity benchmark.

Also adds focused converter fixes where CME was clearly better:

- rendered `<img class="emoticon">` emoji handling
- Unicode whitespace / `&nbsp;` preservation around inline formatting
- template placeholder escaping for `<TOPIC>` / `<medical device>` style text
- Confluence fragment anchor normalization (`#1.-Request-Service` → `#1-request-service`)
- PlantUML storage macro conversion to fenced `plantuml` blocks

## Gap report

Adds `docs/cme-markdown-transformation-gaps.md` with the transformation gaps where CME remains stronger or broader.

Explicit xfail gaps:

- wiki-style link mode (`[[Page]]`, `[[#Heading]]`)
- rendered-HTML PlantUML lookup via separate `editor2` XML

## Validation

- `git diff --check`
- `uv run --extra dev pytest tests/test_cme_transform_parity.py -q` → 45 passed, 2 xfailed
- `uv run --extra dev pytest -q` → 319 passed, 2 xfailed
