### PR TITLE
Cookie auth via legacy v1 REST endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you don't have an API token, you can authenticate with a browser cookie inste
 confluence-export --base-url https://example.atlassian.net --cookie 'tenant.session.token=...' export SPACEKEY -o ./output
 ```
 
-If no token or cookie is provided, the tool will prompt interactively. Browser credentials are used for the current run only and never saved.
+Cookie authentication uses Confluence's legacy REST read endpoints because Confluence Cloud REST v2 rejects browser session cookies. Use the normal site URL (`https://example.atlassian.net`), not the OAuth gateway URL. If no token or cookie is provided, the tool will prompt interactively. Browser credentials are used for the current run only and never saved.
 
 ## Required permissions
 

--- a/src/confluence_export/cache.py
+++ b/src/confluence_export/cache.py
@@ -77,12 +77,16 @@ class CacheStore:
                     attachments[page_id] = atts
         print(file=sys.stderr)
 
+        # v2 always returns current+archived regardless of the requested flag, so
+        # the cache is archive-capable even when the caller asked for current-only.
+        # Derive the bit from the client's delivered shape, not just the request.
+        cache_includes_archived = include_archived or client.returns_archived_pages
         cs = CachedSpace(
             space=space,
             pages=pages,
             attachments=attachments,
             updated_at=datetime.now(timezone.utc).isoformat(),
-            include_archived=include_archived,
+            include_archived=cache_includes_archived,
         )
         self.save(cs)
         return cs

--- a/src/confluence_export/cache.py
+++ b/src/confluence_export/cache.py
@@ -82,6 +82,7 @@ class CacheStore:
             pages=pages,
             attachments=attachments,
             updated_at=datetime.now(timezone.utc).isoformat(),
+            include_archived=include_archived,
         )
         self.save(cs)
         return cs
@@ -129,6 +130,8 @@ class CacheStore:
     ) -> CachedSpace:
         """Load from cache, or refresh if not cached."""
         cs = self.load(space.key)
-        if cs is not None:
+        # A current-only cache cannot satisfy an archived export. Older cache
+        # files have no provenance bit and intentionally fall into this branch.
+        if cs is not None and (cs.include_archived or not include_archived):
             return cs
         return self.refresh(client, space, include_archived=include_archived)

--- a/src/confluence_export/cache.py
+++ b/src/confluence_export/cache.py
@@ -42,10 +42,12 @@ class CacheStore:
         if p.exists():
             p.unlink()
 
-    def refresh(self, client: ConfluenceClient, space: Space) -> CachedSpace:
+    def refresh(
+        self, client: ConfluenceClient, space: Space, include_archived: bool = False
+    ) -> CachedSpace:
         """Fetch all pages + attachments from the API and cache them."""
         print(f"Fetching pages for space {space.key}...", file=sys.stderr)
-        pages = client.get_pages_in_space(space.id)
+        pages = client.get_pages_in_space(space.id, include_archived=include_archived)
         print(f"Found {len(pages)} pages.", file=sys.stderr)
 
         # Resolve folders: pages may reference parent IDs that are folders,
@@ -122,9 +124,11 @@ class CacheStore:
 
         return pages
 
-    def ensure_loaded(self, client: ConfluenceClient, space: Space) -> CachedSpace:
+    def ensure_loaded(
+        self, client: ConfluenceClient, space: Space, include_archived: bool = False
+    ) -> CachedSpace:
         """Load from cache, or refresh if not cached."""
         cs = self.load(space.key)
         if cs is not None:
             return cs
-        return self.refresh(client, space)
+        return self.refresh(client, space, include_archived=include_archived)

--- a/src/confluence_export/cli.py
+++ b/src/confluence_export/cli.py
@@ -69,7 +69,9 @@ def _prompt_browser_credentials(base_url: str, reason: str) -> tuple[str, str]:
         f"  1. Open {base_url} in your browser and log in\n"
         f"  2. Open DevTools (F12) -> Network tab\n"
         f"  3. Reload the page and click any API request to /wiki/\n"
-        f"  4. Copy the 'Cookie' or 'Authorization' header value\n",
+        f"  4. Copy the 'Cookie' or 'Authorization' header value\n"
+        f"\n"
+        f"Cookie headers use Confluence's legacy REST read endpoints for this run.\n",
         file=sys.stderr,
     )
     try:
@@ -105,7 +107,7 @@ def _apply_browser_credentials(client: ConfluenceClient, base_url: str, reason: 
     # Verify credentials with a minimal request (1 space, fast)
     print("Verifying credentials...", file=sys.stderr, flush=True)
     try:
-        client._get("/wiki/api/v2/spaces", {"limit": "1"})
+        client.verify_auth()
     except AuthenticationError as exc:
         print(f"Authentication failed (HTTP {exc.status_code}).", file=sys.stderr)
         sys.exit(1)
@@ -200,8 +202,8 @@ def _with_auth_fallback(fn, client: ConfluenceClient, config) -> object:
             if status2 is None:
                 raise
             print(
-                f"\nBrowser token also rejected (HTTP {status2}). "
-                f"The token may have expired — try again with a fresh one.",
+                f"\nBrowser credentials also rejected (HTTP {status2}). "
+                f"They may have expired — try again with fresh credentials.",
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -286,7 +288,8 @@ def main() -> None:
         print(f"\nRun 'confluence-export configure' to set up credentials.", file=sys.stderr)
         sys.exit(1)
 
-    config = _maybe_route_via_gateway(config)
+    if not args.cookie:
+        config = _maybe_route_via_gateway(config)
 
     client = ConfluenceClient(config, verbose=args.verbose)
 
@@ -294,7 +297,7 @@ def main() -> None:
         client.set_cookies(args.cookie)
         print("Using browser cookies. Verifying credentials...", file=sys.stderr, flush=True)
         try:
-            client._get("/wiki/api/v2/spaces", {"limit": "1"})
+            client.verify_auth()
         except Exception:
             print("Cookie authentication failed.", file=sys.stderr)
             sys.exit(1)

--- a/src/confluence_export/cli.py
+++ b/src/confluence_export/cli.py
@@ -549,7 +549,9 @@ def _cmd_diff(
         space = cs.space
     else:
         space = _with_auth_fallback(lambda: _resolve_space(client, space_key), client, config)
-    cs = _with_auth_fallback(lambda: cache.refresh(client, space), client, config)
+    cs = _with_auth_fallback(
+        lambda: cache.refresh(client, space, include_archived=include_archived), client, config
+    )
 
     # Filter API pages
     api_pages = [p for p in cs.pages if p.status != "folder"]

--- a/src/confluence_export/client.py
+++ b/src/confluence_export/client.py
@@ -299,23 +299,29 @@ class ConfluenceClient:
         results = self._paginate("/wiki/api/v2/spaces", {"limit": "250"})
         return [self._remember_space(Space.from_api(r)) for r in results]
 
-    def get_pages_in_space(self, space_id: str) -> list[Page]:
+    def get_pages_in_space(self, space_id: str, include_archived: bool = False) -> list[Page]:
         if self.api_flavor == "cookie_v1":
             space_key = self._space_key_for_v1(space_id)
-            results = self._paginate_offset(
-                "/wiki/rest/api/content",
-                {
-                    "spaceKey": space_key,
-                    "type": "page",
-                    "status": "current",
-                    "expand": "body.storage,version,ancestors,space,history,extensions",
-                    "limit": "250",
-                },
-            )
-            return [self._page_from_v1(r) for r in results]
+            # v1 status is single-valued, so archived pages need a second call.
+            statuses = ["current", "archived"] if include_archived else ["current"]
+            pages: list[Page] = []
+            for status in statuses:
+                results = self._paginate_offset(
+                    "/wiki/rest/api/content",
+                    {
+                        "spaceKey": space_key,
+                        "type": "page",
+                        "status": status,
+                        "expand": "body.storage,version,ancestors,space,history,extensions",
+                        "limit": "250",
+                    },
+                )
+                pages.extend(self._page_from_v1(r) for r in results)
+            return pages
 
         # body-format=storage returns the body inline with every page, so the
         # exporter doesn't need an N+1 round trip to fetch each body later.
+        # v2 defaults to status=current,archived; no flag-gating needed.
         path = f"/wiki/api/v2/spaces/{space_id}/pages"
         results = self._paginate(path, {"limit": "250", "body-format": "storage"})
         return [Page.from_api(r) for r in results]

--- a/src/confluence_export/client.py
+++ b/src/confluence_export/client.py
@@ -83,6 +83,16 @@ class ConfluenceClient:
         else:
             self._get("/wiki/api/v2/spaces", {"limit": "1"})
 
+    @property
+    def returns_archived_pages(self) -> bool:
+        """True when get_pages_in_space returns archived pages regardless of include_archived.
+
+        v2 defaults to status=current,archived. cookie_v1 only fetches archived when
+        the flag is set. Callers (e.g. the cache) use this to label what the server
+        actually delivered, not just what the caller asked for.
+        """
+        return self.api_flavor != "cookie_v1"
+
     def _get(self, path: str, params: dict | None = None, max_retries: int = 3) -> dict:
         """GET with retry + rate-limit handling."""
         url = self.base_url + path

--- a/src/confluence_export/client.py
+++ b/src/confluence_export/client.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import sys
 import time
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import parse_qs, quote, urlparse
 
 import requests
 from requests.auth import HTTPBasicAuth
 
 from confluence_export.config import Config
-from confluence_export.types import Attachment, Page, Space
+from confluence_export.types import Attachment, Page, Space, Version
 
 
 class AuthenticationError(Exception):
@@ -36,6 +36,8 @@ class ConfluenceClient:
         self.session = requests.Session()
         self.session.headers.update({"Accept": "application/json"})
         self.session.timeout = 30
+        self.api_flavor = "v2"
+        self._space_key_by_id: dict[str, str] = {}
 
         if config.api_token:
             if config.use_bearer:
@@ -58,17 +60,28 @@ class ConfluenceClient:
     def set_bearer_token(self, token: str) -> None:
         """Replace current credentials with a Bearer token."""
         self.session.auth = None
+        self.session.cookies.clear()
         self.session.headers["Authorization"] = f"Bearer {token}"
+        self.api_flavor = "v2"
 
     def set_cookies(self, cookie_string: str) -> None:
         """Replace current credentials with browser session cookies."""
         self.session.auth = None
         self.session.headers.pop("Authorization", None)
+        self.session.cookies.clear()
         for pair in cookie_string.split(";"):
             pair = pair.strip()
             if "=" in pair:
                 name, _, value = pair.partition("=")
                 self.session.cookies.set(name.strip(), value.strip())
+        self.api_flavor = "cookie_v1"
+
+    def verify_auth(self) -> None:
+        """Verify current credentials with a minimal request."""
+        if self.api_flavor == "cookie_v1":
+            self._get("/wiki/rest/api/space", {"limit": "1"})
+        else:
+            self._get("/wiki/api/v2/spaces", {"limit": "1"})
 
     def _get(self, path: str, params: dict | None = None, max_retries: int = 3) -> dict:
         """GET with retry + rate-limit handling."""
@@ -132,13 +145,175 @@ class ConfluenceClient:
 
         return all_results
 
+    def _paginate_offset(self, path: str, params: dict | None = None) -> list[dict]:
+        """Fetch all pages of results using v1 start/limit pagination."""
+        all_results: list[dict] = []
+        current_path = path
+        current_params = dict(params) if params else {}
+
+        while True:
+            data = self._get(current_path, current_params)
+            all_results.extend(data.get("results", []))
+
+            next_link = data.get("_links", {}).get("next")
+            if not next_link:
+                break
+
+            parsed = urlparse(next_link)
+            current_path = parsed.path
+            current_params = {k: v[0] for k, v in parse_qs(parsed.query).items()}
+
+        return all_results
+
+    @staticmethod
+    def _account_id(user: dict | None) -> str:
+        if not user:
+            return ""
+        return str(
+            user.get("accountId")
+            or user.get("account_id")
+            or user.get("userKey")
+            or user.get("username")
+            or ""
+        )
+
+    @classmethod
+    def _version_from_v1(cls, data: dict | None) -> Version:
+        if not data:
+            return Version()
+        return Version(
+            created_at=data.get("createdAt", "") or data.get("when", ""),
+            message=data.get("message", ""),
+            number=data.get("number", 0),
+            minor_edit=data.get("minorEdit", False),
+            author_id=cls._account_id(data.get("by")),
+        )
+
+    def _remember_space(self, space: Space) -> Space:
+        if space.id and space.key:
+            self._space_key_by_id[space.id] = space.key
+        return space
+
+    def _space_key_for_v1(self, space_id: str) -> str:
+        if space_id in self._space_key_by_id:
+            return self._space_key_by_id[space_id]
+
+        for space in self.get_spaces():
+            if space.id == space_id:
+                return space.key
+
+        # Last-resort fallback for direct tests/callers that pass a key.
+        return space_id
+
+    def _space_from_v1(self, data: dict) -> Space:
+        links = data.get("_links", {})
+        homepage = data.get("homepage") or {}
+        return self._remember_space(
+            Space(
+                id=str(data.get("id", "")),
+                key=data.get("key", ""),
+                name=data.get("name", ""),
+                type=data.get("type", ""),
+                status=data.get("status", ""),
+                homepage_id=str(data.get("homepageId", "") or homepage.get("id", "")),
+                webui=links.get("webui", ""),
+                base=links.get("base", ""),
+            )
+        )
+
+    def _page_from_v1(self, data: dict) -> Page:
+        links = data.get("_links", {})
+        body = data.get("body", {})
+        storage = body.get("storage", {}) if body else {}
+        space = data.get("space") or {}
+        history = data.get("history") or {}
+        ancestors = data.get("ancestors") or []
+        parent = ancestors[-1] if ancestors else {}
+        extensions = data.get("extensions") or {}
+        return Page(
+            id=str(data.get("id", "")),
+            title=data.get("title", ""),
+            space_id=str(space.get("id", "")),
+            parent_id=str(parent.get("id", "") or ""),
+            parent_type=parent.get("type", ""),
+            position=extensions.get("position", 0) or 0,
+            status=data.get("status", ""),
+            author_id=self._account_id(history.get("createdBy")),
+            created_at=history.get("createdDate", ""),
+            version=self._version_from_v1(data.get("version")),
+            body_storage=storage.get("value", "") if storage else "",
+            webui=links.get("webui", ""),
+            editui=links.get("editui", ""),
+            tinyui=links.get("tinyui", ""),
+        )
+
+    def _folder_from_v1(self, data: dict) -> dict:
+        ancestors = data.get("ancestors") or []
+        parent = ancestors[-1] if ancestors else {}
+        space = data.get("space") or {}
+        extensions = data.get("extensions") or {}
+        return {
+            "id": str(data.get("id", "")),
+            "title": data.get("title", ""),
+            "spaceId": str(space.get("id", "")),
+            "parentId": str(parent.get("id", "") or ""),
+            "parentType": parent.get("type", ""),
+            "position": extensions.get("position", 0) or 0,
+            "status": "folder",
+        }
+
+    def _attachment_from_v1(self, data: dict, page_id: str) -> Attachment:
+        links = data.get("_links", {})
+        metadata = data.get("metadata") or {}
+        extensions = data.get("extensions") or {}
+        history = data.get("history") or {}
+        version = self._version_from_v1(data.get("version"))
+        return Attachment(
+            id=str(data.get("id", "")),
+            title=data.get("title", ""),
+            media_type=(
+                data.get("mediaType", "")
+                or metadata.get("mediaType", "")
+                or extensions.get("mediaType", "")
+            ),
+            media_type_description=(
+                data.get("mediaTypeDescription", "")
+                or metadata.get("mediaTypeDescription", "")
+            ),
+            file_size=data.get("fileSize", 0) or extensions.get("fileSize", 0) or 0,
+            page_id=page_id,
+            comment=data.get("comment", ""),
+            created_at=history.get("createdDate", "") or version.created_at,
+            version=version,
+            download_link=links.get("download", "") or data.get("downloadLink", ""),
+            webui=links.get("webui", ""),
+        )
+
     # -- API methods ---------------------------------------------------------
 
     def get_spaces(self) -> list[Space]:
+        if self.api_flavor == "cookie_v1":
+            results = self._paginate_offset("/wiki/rest/api/space", {"limit": "250"})
+            return [self._space_from_v1(r) for r in results]
+
         results = self._paginate("/wiki/api/v2/spaces", {"limit": "250"})
-        return [Space.from_api(r) for r in results]
+        return [self._remember_space(Space.from_api(r)) for r in results]
 
     def get_pages_in_space(self, space_id: str) -> list[Page]:
+        if self.api_flavor == "cookie_v1":
+            space_key = self._space_key_for_v1(space_id)
+            results = self._paginate_offset(
+                "/wiki/rest/api/content",
+                {
+                    "spaceKey": space_key,
+                    "type": "page",
+                    "status": "current",
+                    "expand": "body.storage,version,ancestors,space,history,extensions",
+                    "limit": "250",
+                },
+            )
+            return [self._page_from_v1(r) for r in results]
+
         # body-format=storage returns the body inline with every page, so the
         # exporter doesn't need an N+1 round trip to fetch each body later.
         path = f"/wiki/api/v2/spaces/{space_id}/pages"
@@ -147,24 +322,53 @@ class ConfluenceClient:
 
     def get_space_by_key(self, key: str) -> Space | None:
         """Look up a single space by key using the server-side `keys` filter."""
+        if self.api_flavor == "cookie_v1":
+            try:
+                data = self._get(f"/wiki/rest/api/space/{quote(key, safe='')}")
+            except requests.exceptions.HTTPError as exc:
+                if exc.response is not None and exc.response.status_code == 404:
+                    return None
+                raise
+            return self._space_from_v1(data)
+
         data = self._get("/wiki/api/v2/spaces", {"keys": key, "limit": "1"})
         results = data.get("results", [])
         if not results:
             return None
-        return Space.from_api(results[0])
+        return self._remember_space(Space.from_api(results[0]))
 
     def get_page_by_id(self, page_id: str) -> Page:
+        if self.api_flavor == "cookie_v1":
+            data = self._get(
+                f"/wiki/rest/api/content/{quote(page_id, safe='')}",
+                {"expand": "body.storage,version,ancestors,space,history,extensions"},
+            )
+            return self._page_from_v1(data)
+
         data = self._get(f"/wiki/api/v2/pages/{page_id}", {"body-format": "storage"})
         return Page.from_api(data)
 
     def get_folder_by_id(self, folder_id: str) -> dict | None:
         """Fetch a folder by ID. Returns raw API dict or None on failure."""
         try:
+            if self.api_flavor == "cookie_v1":
+                data = self._get(
+                    f"/wiki/rest/api/content/{quote(folder_id, safe='')}",
+                    {"expand": "ancestors,space,extensions"},
+                )
+                return self._folder_from_v1(data)
             return self._get(f"/wiki/api/v2/folders/{folder_id}")
         except Exception:
             return None
 
     def get_attachments(self, page_id: str) -> list[Attachment]:
+        if self.api_flavor == "cookie_v1":
+            path = f"/wiki/rest/api/content/{quote(page_id, safe='')}/child/attachment"
+            results = self._paginate_offset(
+                path, {"expand": "version,metadata,extensions,history", "limit": "250"}
+            )
+            return [self._attachment_from_v1(r, page_id) for r in results]
+
         path = f"/wiki/api/v2/pages/{page_id}/attachments"
         results = self._paginate(path, {"limit": "250"})
         return [Attachment.from_api(r) for r in results]

--- a/src/confluence_export/exporter.py
+++ b/src/confluence_export/exporter.py
@@ -113,9 +113,9 @@ class Exporter:
         """Export a space (or subtree) to output_dir."""
         # Ensure cache
         if force_refresh:
-            cs = self.cache.refresh(self.client, space)
+            cs = self.cache.refresh(self.client, space, include_archived=include_archived)
         else:
-            cs = self.cache.ensure_loaded(self.client, space)
+            cs = self.cache.ensure_loaded(self.client, space, include_archived=include_archived)
 
         self._prefetch_bodies(cs)
 

--- a/src/confluence_export/types.py
+++ b/src/confluence_export/types.py
@@ -197,6 +197,7 @@ class CachedSpace:
     pages: list[Page]
     attachments: dict[str, list[Attachment]]  # page_id -> attachments
     updated_at: str = ""
+    include_archived: bool = False
 
     def to_dict(self) -> dict:
         return {
@@ -215,6 +216,7 @@ class CachedSpace:
                 for pid, atts in self.attachments.items()
             },
             "updated_at": self.updated_at,
+            "include_archived": self.include_archived,
         }
 
     @classmethod
@@ -227,4 +229,5 @@ class CachedSpace:
                 for pid, atts in data.get("attachments", {}).items()
             },
             updated_at=data.get("updated_at", ""),
+            include_archived=bool(data.get("include_archived", False)),
         )

--- a/tests/test_auth_fallback.py
+++ b/tests/test_auth_fallback.py
@@ -77,6 +77,7 @@ class TestSetBearerToken:
         client.set_bearer_token("browser-tok-123")
         assert client.session.auth is None
         assert client.session.headers["Authorization"] == "Bearer browser-tok-123"
+        assert client.api_flavor == "v2"
 
 
 # -- Config.needs_token ------------------------------------------------------
@@ -230,6 +231,7 @@ class TestSetCookies:
         assert "Authorization" not in client.session.headers
         assert client.session.cookies.get("session") == "abc123"
         assert client.session.cookies.get("token") == "xyz789"
+        assert client.api_flavor == "cookie_v1"
 
     def test_clears_existing_bearer(self):
         config = Config(base_url="https://x.atlassian.net", email="", api_token="pat")
@@ -238,6 +240,7 @@ class TestSetCookies:
 
         client.set_cookies("foo=bar; baz=qux")
         assert "Authorization" not in client.session.headers
+        assert client.api_flavor == "cookie_v1"
 
 
 # -- Client init without token ----------------------------------------------

--- a/tests/test_auth_fallback.py
+++ b/tests/test_auth_fallback.py
@@ -80,6 +80,26 @@ class TestSetBearerToken:
         assert client.api_flavor == "v2"
 
 
+class TestReturnsArchivedPages:
+    def test_true_for_v2_default(self):
+        config = Config(base_url="https://x.atlassian.net", email="a@b.com", api_token="tok")
+        client = ConfluenceClient(config)
+        assert client.returns_archived_pages is True
+
+    def test_false_after_set_cookies(self):
+        config = Config(base_url="https://x.atlassian.net", email="a@b.com", api_token="tok")
+        client = ConfluenceClient(config)
+        client.set_cookies("session=abc")
+        assert client.returns_archived_pages is False
+
+    def test_true_again_after_set_bearer(self):
+        config = Config(base_url="https://x.atlassian.net", email="a@b.com", api_token="tok")
+        client = ConfluenceClient(config)
+        client.set_cookies("session=abc")
+        client.set_bearer_token("tok-2")
+        assert client.returns_archived_pages is True
+
+
 # -- Config.needs_token ------------------------------------------------------
 
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -97,6 +97,7 @@ class TestCacheStore:
         with patch("confluence_export.cache.cache_dir", return_value=tmp_path):
             store = CacheStore()
             client = MagicMock()
+            client.returns_archived_pages = True
             client.get_pages_in_space.return_value = [
                 Page(id="p1", title="Page", space_id="1", version=Version(number=1))
             ]
@@ -122,6 +123,7 @@ class TestCacheStore:
             store = CacheStore()
             store.save(_make_cached_space(include_archived=False))
             client = MagicMock()
+            client.returns_archived_pages = False
             client.get_pages_in_space.return_value = [
                 Page(id="p1", title="Page", space_id="1", version=Version(number=1)),
                 Page(
@@ -141,3 +143,39 @@ class TestCacheStore:
             client.get_pages_in_space.assert_called_once_with(
                 "1", include_archived=True
             )
+
+    def test_refresh_marks_v2_cache_archive_capable_when_not_requested(self, tmp_path):
+        with patch("confluence_export.cache.cache_dir", return_value=tmp_path):
+            store = CacheStore()
+            client = MagicMock()
+            client.returns_archived_pages = True
+            client.get_pages_in_space.return_value = []
+            client.get_attachments.return_value = []
+
+            cs = store.refresh(client, _make_space(), include_archived=False)
+
+            assert cs.include_archived is True
+
+    def test_refresh_marks_cookie_v1_current_only_when_not_requested(self, tmp_path):
+        with patch("confluence_export.cache.cache_dir", return_value=tmp_path):
+            store = CacheStore()
+            client = MagicMock()
+            client.returns_archived_pages = False
+            client.get_pages_in_space.return_value = []
+            client.get_attachments.return_value = []
+
+            cs = store.refresh(client, _make_space(), include_archived=False)
+
+            assert cs.include_archived is False
+
+    def test_refresh_marks_cookie_v1_archive_capable_when_requested(self, tmp_path):
+        with patch("confluence_export.cache.cache_dir", return_value=tmp_path):
+            store = CacheStore()
+            client = MagicMock()
+            client.returns_archived_pages = False
+            client.get_pages_in_space.return_value = []
+            client.get_attachments.return_value = []
+
+            cs = store.refresh(client, _make_space(), include_archived=True)
+
+            assert cs.include_archived is True

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -13,12 +13,13 @@ def _make_space():
     return Space(id="1", key="TEST", name="Test Space")
 
 
-def _make_cached_space():
+def _make_cached_space(include_archived: bool = False):
     return CachedSpace(
         space=_make_space(),
         pages=[Page(id="p1", title="Page", space_id="1", version=Version(number=1))],
         attachments={},
         updated_at="2025-01-01T00:00:00Z",
+        include_archived=include_archived,
     )
 
 
@@ -82,6 +83,16 @@ class TestCacheStore:
             assert loaded is not None
             assert loaded.pages[0].body_storage == "<p>cached body</p>"
 
+    def test_save_and_load_preserves_include_archived(self, tmp_path):
+        with patch("confluence_export.cache.cache_dir", return_value=tmp_path):
+            store = CacheStore()
+            cs = _make_cached_space(include_archived=True)
+            store.save(cs)
+
+            loaded = store.load("TEST")
+            assert loaded is not None
+            assert loaded.include_archived is True
+
     def test_ensure_loaded_refresh(self, tmp_path):
         with patch("confluence_export.cache.cache_dir", return_value=tmp_path):
             store = CacheStore()
@@ -94,3 +105,39 @@ class TestCacheStore:
             result = store.ensure_loaded(client, _make_space())
             assert result.space.key == "TEST"
             client.get_pages_in_space.assert_called_once()
+
+    def test_ensure_loaded_uses_archived_cache_when_requested(self, tmp_path):
+        with patch("confluence_export.cache.cache_dir", return_value=tmp_path):
+            store = CacheStore()
+            store.save(_make_cached_space(include_archived=True))
+
+            client = MagicMock()
+            result = store.ensure_loaded(client, _make_space(), include_archived=True)
+
+            assert result.include_archived is True
+            client.get_pages_in_space.assert_not_called()
+
+    def test_ensure_loaded_refreshes_current_only_cache_when_archived_requested(self, tmp_path):
+        with patch("confluence_export.cache.cache_dir", return_value=tmp_path):
+            store = CacheStore()
+            store.save(_make_cached_space(include_archived=False))
+            client = MagicMock()
+            client.get_pages_in_space.return_value = [
+                Page(id="p1", title="Page", space_id="1", version=Version(number=1)),
+                Page(
+                    id="p2",
+                    title="Archived Page",
+                    space_id="1",
+                    status="archived",
+                    version=Version(number=1),
+                ),
+            ]
+            client.get_attachments.return_value = []
+
+            result = store.ensure_loaded(client, _make_space(), include_archived=True)
+
+            assert result.include_archived is True
+            assert any(p.status == "archived" for p in result.pages)
+            client.get_pages_in_space.assert_called_once_with(
+                "1", include_archived=True
+            )

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -337,17 +337,28 @@ class TestCookieFlag:
              patch("confluence_export.cli.ConfluenceClient", return_value=client):
             main()
         client.set_cookies.assert_called_once_with("session=abc; tok=xyz")
+        client.verify_auth.assert_called_once_with()
         assert "Authenticated" in capsys.readouterr().err
 
     def test_bad_cookie_exits(self, capsys):
         client = _mock_client()
-        client._get.side_effect = Exception("401")
+        client.verify_auth.side_effect = Exception("401")
         with patch("sys.argv", ["confluence-export", "--cookie", "bad=val", "spaces"]), \
              patch("confluence_export.cli.load_config", return_value=_config()), \
              patch("confluence_export.cli.ConfluenceClient", return_value=client):
             with pytest.raises(SystemExit):
                 main()
         assert "failed" in capsys.readouterr().err
+
+    def test_cookie_does_not_route_scoped_token_via_gateway(self):
+        client = _mock_client()
+        config = _config(api_token=SCOPED_TOKEN)
+        with patch("sys.argv", ["confluence-export", "--cookie", "session=abc", "spaces"]), \
+             patch("confluence_export.cli.load_config", return_value=config), \
+             patch("confluence_export.cli.ConfluenceClient", return_value=client), \
+             patch("confluence_export.cli._maybe_route_via_gateway") as mock_route:
+            main()
+        mock_route.assert_not_called()
 
 
 class TestNeedsToken:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -243,6 +243,144 @@ class TestApiMethodsExtra:
             assert len(atts) == 1
 
 
+class TestCookieV1Mode:
+    def test_verify_auth_uses_v1_space_endpoint(self):
+        client = _make_client()
+        client.set_cookies("tenant.session.token=abc")
+
+        with patch.object(client, "_get", return_value={"results": []}) as mock:
+            client.verify_auth()
+
+        mock.assert_called_once_with("/wiki/rest/api/space", {"limit": "1"})
+
+    def test_verify_auth_uses_v2_for_token_auth(self):
+        client = _make_client()
+
+        with patch.object(client, "_get", return_value={"results": []}) as mock:
+            client.verify_auth()
+
+        mock.assert_called_once_with("/wiki/api/v2/spaces", {"limit": "1"})
+
+    def test_get_spaces_uses_v1_mapper_in_cookie_mode(self):
+        client = _make_client()
+        client.set_cookies("session=abc")
+
+        with patch.object(client, "_paginate_offset") as mock:
+            mock.return_value = [
+                {
+                    "id": "100",
+                    "key": "ENG",
+                    "name": "Engineering",
+                    "type": "global",
+                    "status": "current",
+                    "_links": {"webui": "/display/ENG", "base": "https://x.atlassian.net/wiki"},
+                }
+            ]
+            spaces = client.get_spaces()
+
+        assert spaces[0].id == "100"
+        assert spaces[0].key == "ENG"
+        assert client._space_key_by_id["100"] == "ENG"
+        mock.assert_called_once_with("/wiki/rest/api/space", {"limit": "250"})
+
+    def test_get_pages_in_space_uses_mapped_space_key(self):
+        client = _make_client()
+        client.set_cookies("session=abc")
+        client._space_key_by_id["100"] = "ENG"
+
+        with patch.object(client, "_paginate_offset") as mock:
+            mock.return_value = [
+                {
+                    "id": "42",
+                    "title": "Child",
+                    "status": "current",
+                    "space": {"id": "100"},
+                    "ancestors": [{"id": "1", "type": "page"}],
+                    "extensions": {"position": 7},
+                    "body": {"storage": {"value": "<p>Hello</p>"}},
+                    "history": {
+                        "createdDate": "2026-01-01T00:00:00Z",
+                        "createdBy": {"accountId": "creator"},
+                    },
+                    "version": {
+                        "when": "2026-01-02T00:00:00Z",
+                        "number": 3,
+                        "by": {"accountId": "editor"},
+                    },
+                    "_links": {"webui": "/display/ENG/Child"},
+                }
+            ]
+            pages = client.get_pages_in_space("100")
+
+        assert pages[0].id == "42"
+        assert pages[0].space_id == "100"
+        assert pages[0].parent_id == "1"
+        assert pages[0].position == 7
+        assert pages[0].body_storage == "<p>Hello</p>"
+        assert pages[0].author_id == "creator"
+        assert pages[0].version.author_id == "editor"
+        assert pages[0].version.number == 3
+        _, params = mock.call_args.args
+        assert params["spaceKey"] == "ENG"
+        assert params["type"] == "page"
+        assert "body.storage" in params["expand"]
+
+    def test_get_space_by_key_uses_v1_endpoint(self):
+        client = _make_client()
+        client.set_cookies("session=abc")
+
+        with patch.object(client, "_get") as mock:
+            mock.return_value = {"id": "100", "key": "ENG", "name": "Engineering"}
+            space = client.get_space_by_key("ENG")
+
+        assert space is not None
+        assert space.key == "ENG"
+        mock.assert_called_once_with("/wiki/rest/api/space/ENG")
+
+    def test_get_page_by_id_uses_v1_endpoint(self):
+        client = _make_client()
+        client.set_cookies("session=abc")
+
+        with patch.object(client, "_get") as mock:
+            mock.return_value = {
+                "id": "42",
+                "title": "Page",
+                "space": {"id": "100"},
+                "body": {"storage": {"value": "<p>Body</p>"}},
+            }
+            page = client.get_page_by_id("42")
+
+        assert page.body_storage == "<p>Body</p>"
+        assert mock.call_args.args[0] == "/wiki/rest/api/content/42"
+
+    def test_get_attachments_uses_v1_endpoint(self):
+        client = _make_client()
+        client.set_cookies("session=abc")
+
+        with patch.object(client, "_paginate_offset") as mock:
+            mock.return_value = [
+                {
+                    "id": "att1",
+                    "title": "file.png",
+                    "metadata": {"mediaType": "image/png"},
+                    "extensions": {"fileSize": 1234},
+                    "version": {"number": 5, "when": "2026-01-03T00:00:00Z"},
+                    "_links": {"download": "/download/attachments/42/file.png"},
+                }
+            ]
+            atts = client.get_attachments("42")
+
+        assert atts[0].id == "att1"
+        assert atts[0].page_id == "42"
+        assert atts[0].media_type == "image/png"
+        assert atts[0].file_size == 1234
+        assert atts[0].version.number == 5
+        mock.assert_called_once_with(
+            "/wiki/rest/api/content/42/child/attachment",
+            {"expand": "version,metadata,extensions,history", "limit": "250"},
+        )
+
+
 class TestVerboseLogging:
     def test_log_when_verbose(self, capsys):
         client = _make_client()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -323,7 +323,19 @@ class TestCookieV1Mode:
         _, params = mock.call_args.args
         assert params["spaceKey"] == "ENG"
         assert params["type"] == "page"
+        assert params["status"] == "current"
         assert "body.storage" in params["expand"]
+
+    def test_get_pages_in_space_archived_issues_second_call(self):
+        client = _make_client()
+        client.set_cookies("session=abc")
+        client._space_key_by_id["100"] = "ENG"
+
+        with patch.object(client, "_paginate_offset", return_value=[]) as mock:
+            client.get_pages_in_space("100", include_archived=True)
+
+        statuses = [call.args[1]["status"] for call in mock.call_args_list]
+        assert statuses == ["current", "archived"]
 
     def test_get_space_by_key_uses_v1_endpoint(self):
         client = _make_client()

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -315,3 +315,22 @@ class TestForceRefresh:
         exporter.export_space(_make_space(), tmp_path, force_refresh=True)
         cache.refresh.assert_called_once()
         cache.ensure_loaded.assert_not_called()
+
+    def test_cached_include_archived_requests_archive_capable_cache(self, tmp_path):
+        exporter, client, cache = _make_exporter()
+        cs = _make_cached_space(
+            pages=[
+                _make_page(),
+                _make_page(id="p2", title="Archived Page", body="<p>Old</p>"),
+            ]
+        )
+        cs.pages[1].status = "archived"
+        cs.include_archived = True
+        cache.ensure_loaded.return_value = cs
+
+        exporter.export_space(_make_space(), tmp_path, include_archived=True)
+
+        cache.ensure_loaded.assert_called_once_with(
+            client, _make_space(), include_archived=True
+        )
+        cache.refresh.assert_not_called()

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -58,6 +58,7 @@ class TestRefreshCollectsAllAttachments:
         }
 
         client = MagicMock()
+        client.returns_archived_pages = True
         client.get_pages_in_space.return_value = pages
         client.get_attachments.side_effect = lambda pid: atts_by_page.get(pid, [])
         client.get_folder_by_id.return_value = None
@@ -79,6 +80,7 @@ class TestRefreshCollectsAllAttachments:
         ]
 
         client = MagicMock()
+        client.returns_archived_pages = True
         client.get_pages_in_space.return_value = pages
         client.get_attachments.return_value = []
         client.get_folder_by_id.return_value = None
@@ -198,6 +200,7 @@ class TestProgressReachesTotal:
         pages = [_make_page(str(i)) for i in range(1, n + 1)]
 
         client = MagicMock()
+        client.returns_archived_pages = True
         client.get_pages_in_space.return_value = pages
         client.get_attachments.return_value = []
         client.get_folder_by_id.return_value = None

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -118,6 +118,7 @@ class TestCachedSpace:
             pages=[page],
             attachments={"p1": [att]},
             updated_at="2025-01-01T00:00:00Z",
+            include_archived=True,
         )
         d = cs.to_dict()
         cs2 = CachedSpace.from_dict(d)
@@ -125,6 +126,16 @@ class TestCachedSpace:
         assert len(cs2.pages) == 1
         assert len(cs2.attachments["p1"]) == 1
         assert cs2.updated_at == "2025-01-01T00:00:00Z"
+        assert cs2.include_archived is True
+
+    def test_round_trip_defaults_old_cache_to_current_only(self):
+        cs = CachedSpace.from_dict({
+            "space": {"id": "1", "key": "TEST", "name": "Test"},
+            "pages": [],
+            "attachments": {},
+            "updated_at": "2025-01-01T00:00:00Z",
+        })
+        assert cs.include_archived is False
 
     def test_round_trip_preserves_page_bodies(self):
         space = Space(id="1", key="TEST", name="Test")


### PR DESCRIPTION
## Summary

Confluence Cloud's v2 REST API rejects browser session cookies, so `--cookie` auth never worked against v2. This branch adds a v1 REST fallback that engages automatically when cookies are set, plus the plumbing to keep `--include-archived` behaving the same way across auth modes.

- **Cookie auth via v1 REST** (`2b164c3`). `set_cookies()` flips an `api_flavor` flag; `get_spaces`, `get_pages_in_space`, `get_space_by_key`, `get_page_by_id`, `get_folder_by_id`, and `get_attachments` each route to `/wiki/rest/api/...` with v1-shaped response mappers. A space-id↔key cache makes the v1 `spaceKey` requirement invisible to callers.
- **`--include-archived` parity** (`09e2471`). v1's `status` param is single-valued, so cookie mode issues two calls (current + archived) when the flag is set. v2 already returns both by default.
- **Cache provenance bit** (`e986bc9`). `CachedSpace.include_archived` records whether the cache covers archived pages, so `--cached --include-archived` against a current-only cache refreshes instead of silently dropping archived content. Old cache files default to `False` on load.
- **Stamp by delivered shape, not requested flag** (`7ac0dc9`). v2 always returns archived; new `ConfluenceClient.returns_archived_pages` property lets the cache mark v2 refreshes as archive-capable even when the caller didn't ask for archived. Prevents an unnecessary refresh on the next `--cached --include-archived` run.

Also: README note that cookie auth needs the site URL (not the OAuth gateway URL), and a small CLI guard so `--cookie` skips `_maybe_route_via_gateway` when a scoped token is configured.

## Test plan

- [x] `uv run pytest tests/ -q` — 318 pass (was 305 on main)
- [ ] Manual: `confluence-export --cookie '<browser-cookie>' spaces` against a real instance
- [ ] Manual: `confluence-export --cookie ... export SPC --include-archived` and verify archived pages appear
- [ ] Manual: `confluence-export export SPC` (Bearer/Basic auth), then `... --cached --include-archived` and verify no refresh happens