### PR TITLE
Document required Confluence API scopes and add --no-author-lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ read:user:confluence
 
 For classic OAuth 2.0 (3LO) tokens, the equivalent set is `read:confluence-space.summary`, `read:confluence-content.all`, `readonly:content.attachment:confluence`, and `read:confluence-user`.
 
+Scoped tokens must be addressed via the OAuth gateway URL (`https://api.atlassian.com/ex/confluence/{cloudId}/...`) rather than the site URL. The tool detects this automatically: on first use, it looks up your site's cloud ID from the unauthenticated `/_edge/tenant_info` endpoint, rewrites `base_url` in the saved config, and routes all subsequent requests through the gateway. No manual configuration needed — keep `base_url` set to your site URL.
+
 ## Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ confluence-export --base-url https://example.atlassian.net --cookie 'tenant.sess
 
 If no token or cookie is provided, the tool will prompt interactively. Browser credentials are used for the current run only and never saved.
 
+## Required permissions
+
+Basic Auth (email + API token) and unscoped Personal Access Tokens use the underlying user's full permissions — no further setup needed. If you provision a [scoped API token](https://developer.atlassian.com/cloud/confluence/scopes-for-oauth-2-3LO-and-forge-apps/) or use OAuth 2.0 / Forge, grant these five granular read scopes:
+
+```
+read:space:confluence
+read:page:confluence
+read:folder:confluence
+read:attachment:confluence
+read:user:confluence
+```
+
+`read:user:confluence` is only needed to render `@mentions` and `profile` macros with display names instead of opaque Atlassian account IDs in the exported markdown. If your token can't grant it, pass `--no-author-lookup` to skip user resolution; mentions fall back to the raw account ID. The other four scopes are required.
+
+For classic OAuth 2.0 (3LO) tokens, the equivalent set is `read:confluence-space.summary`, `read:confluence-content.all`, `readonly:content.attachment:confluence`, and `read:confluence-user`.
+
 ## Commands
 
 ```bash
@@ -80,6 +96,7 @@ confluence-export export SPACEKEY -o ./output       # export full space
 confluence-export export SPACEKEY --path /Sub/Tree  # export a subtree
 confluence-export export SPACEKEY --no-media        # skip attachments
 confluence-export export SPACEKEY --no-git          # skip git versioning
+confluence-export export SPACEKEY --no-author-lookup # skip Confluence user lookup
 confluence-export diff SPACEKEY ./output            # compare export vs. live
 confluence-export refresh SPACEKEY                  # force-refresh cache
 ```

--- a/src/confluence_export/cli.py
+++ b/src/confluence_export/cli.py
@@ -187,6 +187,11 @@ def main() -> None:
     export_p.add_argument("--include-html", action="store_true", help="Save raw HTML alongside markdown")
     export_p.add_argument("--include-archived", action="store_true", help="Include archived pages (skipped by default)")
     export_p.add_argument("--no-git", action="store_true", help="Skip automatic git versioning")
+    export_p.add_argument(
+        "--no-author-lookup",
+        action="store_true",
+        help="Skip Confluence user lookups (for tokens without read:user:confluence)",
+    )
 
     # diff
     diff_p = sub.add_parser("diff", help="Compare export dir against current Confluence state")
@@ -261,6 +266,7 @@ def main() -> None:
                 debug=args.include_html,
                 include_archived=args.include_archived,
                 no_git=args.no_git,
+                no_author_lookup=args.no_author_lookup,
             )
         case "diff":
             _cmd_diff(
@@ -321,6 +327,15 @@ def _cmd_configure() -> None:
     cfg = Config(base_url=base_url.rstrip("/"), email=email, api_token=token)
     path = save_config(cfg)
     print(f"\nConfiguration saved to {path}")
+    print(
+        "\nIf this is a scoped API token, grant these five read scopes:\n"
+        "  read:space:confluence\n"
+        "  read:page:confluence\n"
+        "  read:folder:confluence\n"
+        "  read:attachment:confluence\n"
+        "  read:user:confluence  (omit and pass --no-author-lookup to skip)\n"
+        "Basic Auth and unscoped tokens already have full access."
+    )
 
 
 def _cmd_spaces(client: ConfluenceClient) -> None:
@@ -384,6 +399,7 @@ def _cmd_export(
     debug: bool = False,
     include_archived: bool = False,
     no_git: bool = False,
+    no_author_lookup: bool = False,
 ) -> None:
     """Export page tree as LLM-ready markdown."""
     space = _with_auth_fallback(lambda: _resolve_space(client, space_key), client, config)
@@ -417,6 +433,7 @@ def _cmd_export(
         download_media=not no_media,
         render_drawio=not no_drawio_render,
         debug=debug,
+        skip_author_lookup=no_author_lookup,
     )
 
     result = exporter.export_space(

--- a/src/confluence_export/cli.py
+++ b/src/confluence_export/cli.py
@@ -12,7 +12,15 @@ import requests
 
 from confluence_export.cache import CacheStore
 from confluence_export.client import AuthenticationError, ConfluenceClient
-from confluence_export.config import Config, config_path, load_config, save_config
+from confluence_export.config import (
+    Config,
+    config_path,
+    gateway_url,
+    is_atlassian_site_url,
+    is_scoped_token,
+    load_config,
+    save_config,
+)
 from confluence_export.diff import compute_diff, format_diff, scan_export_dir
 from confluence_export.tree import (
     build_tree,
@@ -106,6 +114,58 @@ def _apply_browser_credentials(client: ConfluenceClient, base_url: str, reason: 
         print(f"Authentication failed (HTTP {status}).", file=sys.stderr)
         sys.exit(1)
     print("Authenticated.", file=sys.stderr, flush=True)
+
+
+def _resolve_cloud_id(site_url: str) -> str | None:
+    """Look up the Confluence cloud ID for a site URL via /_edge/tenant_info.
+
+    The endpoint is unauthenticated and returns `{"cloudId": "<uuid>"}`.
+    Returns None on any failure so callers can fall back to the site URL.
+    """
+    try:
+        resp = requests.get(
+            site_url.rstrip("/") + "/_edge/tenant_info",
+            headers={"Accept": "application/json"},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        cloud_id = resp.json().get("cloudId")
+        return cloud_id if isinstance(cloud_id, str) and cloud_id else None
+    except (requests.exceptions.RequestException, ValueError):
+        return None
+
+
+def _maybe_route_via_gateway(config: Config) -> Config:
+    """Rewrite a site-URL `base_url` to the OAuth gateway when the token is scoped.
+
+    Atlassian scoped API tokens (ATATT…=ADA…) are rejected with 401 against
+    the site URL — they must go through `api.atlassian.com/ex/confluence/{cloudId}`.
+    This is invisible to users: we detect a site URL paired with a scoped token,
+    resolve the cloudId, rewrite the config, and persist so the round-trip
+    happens at most once per token rotation.
+    """
+    if not (is_atlassian_site_url(config.base_url) and is_scoped_token(config.api_token)):
+        return config
+
+    cloud_id = _resolve_cloud_id(config.base_url)
+    if not cloud_id:
+        # Cloud ID lookup failed — leave config alone and let the request fail
+        # with the underlying 401 so the user sees the real error.
+        return config
+
+    new_url = gateway_url(cloud_id)
+    print(
+        f"Routing scoped token through OAuth gateway: {new_url}",
+        file=sys.stderr,
+    )
+    config.base_url = new_url
+    try:
+        save_config(config)
+    except OSError:
+        # If we can't persist (e.g. read-only filesystem in CI), the rewrite
+        # still applies for this run — next run will redo the lookup.
+        pass
+    return config
 
 
 def _is_auth_error(exc: Exception) -> int | None:
@@ -226,6 +286,8 @@ def main() -> None:
         print(f"\nRun 'confluence-export configure' to set up credentials.", file=sys.stderr)
         sys.exit(1)
 
+    config = _maybe_route_via_gateway(config)
+
     client = ConfluenceClient(config, verbose=args.verbose)
 
     if args.cookie:
@@ -327,6 +389,10 @@ def _cmd_configure() -> None:
     cfg = Config(base_url=base_url.rstrip("/"), email=email, api_token=token)
     path = save_config(cfg)
     print(f"\nConfiguration saved to {path}")
+    # Scoped tokens must be routed through the OAuth gateway. Resolve the
+    # cloudId now so the user sees the rewrite (and the eventual saved URL)
+    # before they hit the first command.
+    _maybe_route_via_gateway(cfg)
     print(
         "\nIf this is a scoped API token, grant these five read scopes:\n"
         "  read:space:confluence\n"

--- a/src/confluence_export/config.py
+++ b/src/confluence_export/config.py
@@ -4,11 +4,40 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urlparse
 
 CONFIG_DIR_NAME = "confluence-export"
 CONFIG_FILE = "config.json"
+
+GATEWAY_HOST = "api.atlassian.com"
+_SITE_HOST_RE = re.compile(r"^[a-z0-9][a-z0-9-]*\.atlassian\.net$", re.IGNORECASE)
+
+
+def is_scoped_token(token: str) -> bool:
+    """True if token looks like an Atlassian scoped API token (ATATT…=ADA…).
+
+    Scoped tokens require requests to be routed through the OAuth gateway URL
+    `https://api.atlassian.com/ex/confluence/{cloudId}/...` rather than the
+    Confluence site URL. The `=ADA<hex>` suffix encodes the scope set; tokens
+    without it are full-access (legacy) tokens that work with the site URL.
+    """
+    return bool(token) and token.startswith("ATATT") and "=ADA" in token
+
+
+def is_atlassian_site_url(url: str) -> bool:
+    """True if url points at a `*.atlassian.net` site (not the OAuth gateway)."""
+    if not url:
+        return False
+    host = urlparse(url).hostname or ""
+    return bool(_SITE_HOST_RE.match(host))
+
+
+def gateway_url(cloud_id: str) -> str:
+    """Build the OAuth gateway base URL for a Confluence cloud ID."""
+    return f"https://{GATEWAY_HOST}/ex/confluence/{cloud_id}"
 
 
 def _config_dir() -> Path:

--- a/src/confluence_export/exporter.py
+++ b/src/confluence_export/exporter.py
@@ -46,6 +46,7 @@ class Exporter:
         download_media: bool = True,
         render_drawio: bool = True,
         debug: bool = False,
+        skip_author_lookup: bool = False,
     ):
         self.client = client
         self.cache = cache
@@ -53,10 +54,13 @@ class Exporter:
         self.download_media = download_media
         self.render_drawio = render_drawio
         self.debug = debug
+        self.skip_author_lookup = skip_author_lookup
         self._user_cache: dict[str, dict | None] = {}
 
     def _resolve_user(self, account_id: str) -> dict | None:
         """Resolve user account ID to user info dict, with caching."""
+        if self.skip_author_lookup:
+            return None
         if account_id not in self._user_cache:
             self._user_cache[account_id] = self.client.get_user_info(account_id)
         return self._user_cache[account_id]

--- a/src/confluence_export/media.py
+++ b/src/confluence_export/media.py
@@ -94,9 +94,22 @@ def download_attachments(
 
     def _download_one(item: tuple[Attachment, Path]) -> Path:
         att, dest = item
-        download_path = att.download_link
-        if not download_path.startswith("/wiki"):
-            download_path = f"/wiki{download_path}"
+        # Prefer the v1 REST attachment-download endpoint over the legacy
+        # `_links.download` path (`/wiki/download/attachments/...`). The REST
+        # endpoint works on both the site URL and the OAuth gateway URL used
+        # for scoped API tokens, whereas the legacy download path 401s through
+        # the gateway. Fall back to the legacy path only when the cached
+        # attachment has no page_id (very old caches written before this field
+        # existed).
+        if att.page_id and att.id:
+            download_path = (
+                f"/wiki/rest/api/content/{att.page_id}"
+                f"/child/attachment/{att.id}/download"
+            )
+        else:
+            download_path = att.download_link
+            if not download_path.startswith("/wiki"):
+                download_path = f"/wiki{download_path}"
         client.download_attachment_to_file(download_path, str(dest))
         return dest
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -7,7 +7,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from confluence_export.cli import main, _maybe_route_via_gateway, _resolve_space
+import requests
+
+from confluence_export.cli import (
+    _maybe_route_via_gateway,
+    _resolve_cloud_id,
+    _resolve_space,
+    main,
+)
 from confluence_export.config import Config
 from confluence_export.types import CachedSpace, Page, Space, Version
 
@@ -352,6 +359,64 @@ class TestNeedsToken:
              patch("confluence_export.cli._apply_browser_credentials") as mock_apply:
             main()
         mock_apply.assert_called_once()
+
+
+class TestResolveCloudId:
+    """Cloud-ID lookup against the unauthenticated /_edge/tenant_info endpoint."""
+
+    def _mock_response(self, *, status=200, body=None, raise_json=False):
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        if status >= 400:
+            resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+                f"HTTP {status}"
+            )
+        if raise_json:
+            resp.json.side_effect = ValueError("bad json")
+        else:
+            resp.json.return_value = body or {}
+        return resp
+
+    def test_happy_path_returns_cloud_id(self):
+        resp = self._mock_response(body={"cloudId": "abc-123"})
+        with patch("confluence_export.cli.requests.get", return_value=resp) as mock_get:
+            assert _resolve_cloud_id("https://acme.atlassian.net/") == "abc-123"
+        # Trailing slash stripped, /_edge/tenant_info appended.
+        called_url = mock_get.call_args[0][0]
+        assert called_url == "https://acme.atlassian.net/_edge/tenant_info"
+
+    def test_network_error_returns_none(self):
+        with patch(
+            "confluence_export.cli.requests.get",
+            side_effect=requests.exceptions.ConnectionError("dns"),
+        ):
+            assert _resolve_cloud_id("https://acme.atlassian.net") is None
+
+    def test_http_error_returns_none(self):
+        resp = self._mock_response(status=503)
+        with patch("confluence_export.cli.requests.get", return_value=resp):
+            assert _resolve_cloud_id("https://acme.atlassian.net") is None
+
+    def test_bad_json_returns_none(self):
+        resp = self._mock_response(raise_json=True)
+        with patch("confluence_export.cli.requests.get", return_value=resp):
+            assert _resolve_cloud_id("https://acme.atlassian.net") is None
+
+    def test_missing_cloud_id_field_returns_none(self):
+        resp = self._mock_response(body={"someOther": "value"})
+        with patch("confluence_export.cli.requests.get", return_value=resp):
+            assert _resolve_cloud_id("https://acme.atlassian.net") is None
+
+    def test_non_string_cloud_id_returns_none(self):
+        # Defensive: API contract says string, but guard against future drift.
+        resp = self._mock_response(body={"cloudId": 12345})
+        with patch("confluence_export.cli.requests.get", return_value=resp):
+            assert _resolve_cloud_id("https://acme.atlassian.net") is None
+
+    def test_empty_cloud_id_returns_none(self):
+        resp = self._mock_response(body={"cloudId": ""})
+        with patch("confluence_export.cli.requests.get", return_value=resp):
+            assert _resolve_cloud_id("https://acme.atlassian.net") is None
 
 
 class TestMaybeRouteViaGateway:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -7,9 +7,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from confluence_export.cli import main, _resolve_space
+from confluence_export.cli import main, _maybe_route_via_gateway, _resolve_space
 from confluence_export.config import Config
 from confluence_export.types import CachedSpace, Page, Space, Version
+
+SCOPED_TOKEN = "ATATT3xFfGF0_dummy_payload_TgVilzYuG3Sh8MtCp_8=ADA80198"
+LEGACY_TOKEN = "ATATT3xFfGF0_dummy_no_scope_marker_here"
 
 
 def _space(key="TEST", name="Test Space"):
@@ -349,6 +352,86 @@ class TestNeedsToken:
              patch("confluence_export.cli._apply_browser_credentials") as mock_apply:
             main()
         mock_apply.assert_called_once()
+
+
+class TestMaybeRouteViaGateway:
+    """Auto-rewrite of site URL to OAuth gateway for scoped tokens."""
+
+    def test_scoped_token_on_site_url_rewrites_and_persists(self):
+        cfg = Config(
+            base_url="https://acme.atlassian.net",
+            email="a@b.com",
+            api_token=SCOPED_TOKEN,
+        )
+        with patch(
+            "confluence_export.cli._resolve_cloud_id", return_value="cloud-uuid-123"
+        ), patch("confluence_export.cli.save_config") as mock_save:
+            result = _maybe_route_via_gateway(cfg)
+
+        assert result.base_url == "https://api.atlassian.com/ex/confluence/cloud-uuid-123"
+        mock_save.assert_called_once_with(cfg)
+
+    def test_legacy_token_left_alone(self):
+        cfg = Config(
+            base_url="https://acme.atlassian.net",
+            email="a@b.com",
+            api_token=LEGACY_TOKEN,
+        )
+        with patch("confluence_export.cli._resolve_cloud_id") as mock_resolve, \
+             patch("confluence_export.cli.save_config") as mock_save:
+            result = _maybe_route_via_gateway(cfg)
+
+        # No network call, no rewrite, no save
+        mock_resolve.assert_not_called()
+        mock_save.assert_not_called()
+        assert result.base_url == "https://acme.atlassian.net"
+
+    def test_already_gateway_url_left_alone(self):
+        # If base_url is already the gateway, nothing to do.
+        cfg = Config(
+            base_url="https://api.atlassian.com/ex/confluence/cloud-uuid",
+            email="a@b.com",
+            api_token=SCOPED_TOKEN,
+        )
+        with patch("confluence_export.cli._resolve_cloud_id") as mock_resolve, \
+             patch("confluence_export.cli.save_config") as mock_save:
+            result = _maybe_route_via_gateway(cfg)
+
+        mock_resolve.assert_not_called()
+        mock_save.assert_not_called()
+        assert result.base_url == cfg.base_url
+
+    def test_cloud_id_lookup_failure_leaves_url_intact(self):
+        """If /_edge/tenant_info is unreachable, fall back to the original URL
+        so the caller sees the underlying 401 instead of a silent rewrite."""
+        cfg = Config(
+            base_url="https://acme.atlassian.net",
+            email="a@b.com",
+            api_token=SCOPED_TOKEN,
+        )
+        with patch(
+            "confluence_export.cli._resolve_cloud_id", return_value=None
+        ), patch("confluence_export.cli.save_config") as mock_save:
+            result = _maybe_route_via_gateway(cfg)
+
+        mock_save.assert_not_called()
+        assert result.base_url == "https://acme.atlassian.net"
+
+    def test_persist_failure_does_not_break_run(self, tmp_path):
+        """A read-only filesystem must not stop the rewrite from applying."""
+        cfg = Config(
+            base_url="https://acme.atlassian.net",
+            email="a@b.com",
+            api_token=SCOPED_TOKEN,
+        )
+        with patch(
+            "confluence_export.cli._resolve_cloud_id", return_value="cloud-uuid"
+        ), patch(
+            "confluence_export.cli.save_config", side_effect=OSError("read-only fs")
+        ):
+            result = _maybe_route_via_gateway(cfg)
+
+        assert result.base_url.startswith("https://api.atlassian.com/")
 
 
 class TestConfigError:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -246,6 +246,27 @@ class TestExportCommand:
 
         assert not (Path(out) / ".git").exists()
 
+    def test_no_author_lookup_flag_propagates_to_exporter(self, tmp_path):
+        client = _mock_client()
+        cache = MagicMock()
+        cache.refresh.return_value = _cached_space()
+        out = str(tmp_path / "out")
+        argv = [
+            "confluence-export", "export", "TEST",
+            "-o", out, "--no-media", "--no-git", "--no-author-lookup",
+        ]
+        with patch("sys.argv", argv), \
+             patch("confluence_export.cli.load_config", return_value=_config()), \
+             patch("confluence_export.cli.ConfluenceClient", return_value=client), \
+             patch("confluence_export.cli.CacheStore", return_value=cache), \
+             patch("confluence_export.cli.Exporter") as exporter_cls:
+            exporter_cls.return_value.export_space.return_value = MagicMock(
+                count=0, written_files=[]
+            )
+            main()
+
+        assert exporter_cls.call_args.kwargs["skip_author_lookup"] is True
+
 
 class TestRefreshCommand:
     def test_refreshes_and_reports(self, capsys):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,7 +9,14 @@ from unittest.mock import patch
 
 import pytest
 
-from confluence_export.config import Config, load_config, save_config
+from confluence_export.config import (
+    Config,
+    gateway_url,
+    is_atlassian_site_url,
+    is_scoped_token,
+    load_config,
+    save_config,
+)
 
 
 class TestConfig:
@@ -97,6 +104,45 @@ class TestLoadConfig:
 
         with pytest.raises(ValueError, match="base_url"):
             load_config()
+
+
+class TestIsScopedToken:
+    def test_scoped_token_detected(self):
+        # Real-world scoped token shape: ATATT3 + ... + =ADA<hex>
+        token = "ATATT3xFfGF0_dummy_payload_TgVilzYuG3Sh8MtCp_8=ADA80198"
+        assert is_scoped_token(token) is True
+
+    def test_legacy_atatt_without_ada_suffix(self):
+        # Old-style ATATT tokens (full-access) lack the =ADA scope marker
+        assert is_scoped_token("ATATT3xFfGF0_dummy_no_scope_marker_here") is False
+
+    def test_non_atatt_token(self):
+        # Server PATs (Bearer-style) don't start with ATATT
+        assert is_scoped_token("NDgyNDk2OTk2NzY3OmDsiR4mCSIaSjMqOg") is False
+
+    def test_empty_token(self):
+        assert is_scoped_token("") is False
+
+
+class TestIsAtlassianSiteUrl:
+    def test_site_url(self):
+        assert is_atlassian_site_url("https://acme.atlassian.net") is True
+        assert is_atlassian_site_url("https://acme.atlassian.net/") is True
+
+    def test_gateway_url(self):
+        assert is_atlassian_site_url("https://api.atlassian.com/ex/confluence/abc") is False
+
+    def test_self_hosted(self):
+        assert is_atlassian_site_url("https://wiki.example.com") is False
+
+    def test_empty(self):
+        assert is_atlassian_site_url("") is False
+
+
+class TestGatewayUrl:
+    def test_format(self):
+        cid = "6298609d-df12-4367-a2f6-2ead80671779"
+        assert gateway_url(cid) == f"https://api.atlassian.com/ex/confluence/{cid}"
 
 
 class TestSaveConfig:

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -253,6 +253,13 @@ class TestUserResolution:
         assert exporter._resolve_user("u1") == {"displayName": "Alice"}
         client.get_user_info.assert_called_once_with("u1")  # only 1 API call
 
+    def test_skip_author_lookup_returns_none_without_api_call(self):
+        exporter, client, _ = _make_exporter(skip_author_lookup=True)
+
+        assert exporter._resolve_user("u1") is None
+        assert exporter._resolve_user("u2") is None
+        client.get_user_info.assert_not_called()
+
 
 class TestWorkspaceDirectory:
     def test_workspace_created_for_each_page(self, tmp_path):

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -15,9 +15,16 @@ from confluence_export.media import (
 from confluence_export.types import Attachment, Version
 
 
-def _att(title="img.png", version=1, file_size=100, download_link="/wiki/download/a1"):
+def _att(
+    title="img.png",
+    version=1,
+    file_size=100,
+    download_link="/wiki/download/a1",
+    page_id="p1",
+    att_id="att1",
+):
     return Attachment(
-        id="a1", title=title, file_size=file_size,
+        id=att_id, title=title, file_size=file_size, page_id=page_id,
         download_link=download_link, version=Version(number=version),
     )
 
@@ -125,16 +132,37 @@ class TestDownloadAttachments:
         assert len(_attachment_paths(result)) == 0
         assert "failed to download" in capsys.readouterr().err
 
-    def test_prepends_wiki_prefix(self, tmp_path):
+    def test_uses_v1_content_attachment_endpoint(self, tmp_path):
+        """The download path is built from page_id + att_id, ignoring the
+        legacy `_links.download` URL — the v1 REST endpoint works on both
+        the site URL and the OAuth gateway URL used for scoped tokens.
+        """
         media_dir = tmp_path / ".media"
         media_dir.mkdir()
 
-        att = _att(download_link="/rest/api/content/a1/download")
+        att = _att(page_id="2172649563", att_id="att2173468762")
         client = MagicMock()
 
         download_attachments(client, [att], media_dir)
-        call_args = client.download_attachment_to_file.call_args[0]
-        assert call_args[0].startswith("/wiki")
+        path = client.download_attachment_to_file.call_args[0][0]
+        assert path == "/wiki/rest/api/content/2172649563/child/attachment/att2173468762/download"
+
+    def test_falls_back_to_download_link_for_legacy_cache(self, tmp_path):
+        """Cached attachments written before page_id was tracked still work
+        via the legacy `_links.download` path."""
+        media_dir = tmp_path / ".media"
+        media_dir.mkdir()
+
+        att = _att(
+            page_id="",
+            att_id="",
+            download_link="/download/attachments/123/img.png?version=1",
+        )
+        client = MagicMock()
+
+        download_attachments(client, [att], media_dir)
+        path = client.download_attachment_to_file.call_args[0][0]
+        assert path.startswith("/wiki/download/attachments/")
 
 
 class TestMigrateMediaDirs:


### PR DESCRIPTION
## Summary

Three things, landed together because the second uncovered the first while testing it against a real scoped token.

### 1. Document required Confluence API scopes (commit `729d79f`)

- Adds a "Required permissions" section to the README listing the five granular OAuth read scopes a scoped API token needs (and the classic 3LO equivalents).
- Prints the same scope list at the end of `configure` so users provisioning a token immediately know what to grant.
- Adds `--no-author-lookup` to `export` so tokens without `read:user:confluence` (the most common 401 source on scoped tokens) can still complete an export. Mentions and `profile` macros fall back to the raw account ID instead of failing repeatedly.

The user lookup endpoint (v1 `/wiki/rest/api/user`) is used to render `@mentions` and `profile` macros with display names instead of opaque Atlassian account IDs in the exported markdown — **not** for git commit author attribution as issue #12 originally described. The README and configure output reflect the actual purpose.

### 2. Auto-route scoped tokens through the OAuth gateway (commit `5ca6eb1`)

Atlassian scoped API tokens (`ATATT…=ADA…`) are rejected with 401 against the Confluence site URL. They must be addressed via the OAuth gateway URL (`https://api.atlassian.com/ex/confluence/{cloudId}/...`) — a constraint documented only in the token-creation flow ("construct the request URL with a cloud ID") and easy to miss until the first 401 lands.

- Detects a site URL paired with a scoped token, looks up the cloud ID from the unauthenticated `/_edge/tenant_info` endpoint, rewrites `base_url` to the gateway, and persists. The round-trip happens at most once per token rotation; legacy/Basic-Auth tokens are left untouched. If the cloudId lookup fails we leave the URL alone so the user sees the real 401 instead of a silent rewrite.
- Switches attachment downloads from the legacy `_links.download` path (`/wiki/download/attachments/...`) to the v1 REST endpoint (`/wiki/rest/api/content/{pageId}/child/attachment/{attId}/download`). The legacy path 401s through the gateway; the REST endpoint returns a 302 to a signed `api.media.atlassian.com` URL on both site and gateway hosts, so the same code path now serves Basic Auth, unscoped tokens, and scoped tokens. The legacy path is retained as a fallback for caches written before `page_id` was tracked on `Attachment`.

### 3. Coverage for `_resolve_cloud_id` (commit `fd4e7f0`)

The `/_edge/tenant_info` call was the one piece of gateway routing not exercised by the existing `_maybe_route_via_gateway` tests (which mock it out), and codecov flagged the patch as below threshold. Adds seven focused tests for the happy path plus every branch that returns `None`: connection error, HTTP error, JSON decode error, missing field, non-string field, empty string. URL construction (trailing-slash strip + `/_edge/tenant_info` append) is asserted in the happy path.

## Deferred

- v2 `users-bulk` migration suggested in #12: v2 has no GET-by-accountId, so a one-shot lookup would force a bulk fetch + cache redesign for the same end result the `--no-author-lookup` opt-out flag already delivers.
- `configure` prompt UX gap caught during `/review` of this PR: after first use the saved `base_url` is the gateway form, so the prompt default contradicts the README's "keep `base_url` set to your site URL" advice. Filed as #14 — out of scope here because it would mean a config schema migration (`site_url` + derived `base_url`).

## Test plan

- [x] `pytest` — 298 tests pass (was 276 before this PR), including the seven new `_resolve_cloud_id` branch tests, five `_maybe_route_via_gateway` rewrite tests, and three `is_scoped_token` / `is_atlassian_site_url` / `gateway_url` helper tests.
- [x] `--cov=confluence_export` — patch coverage 100% for the new statements; total 1526 stmts / 102 missed (same miss count as before this PR).
- [x] Live verification on a personal Confluence space with a real scoped token (`ATATT3…=ADA80198`):
  - Reset `base_url` to `https://<site>.atlassian.net` in config; first command printed `Routing scoped token through OAuth gateway: https://api.atlassian.com/ex/confluence/{cloudId}` and persisted the new URL.
  - Full export of 39 pages succeeded with zero warnings; the previously-failing attachment (`2026-04-28-bb-policy-ids.md`, 7511 bytes) downloaded correctly via the new v1 REST endpoint.
- [x] Manual: `confluence-export configure` prints the scope list.
- [x] Manual: `confluence-export export SPACE -o ./out --no-author-lookup` against a token without `read:user:confluence` completes the export with mentions rendered as `@<accountId>`.

Closes #12. Follow-up filed as #14.