### PR TITLE
[codex] Add connection profile preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Use a local config when an export directory should override the global default:
 confluence-export configure --local ./docs
 ```
 
-Local configs are discovered from the output directory upward as `.conex/config.json`. Export git commits never stage `.conex/*.json` files.
+Local configs are discovered from the output directory upward as `.conex/config.json`. Export git commits never stage files under `.conex/`.
 
 If you don't have an API token, you can authenticate with a browser cookie instead. Copy the `Cookie` header from DevTools (F12 > Network tab > any `/wiki/` request) and pass it with `--cookie`:
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,15 @@ uv pip install -e .
 confluence-export configure
 ```
 
-Stores your base URL and API token to `~/.config/confluence-export/config.json`. You can also use env vars (`CONFLUENCE_BASE_URL`, `CONFLUENCE_EMAIL`, `CONFLUENCE_API_TOKEN`) or CLI flags (`--base-url`, `--email`, `--api-token`).
+Stores your site URL and credentials to `~/.config/confluence-export/config.json`. You can also use env vars (`CONFLUENCE_SITE_URL`, `CONFLUENCE_BASE_URL`, `CONFLUENCE_EMAIL`, `CONFLUENCE_API_TOKEN`, `CONFLUENCE_PAT`, `CONFLUENCE_COOKIE`) or CLI flags (`--site-url`, `--base-url`, `--email`, `--api-token`, `--cookie`).
+
+Use a local config when an export directory should override the global default:
+
+```bash
+confluence-export configure --local ./docs
+```
+
+Local configs are discovered from the output directory upward as `.conex/config.json`. Export git commits never stage `.conex/*.json` files.
 
 If you don't have an API token, you can authenticate with a browser cookie instead. Copy the `Cookie` header from DevTools (F12 > Network tab > any `/wiki/` request) and pass it with `--cookie`:
 
@@ -68,7 +76,7 @@ If you don't have an API token, you can authenticate with a browser cookie inste
 confluence-export --base-url https://example.atlassian.net --cookie 'tenant.session.token=...' export SPACEKEY -o ./output
 ```
 
-Cookie authentication uses Confluence's legacy REST read endpoints because Confluence Cloud REST v2 rejects browser session cookies. Use the normal site URL (`https://example.atlassian.net`), not the OAuth gateway URL. If no token or cookie is provided, the tool will prompt interactively. Browser credentials are used for the current run only and never saved.
+Cookie authentication uses Confluence's legacy REST read endpoints because Confluence Cloud REST v2 rejects browser session cookies. Use the normal site URL (`https://example.atlassian.net`), not the OAuth gateway URL. Cookie auth is an explicit mode and reports `API mode: Confluence REST v1 compatibility`.
 
 ## Required permissions
 
@@ -86,7 +94,11 @@ read:user:confluence
 
 For classic OAuth 2.0 (3LO) tokens, the equivalent set is `read:confluence-space.summary`, `read:confluence-content.all`, `readonly:content.attachment:confluence`, and `read:confluence-user`.
 
-Scoped tokens must be addressed via the OAuth gateway URL (`https://api.atlassian.com/ex/confluence/{cloudId}/...`) rather than the site URL. The tool detects this automatically: on first use, it looks up your site's cloud ID from the unauthenticated `/_edge/tenant_info` endpoint, rewrites `base_url` in the saved config, and routes all subsequent requests through the gateway. No manual configuration needed — keep `base_url` set to your site URL.
+Scoped tokens must be addressed via the OAuth gateway URL (`https://api.atlassian.com/ex/confluence/{cloudId}/...`) rather than the site URL. The tool detects this automatically: it keeps the saved `site_url` as the user-facing Atlassian URL, resolves or uses the cached `cloud_id`, and derives the gateway `api_base_url` at runtime. No manual configuration needed in the common case; if cloud ID lookup is blocked, provide `--cloud-id` or `--api-base-url`.
+
+Before export, the tool prints the resolved config source, auth mode, API mode, site URL, output directory, and preflight checks. If auth, gateway routing, space resolution, page listing, attachment listing, or output writability fails, export stops before writing output.
+
+In non-interactive runs, commands never prompt for credentials. Run `confluence-export configure` or pass explicit flags/env vars before invoking export from automation.
 
 ## Commands
 

--- a/src/confluence_export/cli.py
+++ b/src/confluence_export/cli.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sys
-import termios
 from pathlib import Path
 
 import requests
@@ -13,13 +13,21 @@ import requests
 from confluence_export.cache import CacheStore
 from confluence_export.client import AuthenticationError, ConfluenceClient
 from confluence_export.config import (
+    ApiDialect,
+    AuthConfig,
+    AuthMode,
     Config,
+    ConnectionProfile,
+    ConnectionProfileError,
     config_path,
     gateway_url,
+    is_gateway_url,
     is_atlassian_site_url,
     is_scoped_token,
-    load_config,
-    save_config,
+    load_connection_profile,
+    local_config_path,
+    resolve_cloud_id,
+    save_connection_config,
 )
 from confluence_export.diff import compute_diff, format_diff, scan_export_dir
 from confluence_export.tree import (
@@ -34,140 +42,25 @@ from confluence_export.exporter import Exporter
 from confluence_export.types import Space
 
 
-def _read_hidden_line(prompt: str) -> str:
-    """Read a line from the terminal with echo disabled, bypassing the TTY line buffer limit."""
-    print(prompt, end="", file=sys.stderr, flush=True)
-    fd = sys.stdin.fileno()
-    old = termios.tcgetattr(fd)
-    try:
-        new = termios.tcgetattr(fd)
-        # Disable echo and canonical mode (removes ~1024 byte line buffer limit)
-        new[3] = new[3] & ~(termios.ECHO | termios.ICANON)
-        new[6][termios.VMIN] = 1
-        new[6][termios.VTIME] = 0
-        termios.tcsetattr(fd, termios.TCSADRAIN, new)
-
-        chars = []
-        while True:
-            ch = os.read(fd, 1)
-            if ch in (b"\r", b"\n", b""):
-                break
-            if ch == b"\x03":  # Ctrl+C
-                raise KeyboardInterrupt
-            chars.append(ch)
-        print(file=sys.stderr)  # newline after hidden input
-        return b"".join(chars).decode("utf-8", errors="replace")
-    finally:
-        termios.tcsetattr(fd, termios.TCSADRAIN, old)
-
-
-def _prompt_browser_credentials(base_url: str, reason: str) -> tuple[str, str]:
-    """Prompt for browser credentials. Returns (type, value) where type is 'bearer' or 'cookie'."""
-    print(f"\n{reason}", file=sys.stderr)
-    print(
-        f"\nTo authenticate via browser session:\n"
-        f"  1. Open {base_url} in your browser and log in\n"
-        f"  2. Open DevTools (F12) -> Network tab\n"
-        f"  3. Reload the page and click any API request to /wiki/\n"
-        f"  4. Copy the 'Cookie' or 'Authorization' header value\n"
-        f"\n"
-        f"Cookie headers use Confluence's legacy REST read endpoints for this run.\n",
-        file=sys.stderr,
-    )
-    try:
-        value = _read_hidden_line("Paste cookie or token (input hidden): ").strip()
-    except (KeyboardInterrupt, EOFError):
-        print("\nCancelled.", file=sys.stderr)
-        sys.exit(1)
-
-    if not value:
-        print("No credentials provided.", file=sys.stderr)
-        sys.exit(1)
-
-    # Strip accidental "Bearer " prefix
-    if value.lower().startswith("bearer "):
-        return ("bearer", value[len("bearer "):])
-
-    # Cookies: contain "=" (key=value), optionally with ";" separators
-    # Bearer tokens are opaque strings without "="
-    if "=" in value:
-        return ("cookie", value)
-
-    return ("bearer", value)
-
-
-def _apply_browser_credentials(client: ConfluenceClient, base_url: str, reason: str) -> None:
-    """Prompt for browser credentials, verify with a quick API call, apply to client."""
-    cred_type, value = _prompt_browser_credentials(base_url, reason)
-    if cred_type == "cookie":
-        client.set_cookies(value)
-    else:
-        client.set_bearer_token(value)
-
-    # Verify credentials with a minimal request (1 space, fast)
-    print("Verifying credentials...", file=sys.stderr, flush=True)
-    try:
-        client.verify_auth()
-    except AuthenticationError as exc:
-        print(f"Authentication failed (HTTP {exc.status_code}).", file=sys.stderr)
-        sys.exit(1)
-    except requests.exceptions.HTTPError as exc:
-        status = exc.response.status_code if exc.response is not None else "?"
-        print(f"Authentication failed (HTTP {status}).", file=sys.stderr)
-        sys.exit(1)
-    print("Authenticated.", file=sys.stderr, flush=True)
-
-
 def _resolve_cloud_id(site_url: str) -> str | None:
-    """Look up the Confluence cloud ID for a site URL via /_edge/tenant_info.
-
-    The endpoint is unauthenticated and returns `{"cloudId": "<uuid>"}`.
-    Returns None on any failure so callers can fall back to the site URL.
-    """
-    try:
-        resp = requests.get(
-            site_url.rstrip("/") + "/_edge/tenant_info",
-            headers={"Accept": "application/json"},
-            timeout=10,
-        )
-        resp.raise_for_status()
-        cloud_id = resp.json().get("cloudId")
-        return cloud_id if isinstance(cloud_id, str) and cloud_id else None
-    except (requests.exceptions.RequestException, ValueError):
-        return None
+    """Compatibility wrapper for tests and older callers."""
+    return resolve_cloud_id(site_url)
 
 
 def _maybe_route_via_gateway(config: Config) -> Config:
-    """Rewrite a site-URL `base_url` to the OAuth gateway when the token is scoped.
-
-    Atlassian scoped API tokens (ATATT…=ADA…) are rejected with 401 against
-    the site URL — they must go through `api.atlassian.com/ex/confluence/{cloudId}`.
-    This is invisible to users: we detect a site URL paired with a scoped token,
-    resolve the cloudId, rewrite the config, and persist so the round-trip
-    happens at most once per token rotation.
-    """
+    """Return a runtime gateway Config for legacy callers without persisting it."""
     if not (is_atlassian_site_url(config.base_url) and is_scoped_token(config.api_token)):
         return config
 
     cloud_id = _resolve_cloud_id(config.base_url)
     if not cloud_id:
-        # Cloud ID lookup failed — leave config alone and let the request fail
-        # with the underlying 401 so the user sees the real error.
         return config
 
-    new_url = gateway_url(cloud_id)
-    print(
-        f"Routing scoped token through OAuth gateway: {new_url}",
-        file=sys.stderr,
+    return Config(
+        base_url=gateway_url(cloud_id),
+        email=config.email,
+        api_token=config.api_token,
     )
-    config.base_url = new_url
-    try:
-        save_config(config)
-    except OSError:
-        # If we can't persist (e.g. read-only filesystem in CI), the rewrite
-        # still applies for this run — next run will redo the lookup.
-        pass
-    return config
 
 
 def _is_auth_error(exc: Exception) -> int | None:
@@ -186,27 +79,31 @@ def _is_auth_error(exc: Exception) -> int | None:
 
 
 def _with_auth_fallback(fn, client: ConfluenceClient, config) -> object:
-    """Call fn(); on auth error, prompt for a browser token and retry once."""
+    """Call fn(); on auth error, fail clearly without interactive fallback."""
     try:
         return fn()
     except Exception as exc:
         status = _is_auth_error(exc)
         if status is None:
             raise
-        reason = f"Authentication failed (HTTP {status}). Browser credentials are needed."
-        _apply_browser_credentials(client, config.base_url, reason)
-        try:
-            return fn()
-        except Exception as exc2:
-            status2 = _is_auth_error(exc2)
-            if status2 is None:
-                raise
-            print(
-                f"\nBrowser credentials also rejected (HTTP {status2}). "
-                f"They may have expired — try again with fresh credentials.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+        print(
+            "Authentication failed and no interactive prompt is available.",
+            file=sys.stderr,
+        )
+        print(f"Reason: HTTP {status} from Confluence.", file=sys.stderr)
+        print(
+            "Next step: run `confluence-export configure` or provide explicit credentials.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def _config_start_dir(args: argparse.Namespace) -> Path:
+    if args.command == "export":
+        return Path(args.output)
+    if args.command == "diff":
+        return Path(args.export_dir)
+    return Path.cwd()
 
 
 def main() -> None:
@@ -214,7 +111,15 @@ def main() -> None:
         prog="confluence-export",
         description="LLM-ready Confluence page tree exporter",
     )
-    parser.add_argument("--base-url", help="Confluence base URL")
+    parser.add_argument("--site-url", help="Confluence site URL")
+    parser.add_argument("--base-url", help="Alias for --site-url")
+    parser.add_argument("--api-base-url", help="Actual Confluence API base URL")
+    parser.add_argument("--cloud-id", help="Atlassian cloud ID for OAuth gateway routing")
+    parser.add_argument(
+        "--auth-type",
+        choices=[mode.value for mode in AuthMode],
+        help="Authentication mode",
+    )
     parser.add_argument("--email", help="User email for authentication")
     parser.add_argument("--api-token", "--pat", help="API token or PAT for authentication")
     parser.add_argument("--cookie", help="Browser cookie string for authentication")
@@ -223,7 +128,15 @@ def main() -> None:
     sub = parser.add_subparsers(dest="command")
 
     # configure
-    sub.add_parser("configure", help="Interactive credential setup")
+    configure_p = sub.add_parser("configure", help="Interactive credential setup")
+    configure_p.add_argument(
+        "--local",
+        nargs="?",
+        const=".",
+        default=None,
+        metavar="DIR",
+        help="Write DIR/.conex/config.json instead of the global config",
+    )
 
     # spaces
     sub.add_parser("spaces", help="List accessible spaces")
@@ -273,54 +186,41 @@ def main() -> None:
         sys.exit(1)
 
     if args.command == "configure":
-        _cmd_configure()
+        _cmd_configure(local_dir=args.local)
         return
 
-    # All other commands need config + client
+    # All other commands need a resolved profile + client.
     try:
-        config = load_config(
+        profile = load_connection_profile(
+            site_url=args.site_url,
             base_url=args.base_url,
+            api_base_url=args.api_base_url,
+            cloud_id=args.cloud_id,
+            auth_type=args.auth_type,
             email=args.email,
             api_token=args.api_token,
+            cookie=args.cookie,
+            start_dir=_config_start_dir(args),
+            interactive=sys.stdin.isatty(),
         )
-    except ValueError as exc:
+    except ConnectionProfileError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         print(f"\nRun 'confluence-export configure' to set up credentials.", file=sys.stderr)
         sys.exit(1)
 
-    if not args.cookie:
-        config = _maybe_route_via_gateway(config)
-
-    client = ConfluenceClient(config, verbose=args.verbose)
-
-    if args.cookie:
-        client.set_cookies(args.cookie)
-        print("Using browser cookies. Verifying credentials...", file=sys.stderr, flush=True)
-        try:
-            client.verify_auth()
-        except Exception:
-            print("Cookie authentication failed.", file=sys.stderr)
-            sys.exit(1)
-        print("Authenticated.", file=sys.stderr, flush=True)
-    elif config.needs_token:
-        _apply_browser_credentials(
-            client, config.base_url, "No API token configured. Browser credentials are needed."
-        )
-
-    cache = CacheStore()
+    client = ConfluenceClient(profile, verbose=args.verbose)
 
     match args.command:
         case "spaces":
-            _with_auth_fallback(lambda: _cmd_spaces(client), client, config)
+            _with_auth_fallback(lambda: _cmd_spaces(client), client, profile)
         case "tree":
-            _cmd_tree(client, cache, config, args.space_key)
+            _cmd_tree(client, CacheStore(), profile, args.space_key)
         case "find":
-            _cmd_find(client, cache, config, args.space_key, args.query)
+            _cmd_find(client, CacheStore(), profile, args.space_key, args.query)
         case "export":
             _cmd_export(
                 client,
-                cache,
-                config,
+                profile,
                 space_key=args.space_key,
                 path_filter=args.path,
                 output_dir=args.output,
@@ -336,66 +236,132 @@ def main() -> None:
         case "diff":
             _cmd_diff(
                 client,
-                cache,
-                config,
+                CacheStore(),
+                profile,
                 space_key=args.space_key,
                 export_dir=args.export_dir,
                 path_filter=args.path,
                 include_archived=args.include_archived,
             )
         case "refresh":
-            _cmd_refresh(client, cache, config, args.space_key)
+            _cmd_refresh(client, CacheStore(), profile, args.space_key)
 
 
 # -- command implementations -------------------------------------------------
 
 
-def _cmd_configure() -> None:
+def _mask_secret(value: str) -> str:
+    return f"{value[:4]}...{value[-4:]}" if len(value) > 8 else ""
+
+
+def _auth_label(mode: AuthMode) -> str:
+    match mode:
+        case AuthMode.BASIC_API_TOKEN:
+            return "Basic API token"
+        case AuthMode.SCOPED_API_TOKEN:
+            return "scoped API token"
+        case AuthMode.BEARER_PAT:
+            return "Bearer token (PAT)"
+        case AuthMode.COOKIE:
+            return "cookie session"
+
+
+def _api_mode_label(dialect: ApiDialect) -> str:
+    match dialect:
+        case ApiDialect.CLOUD_V2:
+            return "Confluence REST v2"
+        case ApiDialect.GATEWAY_V2:
+            return "OAuth gateway"
+        case ApiDialect.COOKIE_V1:
+            return "Confluence REST v1 compatibility"
+
+
+def _read_existing_config(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    with open(path) as f:
+        data = json.load(f)
+    return data if isinstance(data, dict) else {}
+
+
+def _existing_config_defaults(path: Path) -> tuple[str, str, str]:
+    existing = _read_existing_config(path)
+    if existing.get("version") == 2:
+        auth = existing.get("auth") or {}
+        secret = auth.get("token") or auth.get("cookie_header") or ""
+        return (
+            str(existing.get("site_url", "") or ""),
+            str(auth.get("email", "") or ""),
+            str(secret or ""),
+        )
+
+    base_url = str(existing.get("base_url", "") or "")
+    if is_gateway_url(base_url):
+        print(
+            "Existing config contains an OAuth gateway URL. Enter the Confluence site URL.",
+            file=sys.stderr,
+        )
+        base_url = ""
+    return (
+        base_url,
+        str(existing.get("email", "") or ""),
+        str(existing.get("api_token", "") or ""),
+    )
+
+
+def _cmd_configure(local_dir: str | None = None) -> None:
     """Interactive credential setup."""
+    target = local_config_path(local_dir) if local_dir is not None else config_path()
     print("Confluence Export - Configuration")
-    print(f"Config file: {config_path()}\n")
+    print(f"Config file: {target}\n")
 
-    # Load existing config for defaults
-    existing: dict = {}
-    cp = config_path()
-    if cp.exists():
-        import json
+    existing_site_url, existing_email, existing_secret = _existing_config_defaults(target)
 
-        with open(cp) as f:
-            existing = json.load(f)
+    site_url = input(f"Site URL [{existing_site_url}]: ").strip()
+    if not site_url:
+        site_url = existing_site_url
 
-    base_url = input(f"Base URL [{existing.get('base_url', '')}]: ").strip()
-    if not base_url:
-        base_url = existing.get("base_url", "")
-
-    email = input(f"Email (leave empty for PAT Bearer auth) [{existing.get('email', '')}]: ").strip()
+    email = input(
+        f"Email (leave empty for PAT Bearer auth or cookie session) [{existing_email}]: "
+    ).strip()
     if not email:
-        email = existing.get("email", "")
+        email = existing_email
 
-    # Mask existing token
-    existing_token = existing.get("api_token", "")
-    masked = f"{existing_token[:4]}...{existing_token[-4:]}" if len(existing_token) > 8 else ""
-    token_label = "API Token" if email else "Personal Access Token (PAT)"
-    token = input(f"{token_label} [{masked}]: ").strip()
-    if not token:
-        token = existing_token
+    masked = _mask_secret(existing_secret)
+    secret_label = "API token" if email else "PAT or Cookie header"
+    secret = input(f"{secret_label} [{masked}]: ").strip()
+    if not secret:
+        secret = existing_secret
 
-    if not base_url:
-        print("Error: base_url is required.", file=sys.stderr)
+    if not site_url:
+        print("Error: site_url is required.", file=sys.stderr)
         sys.exit(1)
 
-    if email:
-        print("\nAuth mode: Basic Auth (email + API token)")
+    if not email and "=" in secret:
+        auth = AuthConfig(type=AuthMode.COOKIE, cookie_header=secret)
+    elif not email:
+        auth = AuthConfig(type=AuthMode.BEARER_PAT, token=secret)
+    elif is_scoped_token(secret):
+        auth = AuthConfig(type=AuthMode.SCOPED_API_TOKEN, email=email, token=secret)
     else:
-        print("\nAuth mode: Bearer token (PAT)")
+        auth = AuthConfig(type=AuthMode.BASIC_API_TOKEN, email=email, token=secret)
 
-    cfg = Config(base_url=base_url.rstrip("/"), email=email, api_token=token)
-    path = save_config(cfg)
+    cloud_id = None
+    api_base_url = ""
+    if auth.type is AuthMode.SCOPED_API_TOKEN and not is_gateway_url(site_url):
+        cloud_id = resolve_cloud_id(site_url)
+        if cloud_id:
+            api_base_url = gateway_url(cloud_id)
+
+    print(f"\nAuth mode: {_auth_label(auth.type)}")
+    path = save_connection_config(
+        site_url=site_url.rstrip("/"),
+        auth=auth,
+        path=target,
+        cloud_id=cloud_id,
+        api_base_url=api_base_url,
+    )
     print(f"\nConfiguration saved to {path}")
-    # Scoped tokens must be routed through the OAuth gateway. Resolve the
-    # cloudId now so the user sees the rewrite (and the eventual saved URL)
-    # before they hit the first command.
-    _maybe_route_via_gateway(cfg)
     print(
         "\nIf this is a scoped API token, grant these five read scopes:\n"
         "  read:space:confluence\n"
@@ -424,9 +390,11 @@ def _cmd_spaces(client: ConfluenceClient) -> None:
         print(f"{s.key:<{key_w}}  {s.name:<{name_w}}  {s.type:<8}  {s.status}")
 
 
-def _cmd_tree(client: ConfluenceClient, cache: CacheStore, config: Config, space_key: str) -> None:
+def _cmd_tree(
+    client: ConfluenceClient, cache: CacheStore, profile: ConnectionProfile, space_key: str
+) -> None:
     """Show page hierarchy."""
-    space = _with_auth_fallback(lambda: _resolve_space(client, space_key), client, config)
+    space = _with_auth_fallback(lambda: _resolve_space(client, space_key), client, profile)
     cs = cache.ensure_loaded(client, space)
 
     roots = build_tree(cs.pages)
@@ -436,10 +404,14 @@ def _cmd_tree(client: ConfluenceClient, cache: CacheStore, config: Config, space
 
 
 def _cmd_find(
-    client: ConfluenceClient, cache: CacheStore, config: Config, space_key: str, query: str
+    client: ConfluenceClient,
+    cache: CacheStore,
+    profile: ConnectionProfile,
+    space_key: str,
+    query: str,
 ) -> None:
     """Search pages by title."""
-    space = _with_auth_fallback(lambda: _resolve_space(client, space_key), client, config)
+    space = _with_auth_fallback(lambda: _resolve_space(client, space_key), client, profile)
     cs = cache.ensure_loaded(client, space)
 
     results = find_pages(cs.pages, query)
@@ -453,10 +425,124 @@ def _cmd_find(
         print(f"{p.id:<{id_w}}  {path}")
 
 
+def _nearest_existing_parent(path: Path) -> Path:
+    current = path
+    while not current.exists() and current.parent != current:
+        current = current.parent
+    return current
+
+
+def _check_output_writable(output_dir: str) -> None:
+    out = Path(output_dir).expanduser().resolve()
+    if out.exists() and not out.is_dir():
+        raise RuntimeError(f"{out} exists and is not a directory")
+    parent = _nearest_existing_parent(out)
+    if not parent.exists() or not os.access(parent, os.W_OK | os.X_OK):
+        raise RuntimeError(f"{parent} is not writable")
+
+
+def _preflight_error_message(exc: Exception) -> str:
+    if isinstance(exc, AuthenticationError):
+        return f"HTTP {exc.status_code} from {exc.url}"
+    if isinstance(exc, requests.exceptions.HTTPError) and exc.response is not None:
+        return f"HTTP {exc.response.status_code}"
+    return str(exc) or exc.__class__.__name__
+
+
+def _ensure_gateway_route(profile: ConnectionProfile) -> None:
+    if not profile.cloud_id or not is_gateway_url(profile.api_base_url):
+        raise RuntimeError("cloud ID or gateway URL is missing")
+
+
+def _require_space(client: ConfluenceClient, space_key: str) -> Space:
+    space = _find_space(client, space_key)
+    if space is None:
+        raise RuntimeError(f"space '{space_key}' not found")
+    return space
+
+
+def _run_export_preflight(
+    client: ConfluenceClient,
+    profile: ConnectionProfile,
+    *,
+    space_key: str,
+    output_dir: str,
+    no_media: bool,
+    no_git: bool,
+) -> Space:
+    print(f"Using config: {profile.config_source}", file=sys.stderr)
+    print(f"Auth: {_auth_label(profile.auth_mode)}", file=sys.stderr)
+    print(f"API mode: {_api_mode_label(profile.api_dialect)}", file=sys.stderr)
+    print(f"Site: {profile.site_url}", file=sys.stderr)
+    if profile.cloud_id:
+        print(f"Cloud ID: {profile.cloud_id}", file=sys.stderr)
+    print(f"Output: {Path(output_dir).expanduser().resolve()}", file=sys.stderr)
+    print("\nPreflight:", file=sys.stderr)
+
+    failures: list[str] = []
+
+    def step(label: str, fn):
+        try:
+            result = fn()
+            print(f"  ✓ {label}", file=sys.stderr)
+            return result
+        except Exception as exc:
+            reason = _preflight_error_message(exc)
+            failures.append(f"{label}: {reason}")
+            print(f"  ✗ {label}", file=sys.stderr)
+            return None
+
+    step("authenticated", client.verify_auth)
+
+    if profile.api_dialect is ApiDialect.GATEWAY_V2:
+        step("gateway route resolved", lambda: _ensure_gateway_route(profile))
+
+    space = step(
+        "space resolved",
+        lambda: _require_space(client, space_key),
+    )
+
+    sample_page_id = None
+    if space is not None:
+        sample_page_id = step("page listing available", lambda: client.probe_page_listing(space))
+    else:
+        failures.append("page listing available: skipped because space did not resolve")
+        print("  ✗ page listing available", file=sys.stderr)
+
+    if not no_media:
+        if sample_page_id:
+            step("attachment listing available", lambda: client.probe_attachment_listing(sample_page_id))
+        else:
+            print("  ✓ attachment listing skipped (no pages)", file=sys.stderr)
+
+    step("output directory writable", lambda: _check_output_writable(output_dir))
+
+    if no_git:
+        print("  ✓ git skipped", file=sys.stderr)
+    else:
+        from confluence_export.git import git_available
+
+        if git_available():
+            print("  ✓ git available", file=sys.stderr)
+        else:
+            print("  ! git unavailable; export will continue without git", file=sys.stderr)
+
+    if failures:
+        print("\nPreflight failed; export did not start.", file=sys.stderr)
+        for failure in failures:
+            print(f"Reason: {failure}", file=sys.stderr)
+        print(
+            "Next step: run `confluence-export configure` or provide --cloud-id / --api-base-url.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return space
+
+
 def _cmd_export(
     client: ConfluenceClient,
-    cache: CacheStore,
-    config: Config,
+    profile: ConnectionProfile,
     *,
     space_key: str,
     path_filter: str | None,
@@ -471,10 +557,18 @@ def _cmd_export(
     no_author_lookup: bool = False,
 ) -> None:
     """Export page tree as LLM-ready markdown."""
-    space = _with_auth_fallback(lambda: _resolve_space(client, space_key), client, config)
+    space = _run_export_preflight(
+        client,
+        profile,
+        space_key=space_key,
+        output_dir=output_dir,
+        no_media=no_media,
+        no_git=no_git,
+    )
 
     out = Path(output_dir).resolve()
     out.mkdir(parents=True, exist_ok=True)
+    cache = CacheStore()
 
     # TODO(migration): Remove after 2027-01-01
     from confluence_export.media import migrate_media_dirs
@@ -498,7 +592,7 @@ def _cmd_export(
     exporter = Exporter(
         client,
         cache,
-        config.base_url,
+        profile.site_url,
         download_media=not no_media,
         render_drawio=not no_drawio_render,
         debug=debug,
@@ -526,7 +620,7 @@ def _cmd_export(
 def _cmd_diff(
     client: ConfluenceClient,
     cache: CacheStore,
-    config: Config,
+    profile: ConnectionProfile,
     *,
     space_key: str,
     export_dir: str,
@@ -548,9 +642,9 @@ def _cmd_diff(
     if cs is not None:
         space = cs.space
     else:
-        space = _with_auth_fallback(lambda: _resolve_space(client, space_key), client, config)
+        space = _with_auth_fallback(lambda: _resolve_space(client, space_key), client, profile)
     cs = _with_auth_fallback(
-        lambda: cache.refresh(client, space, include_archived=include_archived), client, config
+        lambda: cache.refresh(client, space, include_archived=include_archived), client, profile
     )
 
     # Filter API pages
@@ -580,9 +674,11 @@ def _cmd_diff(
     print(format_diff(result, cs.pages))
 
 
-def _cmd_refresh(client: ConfluenceClient, cache: CacheStore, config: Config, space_key: str) -> None:
+def _cmd_refresh(
+    client: ConfluenceClient, cache: CacheStore, profile: ConnectionProfile, space_key: str
+) -> None:
     """Force-refresh cache for a space."""
-    space = _with_auth_fallback(lambda: _resolve_space(client, space_key), client, config)
+    space = _with_auth_fallback(lambda: _resolve_space(client, space_key), client, profile)
     cs = cache.refresh(client, space)
     print(f"Cache refreshed: {len(cs.pages)} pages (updated {cs.updated_at})")
 
@@ -590,9 +686,10 @@ def _cmd_refresh(client: ConfluenceClient, cache: CacheStore, config: Config, sp
 # -- helpers -----------------------------------------------------------------
 
 
-def _resolve_space(client: ConfluenceClient, space_key: str) -> Space:
+def _find_space(client: ConfluenceClient, space_key: str, *, announce: bool = True) -> Space | None:
     """Find a space by key (case-insensitive)."""
-    print(f"Resolving space '{space_key}'...", file=sys.stderr, flush=True)
+    if announce:
+        print(f"Resolving space '{space_key}'...", file=sys.stderr, flush=True)
     # Try server-side filter first — O(1) round trip vs. paging every space.
     space = client.get_space_by_key(space_key)
     if space is not None:
@@ -603,5 +700,13 @@ def _resolve_space(client: ConfluenceClient, space_key: str) -> Space:
     for s in client.get_spaces():
         if s.key.upper() == key_upper:
             return s
+    return None
+
+
+def _resolve_space(client: ConfluenceClient, space_key: str) -> Space:
+    """Find a space by key (case-insensitive), exiting on failure."""
+    space = _find_space(client, space_key)
+    if space is not None:
+        return space
     print(f"Error: space '{space_key}' not found.", file=sys.stderr)
     sys.exit(1)

--- a/src/confluence_export/cli.py
+++ b/src/confluence_export/cli.py
@@ -16,13 +16,11 @@ from confluence_export.config import (
     ApiDialect,
     AuthConfig,
     AuthMode,
-    Config,
     ConnectionProfile,
     ConnectionProfileError,
     config_path,
     gateway_url,
     is_gateway_url,
-    is_atlassian_site_url,
     is_scoped_token,
     load_connection_profile,
     local_config_path,
@@ -42,27 +40,6 @@ from confluence_export.exporter import Exporter
 from confluence_export.types import Space
 
 
-def _resolve_cloud_id(site_url: str) -> str | None:
-    """Compatibility wrapper for tests and older callers."""
-    return resolve_cloud_id(site_url)
-
-
-def _maybe_route_via_gateway(config: Config) -> Config:
-    """Return a runtime gateway Config for legacy callers without persisting it."""
-    if not (is_atlassian_site_url(config.base_url) and is_scoped_token(config.api_token)):
-        return config
-
-    cloud_id = _resolve_cloud_id(config.base_url)
-    if not cloud_id:
-        return config
-
-    return Config(
-        base_url=gateway_url(cloud_id),
-        email=config.email,
-        api_token=config.api_token,
-    )
-
-
 def _is_auth_error(exc: Exception) -> int | None:
     """Return the HTTP status code if exc looks like an auth failure, else None.
 
@@ -78,8 +55,8 @@ def _is_auth_error(exc: Exception) -> int | None:
     return None
 
 
-def _with_auth_fallback(fn, client: ConfluenceClient, config) -> object:
-    """Call fn(); on auth error, fail clearly without interactive fallback."""
+def _exit_on_auth_error(fn) -> object:
+    """Call fn(); on auth error, fail clearly without prompting."""
     try:
         return fn()
     except Exception as exc:
@@ -212,7 +189,7 @@ def main() -> None:
 
     match args.command:
         case "spaces":
-            _with_auth_fallback(lambda: _cmd_spaces(client), client, profile)
+            _exit_on_auth_error(lambda: _cmd_spaces(client))
         case "tree":
             _cmd_tree(client, CacheStore(), profile, args.space_key)
         case "find":
@@ -264,6 +241,8 @@ def _auth_label(mode: AuthMode) -> str:
             return "Bearer token (PAT)"
         case AuthMode.COOKIE:
             return "cookie session"
+        case _:
+            raise AssertionError(f"Unhandled auth mode: {mode}")
 
 
 def _api_mode_label(dialect: ApiDialect) -> str:
@@ -274,6 +253,8 @@ def _api_mode_label(dialect: ApiDialect) -> str:
             return "OAuth gateway"
         case ApiDialect.COOKIE_V1:
             return "Confluence REST v1 compatibility"
+        case _:
+            raise AssertionError(f"Unhandled API dialect: {dialect}")
 
 
 def _read_existing_config(path: Path) -> dict:
@@ -309,6 +290,21 @@ def _existing_config_defaults(path: Path) -> tuple[str, str, str]:
     )
 
 
+def _looks_like_cookie_header(secret: str) -> bool:
+    if "=" not in secret:
+        return False
+    name, _, value = secret.partition("=")
+    if not name.strip() or not value.strip():
+        return False
+    name_lower = name.strip().lower()
+    return ";" in secret or "." in name_lower or name_lower in {
+        "session",
+        "jsessionid",
+        "cloud.session.token",
+        "tenant.session.token",
+    }
+
+
 def _cmd_configure(local_dir: str | None = None) -> None:
     """Interactive credential setup."""
     target = local_config_path(local_dir) if local_dir is not None else config_path()
@@ -336,11 +332,17 @@ def _cmd_configure(local_dir: str | None = None) -> None:
     if not site_url:
         print("Error: site_url is required.", file=sys.stderr)
         sys.exit(1)
+    if is_gateway_url(site_url):
+        print(
+            "Error: site_url must be the Confluence site URL, not the OAuth gateway URL.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     if not email and is_scoped_token(secret):
         print("Error: scoped API tokens require an email address.", file=sys.stderr)
         sys.exit(1)
-    if not email and "=" in secret:
+    if not email and _looks_like_cookie_header(secret):
         auth = AuthConfig(type=AuthMode.COOKIE, cookie_header=secret)
     elif not email:
         auth = AuthConfig(type=AuthMode.BEARER_PAT, token=secret)
@@ -397,7 +399,7 @@ def _cmd_tree(
     client: ConfluenceClient, cache: CacheStore, profile: ConnectionProfile, space_key: str
 ) -> None:
     """Show page hierarchy."""
-    space = _with_auth_fallback(lambda: _resolve_space(client, space_key), client, profile)
+    space = _exit_on_auth_error(lambda: _resolve_space(client, space_key))
     cs = cache.ensure_loaded(client, space)
 
     roots = build_tree(cs.pages)
@@ -414,7 +416,7 @@ def _cmd_find(
     query: str,
 ) -> None:
     """Search pages by title."""
-    space = _with_auth_fallback(lambda: _resolve_space(client, space_key), client, profile)
+    space = _exit_on_auth_error(lambda: _resolve_space(client, space_key))
     cs = cache.ensure_loaded(client, space)
 
     results = find_pages(cs.pages, query)
@@ -645,9 +647,9 @@ def _cmd_diff(
     if cs is not None:
         space = cs.space
     else:
-        space = _with_auth_fallback(lambda: _resolve_space(client, space_key), client, profile)
-    cs = _with_auth_fallback(
-        lambda: cache.refresh(client, space, include_archived=include_archived), client, profile
+        space = _exit_on_auth_error(lambda: _resolve_space(client, space_key))
+    cs = _exit_on_auth_error(
+        lambda: cache.refresh(client, space, include_archived=include_archived)
     )
 
     # Filter API pages
@@ -681,7 +683,7 @@ def _cmd_refresh(
     client: ConfluenceClient, cache: CacheStore, profile: ConnectionProfile, space_key: str
 ) -> None:
     """Force-refresh cache for a space."""
-    space = _with_auth_fallback(lambda: _resolve_space(client, space_key), client, profile)
+    space = _exit_on_auth_error(lambda: _resolve_space(client, space_key))
     cs = cache.refresh(client, space)
     print(f"Cache refreshed: {len(cs.pages)} pages (updated {cs.updated_at})")
 

--- a/src/confluence_export/cli.py
+++ b/src/confluence_export/cli.py
@@ -337,6 +337,9 @@ def _cmd_configure(local_dir: str | None = None) -> None:
         print("Error: site_url is required.", file=sys.stderr)
         sys.exit(1)
 
+    if not email and is_scoped_token(secret):
+        print("Error: scoped API tokens require an email address.", file=sys.stderr)
+        sys.exit(1)
     if not email and "=" in secret:
         auth = AuthConfig(type=AuthMode.COOKIE, cookie_header=secret)
     elif not email:

--- a/src/confluence_export/client.py
+++ b/src/confluence_export/client.py
@@ -9,7 +9,13 @@ from urllib.parse import parse_qs, quote, urlparse
 import requests
 from requests.auth import HTTPBasicAuth
 
-from confluence_export.config import Config
+from confluence_export.config import (
+    ApiDialect,
+    AuthConfig,
+    AuthMode,
+    Config,
+    ConnectionProfile,
+)
 from confluence_export.types import Attachment, Page, Space, Version
 
 
@@ -29,25 +35,46 @@ class ConfluenceClient:
     size is 10, which accommodates the 8-worker thread pools used by callers.
     """
 
-    def __init__(self, config: Config, verbose: bool = False):
-        self.base_url = config.base_url
+    def __init__(self, config: Config | ConnectionProfile, verbose: bool = False):
+        if isinstance(config, ConnectionProfile):
+            profile = config
+        else:
+            profile = ConnectionProfile(
+                site_url=config.base_url,
+                api_base_url=config.base_url,
+                cloud_id=None,
+                auth_mode=AuthMode.BEARER_PAT if config.use_bearer else AuthMode.BASIC_API_TOKEN,
+                api_dialect=ApiDialect.CLOUD_V2,
+                config_source="legacy Config",
+                interactive=True,
+                auth=AuthConfig(
+                    type=AuthMode.BEARER_PAT if config.use_bearer else AuthMode.BASIC_API_TOKEN,
+                    email=config.email,
+                    token=config.api_token,
+                ),
+            )
+
+        self.profile = profile
+        self.base_url = profile.api_base_url
         self.verbose = verbose
 
         self.session = requests.Session()
         self.session.headers.update({"Accept": "application/json"})
         self.session.timeout = 30
-        self.api_flavor = "v2"
+        self.api_dialect = profile.api_dialect
+        self.api_flavor = "cookie_v1" if profile.api_dialect is ApiDialect.COOKIE_V1 else "v2"
         self._space_key_by_id: dict[str, str] = {}
 
-        if config.api_token:
-            if config.use_bearer:
-                # PAT-only: use Bearer token auth
-                self.session.headers["Authorization"] = f"Bearer {config.api_token}"
-                self._log("Using Bearer token auth (PAT)")
-            else:
-                # Email + API token: use Basic Auth
-                self.session.auth = HTTPBasicAuth(config.email, config.api_token)
-                self._log(f"Using Basic Auth with email: {config.email}")
+        auth = profile.auth
+        if profile.auth_mode is AuthMode.COOKIE and auth.cookie_header:
+            self._set_cookie_header(auth.cookie_header)
+            self._log("Using browser cookie auth")
+        elif profile.auth_mode is AuthMode.BEARER_PAT and auth.token:
+            self.session.headers["Authorization"] = f"Bearer {auth.token}"
+            self._log("Using Bearer token auth (PAT)")
+        elif auth.token:
+            self.session.auth = HTTPBasicAuth(auth.email, auth.token)
+            self._log(f"Using Basic Auth with email: {auth.email}")
         else:
             self._log("No credentials configured — browser token required")
 
@@ -62,10 +89,10 @@ class ConfluenceClient:
         self.session.auth = None
         self.session.cookies.clear()
         self.session.headers["Authorization"] = f"Bearer {token}"
+        self.api_dialect = ApiDialect.CLOUD_V2
         self.api_flavor = "v2"
 
-    def set_cookies(self, cookie_string: str) -> None:
-        """Replace current credentials with browser session cookies."""
+    def _set_cookie_header(self, cookie_string: str) -> None:
         self.session.auth = None
         self.session.headers.pop("Authorization", None)
         self.session.cookies.clear()
@@ -74,11 +101,16 @@ class ConfluenceClient:
             if "=" in pair:
                 name, _, value = pair.partition("=")
                 self.session.cookies.set(name.strip(), value.strip())
+
+    def set_cookies(self, cookie_string: str) -> None:
+        """Replace current credentials with browser session cookies."""
+        self._set_cookie_header(cookie_string)
+        self.api_dialect = ApiDialect.COOKIE_V1
         self.api_flavor = "cookie_v1"
 
     def verify_auth(self) -> None:
         """Verify current credentials with a minimal request."""
-        if self.api_flavor == "cookie_v1":
+        if self.api_dialect is ApiDialect.COOKIE_V1:
             self._get("/wiki/rest/api/space", {"limit": "1"})
         else:
             self._get("/wiki/api/v2/spaces", {"limit": "1"})
@@ -91,7 +123,37 @@ class ConfluenceClient:
         the flag is set. Callers (e.g. the cache) use this to label what the server
         actually delivered, not just what the caller asked for.
         """
-        return self.api_flavor != "cookie_v1"
+        return self.api_dialect is not ApiDialect.COOKIE_V1
+
+    def probe_page_listing(self, space: Space) -> str | None:
+        """Verify page listing and return one page ID when available."""
+        if self.api_dialect is ApiDialect.COOKIE_V1:
+            space_key = space.key or self._space_key_for_v1(space.id)
+            data = self._get(
+                "/wiki/rest/api/content",
+                {
+                    "spaceKey": space_key,
+                    "type": "page",
+                    "status": "current",
+                    "limit": "1",
+                },
+            )
+        else:
+            data = self._get(f"/wiki/api/v2/spaces/{space.id}/pages", {"limit": "1"})
+        results = data.get("results", [])
+        if not results:
+            return None
+        return str(results[0].get("id", "") or "") or None
+
+    def probe_attachment_listing(self, page_id: str) -> None:
+        """Verify attachment listing for a page without downloading files."""
+        if self.api_dialect is ApiDialect.COOKIE_V1:
+            self._get(
+                f"/wiki/rest/api/content/{quote(page_id, safe='')}/child/attachment",
+                {"limit": "1"},
+            )
+        else:
+            self._get(f"/wiki/api/v2/pages/{quote(page_id, safe='')}/attachments", {"limit": "1"})
 
     def _get(self, path: str, params: dict | None = None, max_retries: int = 3) -> dict:
         """GET with retry + rate-limit handling."""
@@ -302,7 +364,7 @@ class ConfluenceClient:
     # -- API methods ---------------------------------------------------------
 
     def get_spaces(self) -> list[Space]:
-        if self.api_flavor == "cookie_v1":
+        if self.api_dialect is ApiDialect.COOKIE_V1:
             results = self._paginate_offset("/wiki/rest/api/space", {"limit": "250"})
             return [self._space_from_v1(r) for r in results]
 
@@ -310,7 +372,7 @@ class ConfluenceClient:
         return [self._remember_space(Space.from_api(r)) for r in results]
 
     def get_pages_in_space(self, space_id: str, include_archived: bool = False) -> list[Page]:
-        if self.api_flavor == "cookie_v1":
+        if self.api_dialect is ApiDialect.COOKIE_V1:
             space_key = self._space_key_for_v1(space_id)
             # v1 status is single-valued, so archived pages need a second call.
             statuses = ["current", "archived"] if include_archived else ["current"]
@@ -338,7 +400,7 @@ class ConfluenceClient:
 
     def get_space_by_key(self, key: str) -> Space | None:
         """Look up a single space by key using the server-side `keys` filter."""
-        if self.api_flavor == "cookie_v1":
+        if self.api_dialect is ApiDialect.COOKIE_V1:
             try:
                 data = self._get(f"/wiki/rest/api/space/{quote(key, safe='')}")
             except requests.exceptions.HTTPError as exc:
@@ -354,7 +416,7 @@ class ConfluenceClient:
         return self._remember_space(Space.from_api(results[0]))
 
     def get_page_by_id(self, page_id: str) -> Page:
-        if self.api_flavor == "cookie_v1":
+        if self.api_dialect is ApiDialect.COOKIE_V1:
             data = self._get(
                 f"/wiki/rest/api/content/{quote(page_id, safe='')}",
                 {"expand": "body.storage,version,ancestors,space,history,extensions"},
@@ -367,7 +429,7 @@ class ConfluenceClient:
     def get_folder_by_id(self, folder_id: str) -> dict | None:
         """Fetch a folder by ID. Returns raw API dict or None on failure."""
         try:
-            if self.api_flavor == "cookie_v1":
+            if self.api_dialect is ApiDialect.COOKIE_V1:
                 data = self._get(
                     f"/wiki/rest/api/content/{quote(folder_id, safe='')}",
                     {"expand": "ancestors,space,extensions"},
@@ -378,7 +440,7 @@ class ConfluenceClient:
             return None
 
     def get_attachments(self, page_id: str) -> list[Attachment]:
-        if self.api_flavor == "cookie_v1":
+        if self.api_dialect is ApiDialect.COOKIE_V1:
             path = f"/wiki/rest/api/content/{quote(page_id, safe='')}/child/attachment"
             results = self._paginate_offset(
                 path, {"expand": "version,metadata,extensions,history", "limit": "250"}

--- a/src/confluence_export/client.py
+++ b/src/confluence_export/client.py
@@ -62,7 +62,6 @@ class ConfluenceClient:
         self.session.headers.update({"Accept": "application/json"})
         self.session.timeout = 30
         self.api_dialect = profile.api_dialect
-        self.api_flavor = "cookie_v1" if profile.api_dialect is ApiDialect.COOKIE_V1 else "v2"
         self._space_key_by_id: dict[str, str] = {}
 
         auth = profile.auth
@@ -84,13 +83,17 @@ class ConfluenceClient:
         if self.verbose:
             print(f"[debug] {msg}", file=sys.stderr)
 
+    @property
+    def api_flavor(self) -> str:
+        """Backward-compatible flavor string derived from the explicit dialect."""
+        return "cookie_v1" if self.api_dialect is ApiDialect.COOKIE_V1 else "v2"
+
     def set_bearer_token(self, token: str) -> None:
         """Replace current credentials with a Bearer token."""
         self.session.auth = None
         self.session.cookies.clear()
         self.session.headers["Authorization"] = f"Bearer {token}"
         self.api_dialect = ApiDialect.CLOUD_V2
-        self.api_flavor = "v2"
 
     def _set_cookie_header(self, cookie_string: str) -> None:
         self.session.auth = None
@@ -106,7 +109,6 @@ class ConfluenceClient:
         """Replace current credentials with browser session cookies."""
         self._set_cookie_header(cookie_string)
         self.api_dialect = ApiDialect.COOKIE_V1
-        self.api_flavor = "cookie_v1"
 
     def verify_auth(self) -> None:
         """Verify current credentials with a minimal request."""

--- a/src/confluence_export/config.py
+++ b/src/confluence_export/config.py
@@ -215,19 +215,14 @@ def _infer_auth_mode(
     email: str,
     token: str,
     cookie_header: str,
-    api_base_url: str = "",
 ) -> AuthMode:
     explicit_mode = _auth_mode(explicit)
-    if explicit_mode is AuthMode.BEARER_PAT and email and token:
-        if is_scoped_token(token) or is_gateway_url(api_base_url):
-            return AuthMode.SCOPED_API_TOKEN
-        return AuthMode.BASIC_API_TOKEN
     if explicit_mode is not None:
         return explicit_mode
     if cookie_header:
         return AuthMode.COOKIE
     if email and token:
-        if is_scoped_token(token) or is_gateway_url(api_base_url):
+        if is_scoped_token(token):
             return AuthMode.SCOPED_API_TOKEN
         return AuthMode.BASIC_API_TOKEN
     if token:
@@ -255,7 +250,6 @@ def _auth_from_v1(data: dict) -> AuthConfig:
         email=email,
         token=token,
         cookie_header="",
-        api_base_url=str(data.get("base_url", "") or ""),
     )
     return AuthConfig(type=mode, email=email, token=token)
 
@@ -275,7 +269,6 @@ def _parse_file_config(path: Path) -> _ResolvedConfig:
             email=email,
             token=token,
             cookie_header=cookie_header,
-            api_base_url=str(data.get("api_base_url", "") or ""),
         )
         return _ResolvedConfig(
             site_url=normalize_url(str(data.get("site_url", "") or "")),
@@ -309,20 +302,63 @@ def _parse_file_config(path: Path) -> _ResolvedConfig:
 
 
 def _overlay(base: _ResolvedConfig, override: _ResolvedConfig) -> _ResolvedConfig:
+    override_auth_has_credentials = False
     if base.auth and override.auth:
+        override_auth_has_cookie = bool(override.auth.cookie_header)
+        override_auth_has_tokenish = bool(override.auth.email or override.auth.token)
+        override_auth_has_credentials = override_auth_has_cookie or override_auth_has_tokenish
+        if override.auth.type is not None:
+            auth_type = override.auth.type
+        elif override_auth_has_credentials:
+            auth_type = None
+        else:
+            auth_type = base.auth.type
         auth = AuthConfig(
-            type=override.auth.type or base.auth.type,
-            email=override.auth.email or base.auth.email,
-            token=override.auth.token or base.auth.token,
-            cookie_header=override.auth.cookie_header or base.auth.cookie_header,
+            type=auth_type,
+            email=override.auth.email or ("" if override_auth_has_cookie else base.auth.email),
+            token=override.auth.token or ("" if override_auth_has_cookie else base.auth.token),
+            cookie_header=override.auth.cookie_header or (
+                "" if override_auth_has_tokenish else base.auth.cookie_header
+            ),
         )
     else:
         auth = override.auth or base.auth
+        override_auth_has_credentials = bool(
+            override.auth and (
+                override.auth.email or override.auth.token or override.auth.cookie_header
+            )
+        )
+
+    site_url_overridden = bool(override.site_url)
+    merged_auth_has_credentials = bool(
+        auth and (auth.email or auth.token or auth.cookie_header)
+    )
+    # A higher-priority explicit non-scoped auth mode may intentionally inherit
+    # credentials from a lower-priority config. It still invalidates cached
+    # gateway routing because the OAuth gateway is scoped-token-only transport.
+    override_auth_forces_site_route = bool(
+        override.auth and override.auth.type in (
+            AuthMode.BASIC_API_TOKEN,
+            AuthMode.BEARER_PAT,
+            AuthMode.COOKIE,
+        )
+        and merged_auth_has_credentials
+    )
+    clear_derived_route = (
+        (site_url_overridden or override_auth_has_credentials or override_auth_forces_site_route)
+        and not override.api_base_url
+    )
 
     return _ResolvedConfig(
         site_url=override.site_url or base.site_url,
-        api_base_url=override.api_base_url or base.api_base_url,
-        cloud_id=override.cloud_id if override.cloud_id is not None else base.cloud_id,
+        api_base_url=override.api_base_url or ("" if clear_derived_route else base.api_base_url),
+        cloud_id=override.cloud_id if override.cloud_id is not None else (
+            None if (
+                site_url_overridden
+                or override_auth_has_credentials
+                or override_auth_forces_site_route
+            ) else base.cloud_id
+        ),
         auth=auth,
         source=override.source or base.source,
         source_label=override.source_label if override.source else base.source_label,
@@ -400,7 +436,11 @@ def _resolve_api_base(
         return site_url, None, ApiDialect.COOKIE_V1
 
     if auth_mode is AuthMode.SCOPED_API_TOKEN:
-        if is_gateway_url(api_base_url):
+        if api_base_url:
+            if not is_gateway_url(api_base_url):
+                raise ConnectionProfileError(
+                    "scoped token api_base_url must be the OAuth gateway URL"
+                )
             return api_base_url, cloud_id or gateway_cloud_id(api_base_url), ApiDialect.GATEWAY_V2
         resolved_cloud_id = cloud_id or resolve_cloud(site_url)
         if not resolved_cloud_id:
@@ -409,7 +449,10 @@ def _resolve_api_base(
             )
         return gateway_url(resolved_cloud_id), resolved_cloud_id, ApiDialect.GATEWAY_V2
 
-    return api_base_url or site_url, cloud_id, ApiDialect.CLOUD_V2
+    if is_gateway_url(api_base_url):
+        raise ConnectionProfileError("OAuth gateway api_base_url requires scoped API token auth")
+
+    return api_base_url or site_url, None, ApiDialect.CLOUD_V2
 
 
 def load_connection_profile(
@@ -467,7 +510,6 @@ def load_connection_profile(
         email=auth.email,
         token=auth.token,
         cookie_header=auth.cookie_header,
-        api_base_url=merged.api_base_url,
     )
     if auth.type is AuthMode.COOKIE and not auth.cookie_header:
         raise ConnectionProfileError("cookie authentication requires a cookie header")

--- a/src/confluence_export/config.py
+++ b/src/confluence_export/config.py
@@ -290,11 +290,10 @@ def _parse_file_config(path: Path) -> _ResolvedConfig:
             "config base_url is the OAuth gateway; run `confluence-export configure` "
             "with the Confluence site URL"
         )
-    cloud_id = gateway_cloud_id(base_url)
     return _ResolvedConfig(
         site_url=base_url,
-        api_base_url=base_url if is_gateway_url(base_url) else "",
-        cloud_id=cloud_id,
+        api_base_url="",
+        cloud_id=None,
         auth=_auth_from_v1(data),
         source=path,
         source_label=display_config_source(path),

--- a/src/confluence_export/config.py
+++ b/src/confluence_export/config.py
@@ -104,10 +104,13 @@ def is_scoped_token(token: str) -> bool:
 
 
 def is_atlassian_site_url(url: str) -> bool:
-    """True if url points at a `*.atlassian.net` site, not the OAuth gateway."""
+    """True if url points at an HTTPS `*.atlassian.net` site."""
     if not url:
         return False
-    host = urlparse(url).hostname or ""
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        return False
+    host = parsed.hostname or ""
     return bool(_SITE_HOST_RE.match(host))
 
 
@@ -176,9 +179,12 @@ def display_config_source(path: Path | None, fallback: str = "CLI/environment") 
 
 def resolve_cloud_id(site_url: str) -> str | None:
     """Look up the Confluence cloud ID for a site URL via /_edge/tenant_info."""
+    site_url = normalize_url(site_url)
+    if not is_atlassian_site_url(site_url):
+        return None
     try:
         resp = requests.get(
-            normalize_url(site_url) + "/_edge/tenant_info",
+            site_url + "/_edge/tenant_info",
             headers={"Accept": "application/json"},
             timeout=10,
         )
@@ -212,6 +218,10 @@ def _infer_auth_mode(
     api_base_url: str = "",
 ) -> AuthMode:
     explicit_mode = _auth_mode(explicit)
+    if explicit_mode is AuthMode.BEARER_PAT and email and token:
+        if is_scoped_token(token) or is_gateway_url(api_base_url):
+            return AuthMode.SCOPED_API_TOKEN
+        return AuthMode.BASIC_API_TOKEN
     if explicit_mode is not None:
         return explicit_mode
     if cookie_header:
@@ -282,6 +292,11 @@ def _parse_file_config(path: Path) -> _ResolvedConfig:
         )
 
     base_url = normalize_url(str(data.get("base_url", "") or ""))
+    if is_gateway_url(base_url):
+        raise ConnectionProfileError(
+            "config base_url is the OAuth gateway; run `confluence-export configure` "
+            "with the Confluence site URL"
+        )
     cloud_id = gateway_cloud_id(base_url)
     return _ResolvedConfig(
         site_url=base_url,
@@ -387,9 +402,6 @@ def _resolve_api_base(
     if auth_mode is AuthMode.SCOPED_API_TOKEN:
         if is_gateway_url(api_base_url):
             return api_base_url, cloud_id or gateway_cloud_id(api_base_url), ApiDialect.GATEWAY_V2
-        if is_gateway_url(site_url):
-            resolved_cloud_id = cloud_id or gateway_cloud_id(site_url)
-            return site_url, resolved_cloud_id, ApiDialect.GATEWAY_V2
         resolved_cloud_id = cloud_id or resolve_cloud(site_url)
         if not resolved_cloud_id:
             raise ConnectionProfileError(
@@ -444,6 +456,10 @@ def load_connection_profile(
         raise ConnectionProfileError("authentication credentials are required")
     if not merged.site_url:
         raise ConnectionProfileError("site_url is required")
+    if is_gateway_url(merged.site_url):
+        raise ConnectionProfileError(
+            "site_url must be the Confluence site URL, not the OAuth gateway URL"
+        )
 
     auth = merged.auth
     auth.type = _infer_auth_mode(
@@ -535,6 +551,10 @@ def _config_to_v2_dict(
 ) -> dict:
     if auth.type is None:
         raise ConnectionProfileError("auth type is required")
+    if is_gateway_url(site_url):
+        raise ConnectionProfileError(
+            "site_url must be the Confluence site URL, not the OAuth gateway URL"
+        )
     data = {
         "version": 2,
         "site_url": normalize_url(site_url),

--- a/src/confluence_export/config.py
+++ b/src/confluence_export/config.py
@@ -1,61 +1,75 @@
-"""Configuration management: CLI args > env vars > config file."""
+"""Configuration and resolved connection profiles."""
 
 from __future__ import annotations
 
 import json
 import os
 import re
-from dataclasses import dataclass
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 from urllib.parse import urlparse
 
+import requests
+
 CONFIG_DIR_NAME = "confluence-export"
 CONFIG_FILE = "config.json"
+LOCAL_CONFIG_DIR_NAME = ".conex"
 
 GATEWAY_HOST = "api.atlassian.com"
 _SITE_HOST_RE = re.compile(r"^[a-z0-9][a-z0-9-]*\.atlassian\.net$", re.IGNORECASE)
+_GATEWAY_PATH_RE = re.compile(r"^/ex/confluence/([^/]+)")
 
 
-def is_scoped_token(token: str) -> bool:
-    """True if token looks like an Atlassian scoped API token (ATATT…=ADA…).
-
-    Scoped tokens require requests to be routed through the OAuth gateway URL
-    `https://api.atlassian.com/ex/confluence/{cloudId}/...` rather than the
-    Confluence site URL. The `=ADA<hex>` suffix encodes the scope set; tokens
-    without it are full-access (legacy) tokens that work with the site URL.
-    """
-    return bool(token) and token.startswith("ATATT") and "=ADA" in token
+class AuthMode(Enum):
+    BASIC_API_TOKEN = "basic_api_token"
+    SCOPED_API_TOKEN = "scoped_api_token"
+    BEARER_PAT = "bearer_pat"
+    COOKIE = "cookie"
 
 
-def is_atlassian_site_url(url: str) -> bool:
-    """True if url points at a `*.atlassian.net` site (not the OAuth gateway)."""
-    if not url:
-        return False
-    host = urlparse(url).hostname or ""
-    return bool(_SITE_HOST_RE.match(host))
+class ApiDialect(Enum):
+    CLOUD_V2 = "cloud_v2"
+    GATEWAY_V2 = "gateway_v2"
+    COOKIE_V1 = "cookie_v1"
 
 
-def gateway_url(cloud_id: str) -> str:
-    """Build the OAuth gateway base URL for a Confluence cloud ID."""
-    return f"https://{GATEWAY_HOST}/ex/confluence/{cloud_id}"
+class ConnectionProfileError(ValueError):
+    """Raised when a connection profile cannot be resolved."""
 
 
-def _config_dir() -> Path:
-    return Path.home() / ".config" / CONFIG_DIR_NAME
+@dataclass
+class AuthConfig:
+    type: AuthMode | None
+    email: str = ""
+    token: str = field(default="", repr=False)
+    cookie_header: str = field(default="", repr=False)
 
 
-def config_path() -> Path:
-    return _config_dir() / CONFIG_FILE
-
-
-def cache_dir() -> Path:
-    return _config_dir() / "cache"
+@dataclass
+class ConnectionProfile:
+    site_url: str
+    api_base_url: str
+    cloud_id: str | None
+    auth_mode: AuthMode
+    api_dialect: ApiDialect
+    config_source: str
+    interactive: bool
+    auth: AuthConfig = field(repr=False)
 
 
 @dataclass
 class Config:
+    """Backward-compatible legacy config shape.
+
+    New command paths should use :class:`ConnectionProfile`. This class remains
+    available for direct callers and older tests.
+    """
+
     base_url: str
-    email: str  # optional — empty means use Bearer auth with PAT
+    email: str
     api_token: str
 
     @property
@@ -73,60 +87,501 @@ class Config:
             raise ValueError("base_url is required")
 
 
+@dataclass
+class _ResolvedConfig:
+    site_url: str = ""
+    api_base_url: str = ""
+    cloud_id: str | None = None
+    auth: AuthConfig | None = None
+    source: Path | None = None
+    source_label: str = "CLI/environment"
+
+
+def is_scoped_token(token: str) -> bool:
+    """True if token looks like an Atlassian scoped API token (ATATT...=ADA...)."""
+    return bool(token) and token.startswith("ATATT") and "=ADA" in token
+
+
+def is_atlassian_site_url(url: str) -> bool:
+    """True if url points at a `*.atlassian.net` site, not the OAuth gateway."""
+    if not url:
+        return False
+    host = urlparse(url).hostname or ""
+    return bool(_SITE_HOST_RE.match(host))
+
+
+def is_gateway_url(url: str) -> bool:
+    """True if url points at Atlassian's Confluence OAuth gateway."""
+    parsed = urlparse(url)
+    return (parsed.hostname or "").lower() == GATEWAY_HOST and bool(
+        _GATEWAY_PATH_RE.match(parsed.path)
+    )
+
+
+def gateway_cloud_id(url: str) -> str | None:
+    """Extract the cloud ID from an OAuth gateway URL, if present."""
+    parsed = urlparse(url)
+    if (parsed.hostname or "").lower() != GATEWAY_HOST:
+        return None
+    match = _GATEWAY_PATH_RE.match(parsed.path)
+    return match.group(1) if match else None
+
+
+def gateway_url(cloud_id: str) -> str:
+    """Build the OAuth gateway base URL for a Confluence cloud ID."""
+    return f"https://{GATEWAY_HOST}/ex/confluence/{cloud_id}"
+
+
+def normalize_url(url: str) -> str:
+    return (url or "").strip().rstrip("/")
+
+
+def _config_dir() -> Path:
+    return Path.home() / ".config" / CONFIG_DIR_NAME
+
+
+def config_path() -> Path:
+    return _config_dir() / CONFIG_FILE
+
+
+def cache_dir() -> Path:
+    return _config_dir() / "cache"
+
+
+def local_config_path(start_dir: str | Path) -> Path:
+    return Path(start_dir).expanduser().resolve() / LOCAL_CONFIG_DIR_NAME / CONFIG_FILE
+
+
+def find_local_config(start_dir: str | Path | None) -> Path | None:
+    """Find the nearest local .conex/config.json from start_dir upward."""
+    if start_dir is None:
+        return None
+    current = Path(start_dir).expanduser().resolve()
+    for candidate_dir in (current, *current.parents):
+        candidate = candidate_dir / LOCAL_CONFIG_DIR_NAME / CONFIG_FILE
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def display_config_source(path: Path | None, fallback: str = "CLI/environment") -> str:
+    if path is None:
+        return fallback
+    try:
+        return f"~/{path.expanduser().resolve().relative_to(Path.home())}"
+    except ValueError:
+        return str(path)
+
+
+def resolve_cloud_id(site_url: str) -> str | None:
+    """Look up the Confluence cloud ID for a site URL via /_edge/tenant_info."""
+    try:
+        resp = requests.get(
+            normalize_url(site_url) + "/_edge/tenant_info",
+            headers={"Accept": "application/json"},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        cloud_id = resp.json().get("cloudId")
+        return cloud_id if isinstance(cloud_id, str) and cloud_id else None
+    except (requests.exceptions.RequestException, ValueError):
+        return None
+
+
+def _auth_mode(value: str | AuthMode | None) -> AuthMode | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, AuthMode):
+        return value
+    try:
+        return AuthMode(str(value))
+    except ValueError as exc:
+        values = ", ".join(mode.value for mode in AuthMode)
+        raise ConnectionProfileError(
+            f"unknown auth type '{value}' (expected one of: {values})"
+        ) from exc
+
+
+def _infer_auth_mode(
+    *,
+    explicit: str | AuthMode | None,
+    email: str,
+    token: str,
+    cookie_header: str,
+    api_base_url: str = "",
+) -> AuthMode:
+    explicit_mode = _auth_mode(explicit)
+    if explicit_mode is not None:
+        return explicit_mode
+    if cookie_header:
+        return AuthMode.COOKIE
+    if email and token:
+        if is_scoped_token(token) or is_gateway_url(api_base_url):
+            return AuthMode.SCOPED_API_TOKEN
+        return AuthMode.BASIC_API_TOKEN
+    if token:
+        return AuthMode.BEARER_PAT
+    if email:
+        return AuthMode.BASIC_API_TOKEN
+    raise ConnectionProfileError("authentication credentials are required")
+
+
+def _read_json(path: Path) -> dict:
+    with open(path) as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ConnectionProfileError(f"config file must contain a JSON object: {path}")
+    return data
+
+
+def _auth_from_v1(data: dict) -> AuthConfig:
+    email = str(data.get("email", "") or "")
+    token = str(data.get("api_token", "") or "")
+    mode = _infer_auth_mode(
+        explicit=None,
+        email=email,
+        token=token,
+        cookie_header="",
+        api_base_url=str(data.get("base_url", "") or ""),
+    )
+    return AuthConfig(type=mode, email=email, token=token)
+
+
+def _parse_file_config(path: Path) -> _ResolvedConfig:
+    data = _read_json(path)
+    if data.get("version") == 2:
+        auth_data = data.get("auth") or {}
+        if not isinstance(auth_data, dict):
+            raise ConnectionProfileError(f"auth must be an object in {path}")
+        token = str(auth_data.get("token", "") or "")
+        email = str(auth_data.get("email", "") or "")
+        cookie_header = str(auth_data.get("cookie_header", "") or "")
+        auth_type = auth_data.get("type")
+        mode = _infer_auth_mode(
+            explicit=auth_type,
+            email=email,
+            token=token,
+            cookie_header=cookie_header,
+            api_base_url=str(data.get("api_base_url", "") or ""),
+        )
+        return _ResolvedConfig(
+            site_url=normalize_url(str(data.get("site_url", "") or "")),
+            api_base_url=normalize_url(str(data.get("api_base_url", "") or "")),
+            cloud_id=str(data.get("cloud_id") or "") or None,
+            auth=AuthConfig(
+                type=mode,
+                email=email,
+                token=token,
+                cookie_header=cookie_header,
+            ),
+            source=path,
+            source_label=display_config_source(path),
+        )
+
+    base_url = normalize_url(str(data.get("base_url", "") or ""))
+    cloud_id = gateway_cloud_id(base_url)
+    return _ResolvedConfig(
+        site_url=base_url,
+        api_base_url=base_url if is_gateway_url(base_url) else "",
+        cloud_id=cloud_id,
+        auth=_auth_from_v1(data),
+        source=path,
+        source_label=display_config_source(path),
+    )
+
+
+def _overlay(base: _ResolvedConfig, override: _ResolvedConfig) -> _ResolvedConfig:
+    if base.auth and override.auth:
+        auth = AuthConfig(
+            type=override.auth.type or base.auth.type,
+            email=override.auth.email or base.auth.email,
+            token=override.auth.token or base.auth.token,
+            cookie_header=override.auth.cookie_header or base.auth.cookie_header,
+        )
+    else:
+        auth = override.auth or base.auth
+
+    return _ResolvedConfig(
+        site_url=override.site_url or base.site_url,
+        api_base_url=override.api_base_url or base.api_base_url,
+        cloud_id=override.cloud_id if override.cloud_id is not None else base.cloud_id,
+        auth=auth,
+        source=override.source or base.source,
+        source_label=override.source_label if override.source else base.source_label,
+    )
+
+
+def _env_config() -> _ResolvedConfig:
+    site_url = os.environ.get("CONFLUENCE_SITE_URL") or os.environ.get("CONFLUENCE_BASE_URL") or ""
+    api_base_url = os.environ.get("CONFLUENCE_API_BASE_URL") or ""
+    cloud_id = os.environ.get("CONFLUENCE_CLOUD_ID") or None
+    email = os.environ.get("CONFLUENCE_EMAIL") or ""
+    token = os.environ.get("CONFLUENCE_API_TOKEN") or os.environ.get("CONFLUENCE_PAT") or ""
+    cookie_header = os.environ.get("CONFLUENCE_COOKIE") or ""
+    auth_type = os.environ.get("CONFLUENCE_AUTH_TYPE")
+
+    auth = None
+    if any((email, token, cookie_header, auth_type)):
+        auth = AuthConfig(
+            type=_auth_mode(auth_type),
+            email=email,
+            token=token,
+            cookie_header=cookie_header,
+        )
+    return _ResolvedConfig(
+        site_url=normalize_url(site_url),
+        api_base_url=normalize_url(api_base_url),
+        cloud_id=cloud_id,
+        auth=auth,
+    )
+
+
+def _cli_config(
+    *,
+    site_url: str | None = None,
+    base_url: str | None = None,
+    api_base_url: str | None = None,
+    cloud_id: str | None = None,
+    auth_type: str | AuthMode | None = None,
+    email: str | None = None,
+    api_token: str | None = None,
+    cookie: str | None = None,
+) -> _ResolvedConfig:
+    chosen_site_url = site_url or base_url or ""
+    auth = None
+    if any(v is not None for v in (auth_type, email, api_token, cookie)):
+        auth = AuthConfig(
+            type=_auth_mode(auth_type) if auth_type is not None else (
+                AuthMode.COOKIE if cookie is not None else None
+            ),
+            email=email or "",
+            token=api_token or "",
+            cookie_header=cookie or "",
+        )
+    return _ResolvedConfig(
+        site_url=normalize_url(chosen_site_url),
+        api_base_url=normalize_url(api_base_url or ""),
+        cloud_id=cloud_id or None,
+        auth=auth,
+    )
+
+
+def _resolve_api_base(
+    *,
+    site_url: str,
+    api_base_url: str,
+    cloud_id: str | None,
+    auth_mode: AuthMode,
+    resolve_cloud: Callable[[str], str | None],
+) -> tuple[str, str | None, ApiDialect]:
+    if auth_mode is AuthMode.COOKIE:
+        if is_gateway_url(site_url):
+            raise ConnectionProfileError(
+                "cookie authentication requires a Confluence site URL, not the OAuth gateway URL"
+            )
+        return site_url, None, ApiDialect.COOKIE_V1
+
+    if auth_mode is AuthMode.SCOPED_API_TOKEN:
+        if is_gateway_url(api_base_url):
+            return api_base_url, cloud_id or gateway_cloud_id(api_base_url), ApiDialect.GATEWAY_V2
+        if is_gateway_url(site_url):
+            resolved_cloud_id = cloud_id or gateway_cloud_id(site_url)
+            return site_url, resolved_cloud_id, ApiDialect.GATEWAY_V2
+        resolved_cloud_id = cloud_id or resolve_cloud(site_url)
+        if not resolved_cloud_id:
+            raise ConnectionProfileError(
+                "scoped token requires OAuth gateway routing, but cloud ID could not be resolved"
+            )
+        return gateway_url(resolved_cloud_id), resolved_cloud_id, ApiDialect.GATEWAY_V2
+
+    return api_base_url or site_url, cloud_id, ApiDialect.CLOUD_V2
+
+
+def load_connection_profile(
+    *,
+    site_url: str | None = None,
+    base_url: str | None = None,
+    api_base_url: str | None = None,
+    cloud_id: str | None = None,
+    auth_type: str | AuthMode | None = None,
+    email: str | None = None,
+    api_token: str | None = None,
+    cookie: str | None = None,
+    start_dir: str | Path | None = None,
+    interactive: bool | None = None,
+    resolve_cloud: Callable[[str], str | None] = resolve_cloud_id,
+) -> ConnectionProfile:
+    """Resolve CLI/env/local/global config into an explicit connection profile."""
+    merged = _ResolvedConfig()
+
+    global_path = config_path()
+    if global_path.exists():
+        merged = _overlay(merged, _parse_file_config(global_path))
+
+    local_path = find_local_config(start_dir)
+    if local_path is not None:
+        merged = _overlay(merged, _parse_file_config(local_path))
+
+    merged = _overlay(merged, _env_config())
+    merged = _overlay(
+        merged,
+        _cli_config(
+            site_url=site_url,
+            base_url=base_url,
+            api_base_url=api_base_url,
+            cloud_id=cloud_id,
+            auth_type=auth_type,
+            email=email,
+            api_token=api_token,
+            cookie=cookie,
+        ),
+    )
+
+    if merged.auth is None:
+        raise ConnectionProfileError("authentication credentials are required")
+    if not merged.site_url:
+        raise ConnectionProfileError("site_url is required")
+
+    auth = merged.auth
+    auth.type = _infer_auth_mode(
+        explicit=auth.type,
+        email=auth.email,
+        token=auth.token,
+        cookie_header=auth.cookie_header,
+        api_base_url=merged.api_base_url,
+    )
+    if auth.type is AuthMode.COOKIE and not auth.cookie_header:
+        raise ConnectionProfileError("cookie authentication requires a cookie header")
+    if auth.type in (AuthMode.BASIC_API_TOKEN, AuthMode.SCOPED_API_TOKEN) and (
+        not auth.email or not auth.token
+    ):
+        raise ConnectionProfileError("email and API token are required for API token authentication")
+    if auth.type is AuthMode.BEARER_PAT and not auth.token:
+        raise ConnectionProfileError("bearer/PAT authentication requires a token")
+    api_base, resolved_cloud_id, dialect = _resolve_api_base(
+        site_url=merged.site_url,
+        api_base_url=merged.api_base_url,
+        cloud_id=merged.cloud_id,
+        auth_mode=auth.type,
+        resolve_cloud=resolve_cloud,
+    )
+
+    return ConnectionProfile(
+        site_url=merged.site_url,
+        api_base_url=api_base,
+        cloud_id=resolved_cloud_id,
+        auth_mode=auth.type,
+        api_dialect=dialect,
+        config_source=merged.source_label,
+        interactive=sys.stdin.isatty() if interactive is None else interactive,
+        auth=auth,
+    )
+
+
 def load_config(
     base_url: str | None = None,
     email: str | None = None,
     api_token: str | None = None,
 ) -> Config:
-    """Load config with priority: explicit args > env vars > config file."""
-    # Start with config file values
+    """Load legacy config with priority: explicit args > env vars > global file.
+
+    This compatibility helper intentionally ignores local config discovery. New
+    command paths use :func:`load_connection_profile`.
+    """
     file_cfg: dict = {}
     cp = config_path()
     if cp.exists():
-        with open(cp) as f:
-            file_cfg = json.load(f)
+        file_cfg = _read_json(cp)
+
+    if file_cfg.get("version") == 2:
+        auth_data = file_cfg.get("auth") or {}
+        file_base_url = file_cfg.get("api_base_url") or file_cfg.get("site_url", "")
+        file_email = auth_data.get("email", "")
+        file_token = auth_data.get("token", "")
+    else:
+        file_base_url = file_cfg.get("base_url", "")
+        file_email = file_cfg.get("email", "")
+        file_token = file_cfg.get("api_token", "")
 
     cfg = Config(
         base_url=(
             base_url
             or os.environ.get("CONFLUENCE_BASE_URL")
-            or file_cfg.get("base_url", "")
+            or os.environ.get("CONFLUENCE_SITE_URL")
+            or str(file_base_url or "")
         ),
-        email=(
-            email
-            or os.environ.get("CONFLUENCE_EMAIL")
-            or file_cfg.get("email", "")
-        ),
+        email=(email or os.environ.get("CONFLUENCE_EMAIL") or str(file_email or "")),
         api_token=(
             api_token
             or os.environ.get("CONFLUENCE_API_TOKEN")
             or os.environ.get("CONFLUENCE_PAT")
-            or file_cfg.get("api_token", "")
+            or str(file_token or "")
         ),
     )
-
-    # Strip trailing slashes from base_url
-    cfg.base_url = cfg.base_url.rstrip("/")
+    cfg.base_url = normalize_url(cfg.base_url)
     cfg.validate()
     return cfg
 
 
-def save_config(cfg: Config) -> Path:
-    """Save config to ~/.config/confluence-export/config.json."""
-    d = _config_dir()
-    d.mkdir(parents=True, exist_ok=True)
-
+def _config_to_v2_dict(
+    *,
+    site_url: str,
+    auth: AuthConfig,
+    cloud_id: str | None = None,
+    api_base_url: str = "",
+) -> dict:
+    if auth.type is None:
+        raise ConnectionProfileError("auth type is required")
     data = {
-        "base_url": cfg.base_url,
-        "email": cfg.email,
-        "api_token": cfg.api_token,
+        "version": 2,
+        "site_url": normalize_url(site_url),
+        "auth": {
+            "type": auth.type.value,
+        },
     }
+    if cloud_id:
+        data["cloud_id"] = cloud_id
+    if api_base_url:
+        data["api_base_url"] = normalize_url(api_base_url)
+    if auth.email:
+        data["auth"]["email"] = auth.email
+    if auth.token:
+        data["auth"]["token"] = auth.token
+    if auth.cookie_header:
+        data["auth"]["cookie_header"] = auth.cookie_header
+    return data
 
-    cp = config_path()
+
+def save_connection_config(
+    *,
+    site_url: str,
+    auth: AuthConfig,
+    path: Path | None = None,
+    cloud_id: str | None = None,
+    api_base_url: str = "",
+) -> Path:
+    """Save a v2 connection config."""
+    cp = path or config_path()
+    cp.parent.mkdir(parents=True, exist_ok=True)
+    data = _config_to_v2_dict(
+        site_url=site_url,
+        auth=auth,
+        cloud_id=cloud_id,
+        api_base_url=api_base_url,
+    )
     with open(cp, "w") as f:
         json.dump(data, f, indent=2)
         f.write("\n")
-
-    # Restrict permissions to owner only
     cp.chmod(0o600)
     return cp
+
+
+def save_config(cfg: Config) -> Path:
+    """Save a legacy Config as a v2 global config."""
+    auth_type = AuthMode.BEARER_PAT if cfg.use_bearer else (
+        AuthMode.SCOPED_API_TOKEN if is_scoped_token(cfg.api_token) else AuthMode.BASIC_API_TOKEN
+    )
+    return save_connection_config(
+        site_url=cfg.base_url,
+        auth=AuthConfig(type=auth_type, email=cfg.email, token=cfg.api_token),
+    )

--- a/src/confluence_export/config.py
+++ b/src/confluence_export/config.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import sys
+import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
@@ -220,6 +221,8 @@ def _infer_auth_mode(
             return AuthMode.SCOPED_API_TOKEN
         return AuthMode.BASIC_API_TOKEN
     if token:
+        if is_scoped_token(token):
+            return AuthMode.SCOPED_API_TOKEN
         return AuthMode.BEARER_PAT
     if email:
         return AuthMode.BASIC_API_TOKEN
@@ -569,9 +572,20 @@ def save_connection_config(
         cloud_id=cloud_id,
         api_base_url=api_base_url,
     )
-    with open(cp, "w") as f:
-        json.dump(data, f, indent=2)
-        f.write("\n")
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{cp.name}.", dir=cp.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+        os.replace(tmp_path, cp)
+    except Exception:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
+        raise
     cp.chmod(0o600)
     return cp
 

--- a/src/confluence_export/git.py
+++ b/src/confluence_export/git.py
@@ -34,14 +34,8 @@ def _chunked_paths(paths: list[str], max_bytes: int = _MAX_ARGV_BYTES) -> Iterat
 
 
 def _is_secret_config_relpath(path: str) -> bool:
-    """True for direct JSON config files under any .conex directory."""
-    parts = Path(path).parts
-    return any(
-        part == ".conex"
-        and i + 1 == len(parts) - 1
-        and parts[-1].endswith(".json")
-        for i, part in enumerate(parts)
-    )
+    """True for any file inside a local .conex directory."""
+    return ".conex" in Path(path).parts
 
 
 def _is_secret_config_path(output_dir: Path, path: Path) -> bool:

--- a/src/confluence_export/git.py
+++ b/src/confluence_export/git.py
@@ -35,7 +35,7 @@ def _chunked_paths(paths: list[str], max_bytes: int = _MAX_ARGV_BYTES) -> Iterat
 
 def _is_secret_config_relpath(path: str) -> bool:
     """True for any file inside a local .conex directory."""
-    return ".conex" in Path(path).parts
+    return any(part.lower() == ".conex" for part in Path(path).parts)
 
 
 def _is_secret_config_path(output_dir: Path, path: Path) -> bool:
@@ -176,7 +176,7 @@ def _remove_stale_files(output_dir: Path, written_files: list[Path]) -> None:
 
 
 def _unstage_secret_configs(output_dir: Path) -> None:
-    """Undo any accidental staging of local .conex JSON configs."""
+    """Undo any accidental staging of local .conex files."""
     result = _run_git(output_dir, "diff", "--cached", "--name-only", "-z", check=False)
     if result is None or not result.stdout:
         return

--- a/src/confluence_export/git.py
+++ b/src/confluence_export/git.py
@@ -33,6 +33,25 @@ def _chunked_paths(paths: list[str], max_bytes: int = _MAX_ARGV_BYTES) -> Iterat
         yield batch
 
 
+def _is_secret_config_relpath(path: str) -> bool:
+    """True for direct JSON config files under any .conex directory."""
+    parts = Path(path).parts
+    return any(
+        part == ".conex"
+        and i + 1 == len(parts) - 1
+        and parts[-1].endswith(".json")
+        for i, part in enumerate(parts)
+    )
+
+
+def _is_secret_config_path(output_dir: Path, path: Path) -> bool:
+    try:
+        rel = path.resolve().relative_to(output_dir.resolve())
+        return _is_secret_config_relpath(str(rel))
+    except ValueError:
+        return _is_secret_config_relpath(str(path))
+
+
 def git_available() -> bool:
     """Check if git is installed and accessible."""
     return shutil.which("git") is not None
@@ -94,6 +113,7 @@ def commit_local_changes(output_dir: Path) -> bool:
     # Stage only modifications to tracked files within output_dir
     if _run_git(output_dir, "add", "-u", ".") is None:
         return False
+    _unstage_secret_configs(output_dir)
 
     # Check if anything was staged
     result = _run_git(output_dir, "diff", "--cached", "--quiet", check=False)
@@ -113,10 +133,11 @@ def commit_export(output_dir: Path, written_files: list[Path], space_key: str) -
     # Stage only the files the exporter wrote. Chunk to avoid hitting the
     # OS argv limit on big spaces (thousands of paths joined into one exec
     # call exceeds macOS ARG_MAX).
-    paths = [str(f) for f in written_files]
+    paths = [str(f) for f in written_files if not _is_secret_config_path(output_dir, f)]
     for batch in _chunked_paths(paths):
         if _run_git(output_dir, "add", "--", *batch) is None:
             return False
+    _unstage_secret_configs(output_dir)
 
     # Remove stale tracked files (deletions/renames/moves upstream)
     _remove_stale_files(output_dir, written_files)
@@ -147,6 +168,8 @@ def _remove_stale_files(output_dir: Path, written_files: list[Path]) -> None:
         parts = Path(rel_path).parts
         if ".workspace" in parts:
             continue
+        if _is_secret_config_relpath(rel_path):
+            continue
         full = (output_dir / rel_path).resolve()
         if full not in written_resolved:
             stale.append(rel_path)
@@ -156,3 +179,16 @@ def _remove_stale_files(output_dir: Path, written_files: list[Path]) -> None:
         # exceed argv limits when passed to a single git rm call.
         for batch in _chunked_paths(stale):
             _run_git(output_dir, "rm", "--quiet", "--", *batch)
+
+
+def _unstage_secret_configs(output_dir: Path) -> None:
+    """Undo any accidental staging of local .conex JSON configs."""
+    result = _run_git(output_dir, "diff", "--cached", "--name-only", "-z", check=False)
+    if result is None or not result.stdout:
+        return
+    secret_paths = [
+        path for path in result.stdout.strip("\0").split("\0")
+        if path and _is_secret_config_relpath(path)
+    ]
+    for batch in _chunked_paths(secret_paths):
+        _run_git(output_dir, "reset", "-q", "HEAD", "--", *batch, check=False)

--- a/tests/test_auth_fallback.py
+++ b/tests/test_auth_fallback.py
@@ -1,4 +1,4 @@
-"""Tests for browser OAuth2 token fallback."""
+"""Tests for auth errors and explicit cookie mode."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ import pytest
 import requests
 
 from confluence_export.client import AuthenticationError, ConfluenceClient
-from confluence_export.cli import _prompt_browser_credentials, _with_auth_fallback
+from confluence_export.cli import _with_auth_fallback
 from confluence_export.config import Config
 
 
@@ -113,53 +113,6 @@ class TestNeedsToken:
         assert cfg.needs_token is False
 
 
-# -- _prompt_browser_credentials ---------------------------------------------
-
-
-class TestPromptBrowserCredentials:
-    def test_bearer_strips_prefix(self):
-        with patch("confluence_export.cli._read_hidden_line", return_value="Bearer abc123"):
-            cred_type, value = _prompt_browser_credentials("https://x.atlassian.net", "reason")
-        assert cred_type == "bearer"
-        assert value == "abc123"
-
-    def test_bearer_case_insensitive(self):
-        with patch("confluence_export.cli._read_hidden_line", return_value="bearer ABC"):
-            cred_type, value = _prompt_browser_credentials("https://x.atlassian.net", "reason")
-        assert cred_type == "bearer"
-        assert value == "ABC"
-
-    def test_raw_token_is_bearer(self):
-        with patch("confluence_export.cli._read_hidden_line", return_value="raw-token-value"):
-            cred_type, value = _prompt_browser_credentials("https://x.atlassian.net", "reason")
-        assert cred_type == "bearer"
-        assert value == "raw-token-value"
-
-    def test_cookies_detected(self):
-        cookies = "session=abc123; token=xyz789"
-        with patch("confluence_export.cli._read_hidden_line", return_value=cookies):
-            cred_type, value = _prompt_browser_credentials("https://x.atlassian.net", "reason")
-        assert cred_type == "cookie"
-        assert value == cookies
-
-    def test_single_cookie_detected(self):
-        cookie = "tenant.session.token=eyJhbGciOi..."
-        with patch("confluence_export.cli._read_hidden_line", return_value=cookie):
-            cred_type, value = _prompt_browser_credentials("https://x.atlassian.net", "reason")
-        assert cred_type == "cookie"
-        assert value == cookie
-
-    def test_ctrl_c_exits(self):
-        with patch("confluence_export.cli._read_hidden_line", side_effect=KeyboardInterrupt):
-            with pytest.raises(SystemExit):
-                _prompt_browser_credentials("https://x.atlassian.net", "reason")
-
-    def test_empty_input_exits(self):
-        with patch("confluence_export.cli._read_hidden_line", return_value=""):
-            with pytest.raises(SystemExit):
-                _prompt_browser_credentials("https://x.atlassian.net", "reason")
-
-
 # -- _with_auth_fallback -----------------------------------------------------
 
 
@@ -168,61 +121,43 @@ class TestWithAuthFallback:
         result = _with_auth_fallback(lambda: 42, MagicMock(), MagicMock())
         assert result == 42
 
-    def test_retries_on_auth_error(self):
-        config = Config(base_url="https://x.atlassian.net", email="", api_token="bad")
-        client = ConfluenceClient(config)
-
-        call_count = 0
-
-        def fn():
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                raise AuthenticationError(401, "https://x.atlassian.net/wiki/api/v2/spaces")
-            return "ok"
-
-        with patch("confluence_export.cli._prompt_browser_credentials", return_value=("bearer", "good-token")), \
-             patch.object(client, "_get", return_value={"results": []}):
-            result = _with_auth_fallback(fn, client, config)
-
-        assert result == "ok"
-        assert call_count == 2
-        assert client.session.headers["Authorization"] == "Bearer good-token"
-
-    def test_exits_on_second_auth_error(self):
+    def test_exits_on_auth_error_without_prompt(self, capsys):
         config = Config(base_url="https://x.atlassian.net", email="", api_token="bad")
         client = ConfluenceClient(config)
 
         def fn():
             raise AuthenticationError(401, "https://x.atlassian.net/wiki/api/v2/spaces")
 
-        with patch("confluence_export.cli._prompt_browser_credentials", return_value=("bearer", "also-bad")), \
-             patch.object(client, "_get", return_value={"results": []}):
+        with pytest.raises(SystemExit):
+            _with_auth_fallback(fn, client, config)
+
+        assert "no interactive prompt" in capsys.readouterr().err
+
+    def test_exits_on_repeated_auth_error(self):
+        config = Config(base_url="https://x.atlassian.net", email="", api_token="bad")
+        client = ConfluenceClient(config)
+
+        def fn():
+            raise AuthenticationError(401, "https://x.atlassian.net/wiki/api/v2/spaces")
+
+        with patch.object(client, "_get", return_value={"results": []}):
             with pytest.raises(SystemExit):
                 _with_auth_fallback(fn, client, config)
 
-    def test_retries_on_http_404(self):
+    def test_exits_on_http_404_without_prompt(self, capsys):
         """Confluence v2 API returns 404 for wrong-instance credentials."""
         config = Config(base_url="https://x.atlassian.net", email="a@b.com", api_token="tok")
         client = ConfluenceClient(config)
 
-        call_count = 0
-
         def fn():
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                resp = MagicMock(spec=requests.Response)
-                resp.status_code = 404
-                raise requests.exceptions.HTTPError(response=resp)
-            return "ok"
+            resp = MagicMock(spec=requests.Response)
+            resp.status_code = 404
+            raise requests.exceptions.HTTPError(response=resp)
 
-        with patch("confluence_export.cli._prompt_browser_credentials", return_value=("bearer", "good-token")), \
-             patch.object(client, "_get", return_value={"results": []}):
-            result = _with_auth_fallback(fn, client, config)
+        with pytest.raises(SystemExit):
+            _with_auth_fallback(fn, client, config)
 
-        assert result == "ok"
-        assert call_count == 2
+        assert "HTTP 404" in capsys.readouterr().err
 
     def test_does_not_catch_other_http_errors(self):
         """Non-auth HTTP errors should propagate, not trigger prompt."""

--- a/tests/test_auth_fallback.py
+++ b/tests/test_auth_fallback.py
@@ -8,7 +8,7 @@ import pytest
 import requests
 
 from confluence_export.client import AuthenticationError, ConfluenceClient
-from confluence_export.cli import _with_auth_fallback
+from confluence_export.cli import _exit_on_auth_error
 from confluence_export.config import Config
 
 
@@ -113,12 +113,12 @@ class TestNeedsToken:
         assert cfg.needs_token is False
 
 
-# -- _with_auth_fallback -----------------------------------------------------
+# -- _exit_on_auth_error -----------------------------------------------------
 
 
-class TestWithAuthFallback:
+class TestExitOnAuthError:
     def test_success_no_prompt(self):
-        result = _with_auth_fallback(lambda: 42, MagicMock(), MagicMock())
+        result = _exit_on_auth_error(lambda: 42)
         assert result == 42
 
     def test_exits_on_auth_error_without_prompt(self, capsys):
@@ -129,7 +129,7 @@ class TestWithAuthFallback:
             raise AuthenticationError(401, "https://x.atlassian.net/wiki/api/v2/spaces")
 
         with pytest.raises(SystemExit):
-            _with_auth_fallback(fn, client, config)
+            _exit_on_auth_error(fn)
 
         assert "no interactive prompt" in capsys.readouterr().err
 
@@ -142,7 +142,7 @@ class TestWithAuthFallback:
 
         with patch.object(client, "_get", return_value={"results": []}):
             with pytest.raises(SystemExit):
-                _with_auth_fallback(fn, client, config)
+                _exit_on_auth_error(fn)
 
     def test_exits_on_http_404_without_prompt(self, capsys):
         """Confluence v2 API returns 404 for wrong-instance credentials."""
@@ -155,7 +155,7 @@ class TestWithAuthFallback:
             raise requests.exceptions.HTTPError(response=resp)
 
         with pytest.raises(SystemExit):
-            _with_auth_fallback(fn, client, config)
+            _exit_on_auth_error(fn)
 
         assert "HTTP 404" in capsys.readouterr().err
 
@@ -170,7 +170,7 @@ class TestWithAuthFallback:
             raise requests.exceptions.HTTPError(response=resp)
 
         with pytest.raises(requests.exceptions.HTTPError):
-            _with_auth_fallback(fn, client, config)
+            _exit_on_auth_error(fn)
 
 
 # -- set_cookies -------------------------------------------------------------

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -380,6 +380,18 @@ class TestConfigureCommand:
         data = json.loads(config_file.read_text())
         assert data["auth"]["type"] == "bearer_pat"
 
+    def test_scoped_token_without_email_exits_before_cookie_classification(self, capsys, tmp_path):
+        config_file = tmp_path / "config.json"
+        inputs = iter(["https://x.atlassian.net", "", "ATATT3xDummy=ADA456abc"])
+        with patch("sys.argv", ["confluence-export", "configure"]), \
+             patch("builtins.input", side_effect=inputs), \
+             patch("confluence_export.cli.config_path", return_value=config_file):
+            with pytest.raises(SystemExit):
+                main()
+
+        assert not config_file.exists()
+        assert "scoped API tokens require an email" in capsys.readouterr().err
+
     def test_configure_local_writes_local_config(self, tmp_path):
         inputs = iter(["https://x.atlassian.net", "", "session=abc"])
         with patch("sys.argv", ["confluence-export", "configure", "--local", str(tmp_path)]), \

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -10,25 +10,16 @@ import pytest
 
 import requests
 
-from confluence_export.cli import (
-    _maybe_route_via_gateway,
-    _resolve_cloud_id,
-    _resolve_space,
-    main,
-)
+from confluence_export.cli import _resolve_space, main
 from confluence_export.config import (
     ApiDialect,
     AuthConfig,
     AuthMode,
-    Config,
     ConnectionProfile,
     ConnectionProfileError,
+    resolve_cloud_id,
 )
 from confluence_export.types import CachedSpace, Page, Space, Version
-
-SCOPED_TOKEN = "ATATT3xFfGF0_dummy_payload_TgVilzYuG3Sh8MtCp_8=ADA80198"
-LEGACY_TOKEN = "ATATT3xFfGF0_dummy_no_scope_marker_here"
-
 
 def _space(key="TEST", name="Test Space"):
     return Space(id="1", key=key, name=name, type="global", status="current")
@@ -43,10 +34,6 @@ def _cached_space():
     ]
     return CachedSpace(space=_space(), pages=pages, attachments={},
                        updated_at="2025-01-01T00:00:00Z")
-
-
-def _config(base_url="https://x.atlassian.net", api_token="tok"):
-    return Config(base_url=base_url, email="", api_token=api_token)
 
 
 def _profile(
@@ -369,6 +356,18 @@ class TestConfigureCommand:
             assert exc.value.code == 1
         assert "site_url" in capsys.readouterr().err
 
+    def test_gateway_site_url_exits(self, capsys, tmp_path):
+        inputs = iter(["https://api.atlassian.com/ex/confluence/cloud-123", "", "tok"])
+        config_file = tmp_path / "config.json"
+        with patch("sys.argv", ["confluence-export", "configure"]), \
+             patch("builtins.input", side_effect=inputs), \
+             patch("confluence_export.cli.config_path", return_value=config_file):
+            with pytest.raises(SystemExit):
+                main()
+
+        assert not config_file.exists()
+        assert "OAuth gateway" in capsys.readouterr().err
+
     def test_bearer_mode_when_no_email(self, capsys, tmp_path):
         config_file = tmp_path / "config.json"
         inputs = iter(["https://x.atlassian.net", "", "my-pat"])
@@ -379,6 +378,18 @@ class TestConfigureCommand:
         assert "Bearer token" in capsys.readouterr().out
         data = json.loads(config_file.read_text())
         assert data["auth"]["type"] == "bearer_pat"
+
+    def test_padded_pat_without_email_is_not_cookie(self, tmp_path):
+        config_file = tmp_path / "config.json"
+        inputs = iter(["https://x.atlassian.net", "", "abc123=="])
+        with patch("sys.argv", ["confluence-export", "configure"]), \
+             patch("builtins.input", side_effect=inputs), \
+             patch("confluence_export.cli.config_path", return_value=config_file):
+            main()
+
+        data = json.loads(config_file.read_text())
+        assert data["auth"]["type"] == "bearer_pat"
+        assert data["auth"]["token"] == "abc123=="
 
     def test_scoped_token_without_email_exits_before_cookie_classification(self, capsys, tmp_path):
         config_file = tmp_path / "config.json"
@@ -445,10 +456,9 @@ class TestCookieFlag:
                  token="",
                  cookie_header="session=abc",
              )), \
-             patch("confluence_export.cli.ConfluenceClient", return_value=client), \
-             patch("confluence_export.cli._maybe_route_via_gateway") as mock_route:
+             patch("confluence_export.cli.ConfluenceClient", return_value=client):
             main()
-        mock_route.assert_not_called()
+        client.get_spaces.assert_called_once()
 
 
 class TestNeedsToken:
@@ -479,7 +489,7 @@ class TestResolveCloudId:
     def test_happy_path_returns_cloud_id(self):
         resp = self._mock_response(body={"cloudId": "abc-123"})
         with patch("confluence_export.config.requests.get", return_value=resp) as mock_get:
-            assert _resolve_cloud_id("https://acme.atlassian.net/") == "abc-123"
+            assert resolve_cloud_id("https://acme.atlassian.net/") == "abc-123"
         # Trailing slash stripped, /_edge/tenant_info appended.
         called_url = mock_get.call_args[0][0]
         assert called_url == "https://acme.atlassian.net/_edge/tenant_info"
@@ -489,101 +499,33 @@ class TestResolveCloudId:
             "confluence_export.config.requests.get",
             side_effect=requests.exceptions.ConnectionError("dns"),
         ):
-            assert _resolve_cloud_id("https://acme.atlassian.net") is None
+            assert resolve_cloud_id("https://acme.atlassian.net") is None
 
     def test_http_error_returns_none(self):
         resp = self._mock_response(status=503)
         with patch("confluence_export.config.requests.get", return_value=resp):
-            assert _resolve_cloud_id("https://acme.atlassian.net") is None
+            assert resolve_cloud_id("https://acme.atlassian.net") is None
 
     def test_bad_json_returns_none(self):
         resp = self._mock_response(raise_json=True)
         with patch("confluence_export.config.requests.get", return_value=resp):
-            assert _resolve_cloud_id("https://acme.atlassian.net") is None
+            assert resolve_cloud_id("https://acme.atlassian.net") is None
 
     def test_missing_cloud_id_field_returns_none(self):
         resp = self._mock_response(body={"someOther": "value"})
         with patch("confluence_export.config.requests.get", return_value=resp):
-            assert _resolve_cloud_id("https://acme.atlassian.net") is None
+            assert resolve_cloud_id("https://acme.atlassian.net") is None
 
     def test_non_string_cloud_id_returns_none(self):
         # Defensive: API contract says string, but guard against future drift.
         resp = self._mock_response(body={"cloudId": 12345})
         with patch("confluence_export.config.requests.get", return_value=resp):
-            assert _resolve_cloud_id("https://acme.atlassian.net") is None
+            assert resolve_cloud_id("https://acme.atlassian.net") is None
 
     def test_empty_cloud_id_returns_none(self):
         resp = self._mock_response(body={"cloudId": ""})
         with patch("confluence_export.config.requests.get", return_value=resp):
-            assert _resolve_cloud_id("https://acme.atlassian.net") is None
-
-
-class TestMaybeRouteViaGateway:
-    """Legacy runtime route helper does not persist gateway URLs."""
-
-    def test_scoped_token_on_site_url_returns_runtime_gateway_config(self):
-        cfg = Config(
-            base_url="https://acme.atlassian.net",
-            email="a@b.com",
-            api_token=SCOPED_TOKEN,
-        )
-        with patch("confluence_export.cli._resolve_cloud_id", return_value="cloud-uuid-123"):
-            result = _maybe_route_via_gateway(cfg)
-
-        assert result.base_url == "https://api.atlassian.com/ex/confluence/cloud-uuid-123"
-        assert cfg.base_url == "https://acme.atlassian.net"
-
-    def test_legacy_token_left_alone(self):
-        cfg = Config(
-            base_url="https://acme.atlassian.net",
-            email="a@b.com",
-            api_token=LEGACY_TOKEN,
-        )
-        with patch("confluence_export.cli._resolve_cloud_id") as mock_resolve:
-            result = _maybe_route_via_gateway(cfg)
-
-        mock_resolve.assert_not_called()
-        assert result.base_url == "https://acme.atlassian.net"
-
-    def test_already_gateway_url_left_alone(self):
-        # If base_url is already the gateway, nothing to do.
-        cfg = Config(
-            base_url="https://api.atlassian.com/ex/confluence/cloud-uuid",
-            email="a@b.com",
-            api_token=SCOPED_TOKEN,
-        )
-        with patch("confluence_export.cli._resolve_cloud_id") as mock_resolve:
-            result = _maybe_route_via_gateway(cfg)
-
-        mock_resolve.assert_not_called()
-        assert result.base_url == cfg.base_url
-
-    def test_cloud_id_lookup_failure_leaves_url_intact(self):
-        """If /_edge/tenant_info is unreachable, fall back to the original URL
-        so the caller sees the underlying 401 instead of a silent rewrite."""
-        cfg = Config(
-            base_url="https://acme.atlassian.net",
-            email="a@b.com",
-            api_token=SCOPED_TOKEN,
-        )
-        with patch(
-            "confluence_export.cli._resolve_cloud_id", return_value=None
-        ):
-            result = _maybe_route_via_gateway(cfg)
-
-        assert result.base_url == "https://acme.atlassian.net"
-
-    def test_runtime_route_does_not_persist(self, tmp_path):
-        cfg = Config(
-            base_url="https://acme.atlassian.net",
-            email="a@b.com",
-            api_token=SCOPED_TOKEN,
-        )
-        with patch("confluence_export.cli._resolve_cloud_id", return_value="cloud-uuid"):
-            result = _maybe_route_via_gateway(cfg)
-
-        assert result.base_url.startswith("https://api.atlassian.com/")
-        assert cfg.base_url == "https://acme.atlassian.net"
+            assert resolve_cloud_id("https://acme.atlassian.net") is None
 
 
 class TestConfigError:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -15,7 +16,14 @@ from confluence_export.cli import (
     _resolve_space,
     main,
 )
-from confluence_export.config import Config
+from confluence_export.config import (
+    ApiDialect,
+    AuthConfig,
+    AuthMode,
+    Config,
+    ConnectionProfile,
+    ConnectionProfileError,
+)
 from confluence_export.types import CachedSpace, Page, Space, Version
 
 SCOPED_TOKEN = "ATATT3xFfGF0_dummy_payload_TgVilzYuG3Sh8MtCp_8=ADA80198"
@@ -39,6 +47,34 @@ def _cached_space():
 
 def _config(base_url="https://x.atlassian.net", api_token="tok"):
     return Config(base_url=base_url, email="", api_token=api_token)
+
+
+def _profile(
+    site_url="https://x.atlassian.net",
+    api_base_url=None,
+    auth_mode=AuthMode.BEARER_PAT,
+    api_dialect=ApiDialect.CLOUD_V2,
+    cloud_id=None,
+    token="tok",
+    email="",
+    cookie_header="",
+):
+    auth = AuthConfig(
+        type=auth_mode,
+        email=email,
+        token=token,
+        cookie_header=cookie_header,
+    )
+    return ConnectionProfile(
+        site_url=site_url,
+        api_base_url=api_base_url or site_url,
+        cloud_id=cloud_id,
+        auth_mode=auth_mode,
+        api_dialect=api_dialect,
+        config_source="test config",
+        interactive=False,
+        auth=auth,
+    )
 
 
 def _mock_client(spaces=None):
@@ -89,7 +125,7 @@ class TestSpacesCommand:
     def test_lists_spaces_with_columns(self, capsys):
         client = _mock_client()
         with patch("sys.argv", ["confluence-export", "spaces"]), \
-             patch("confluence_export.cli.load_config", return_value=_config()), \
+             patch("confluence_export.cli.load_connection_profile", return_value=_profile()), \
              patch("confluence_export.cli.ConfluenceClient", return_value=client):
             main()
         out = capsys.readouterr().out
@@ -100,7 +136,7 @@ class TestSpacesCommand:
     def test_no_spaces_shows_message(self, capsys):
         client = _mock_client(spaces=[])
         with patch("sys.argv", ["confluence-export", "spaces"]), \
-             patch("confluence_export.cli.load_config", return_value=_config()), \
+             patch("confluence_export.cli.load_connection_profile", return_value=_profile()), \
              patch("confluence_export.cli.ConfluenceClient", return_value=client):
             main()
         assert "No spaces found" in capsys.readouterr().out
@@ -112,7 +148,7 @@ class TestTreeCommand:
         cache = MagicMock()
         cache.ensure_loaded.return_value = _cached_space()
         with patch("sys.argv", ["confluence-export", "tree", "TEST"]), \
-             patch("confluence_export.cli.load_config", return_value=_config()), \
+             patch("confluence_export.cli.load_connection_profile", return_value=_profile()), \
              patch("confluence_export.cli.ConfluenceClient", return_value=client), \
              patch("confluence_export.cli.CacheStore", return_value=cache):
             main()
@@ -128,7 +164,7 @@ class TestFindCommand:
         cache = MagicMock()
         cache.ensure_loaded.return_value = _cached_space()
         with patch("sys.argv", ["confluence-export", "find", "TEST", "Child"]), \
-             patch("confluence_export.cli.load_config", return_value=_config()), \
+             patch("confluence_export.cli.load_connection_profile", return_value=_profile()), \
              patch("confluence_export.cli.ConfluenceClient", return_value=client), \
              patch("confluence_export.cli.CacheStore", return_value=cache):
             main()
@@ -141,7 +177,7 @@ class TestFindCommand:
         cache = MagicMock()
         cache.ensure_loaded.return_value = _cached_space()
         with patch("sys.argv", ["confluence-export", "find", "TEST", "zzz-nonexistent"]), \
-             patch("confluence_export.cli.load_config", return_value=_config()), \
+             patch("confluence_export.cli.load_connection_profile", return_value=_profile()), \
              patch("confluence_export.cli.ConfluenceClient", return_value=client), \
              patch("confluence_export.cli.CacheStore", return_value=cache):
             main()
@@ -155,7 +191,7 @@ class TestExportCommand:
         cache.refresh.return_value = _cached_space()
         out = str(tmp_path / "out")
         with patch("sys.argv", ["confluence-export", "export", "TEST", "-o", out, "--no-media", "--no-git"]), \
-             patch("confluence_export.cli.load_config", return_value=_config()), \
+             patch("confluence_export.cli.load_connection_profile", return_value=_profile()), \
              patch("confluence_export.cli.ConfluenceClient", return_value=client), \
              patch("confluence_export.cli.CacheStore", return_value=cache):
             main()
@@ -180,7 +216,7 @@ class TestExportCommand:
         legacy.mkdir(parents=True)
         (legacy / ".versions.json").write_text("{}")
         with patch("sys.argv", ["confluence-export", "export", "TEST", "-o", out, "--no-media", "--no-git"]), \
-             patch("confluence_export.cli.load_config", return_value=_config()), \
+             patch("confluence_export.cli.load_connection_profile", return_value=_profile()), \
              patch("confluence_export.cli.ConfluenceClient", return_value=client), \
              patch("confluence_export.cli.CacheStore", return_value=cache):
             main()
@@ -197,7 +233,7 @@ class TestExportCommand:
         cache.refresh.return_value = _cached_space()
         out = str(tmp_path / "out")
         with patch("sys.argv", ["confluence-export", "export", "TEST", "-o", out, "--no-media"]), \
-             patch("confluence_export.cli.load_config", return_value=_config()), \
+             patch("confluence_export.cli.load_connection_profile", return_value=_profile()), \
              patch("confluence_export.cli.ConfluenceClient", return_value=client), \
              patch("confluence_export.cli.CacheStore", return_value=cache):
             main()
@@ -229,7 +265,7 @@ class TestExportCommand:
         # Use a relative path from tmp_path
         monkeypatch.chdir(tmp_path)
         with patch("sys.argv", ["confluence-export", "export", "TEST", "-o", "output", "--no-media"]), \
-             patch("confluence_export.cli.load_config", return_value=_config()), \
+             patch("confluence_export.cli.load_connection_profile", return_value=_profile()), \
              patch("confluence_export.cli.ConfluenceClient", return_value=client), \
              patch("confluence_export.cli.CacheStore", return_value=cache):
             main()
@@ -249,7 +285,7 @@ class TestExportCommand:
         cache.refresh.return_value = _cached_space()
         out = str(tmp_path / "out")
         with patch("sys.argv", ["confluence-export", "export", "TEST", "-o", out, "--no-media", "--no-git"]), \
-             patch("confluence_export.cli.load_config", return_value=_config()), \
+             patch("confluence_export.cli.load_connection_profile", return_value=_profile()), \
              patch("confluence_export.cli.ConfluenceClient", return_value=client), \
              patch("confluence_export.cli.CacheStore", return_value=cache):
             main()
@@ -266,7 +302,7 @@ class TestExportCommand:
             "-o", out, "--no-media", "--no-git", "--no-author-lookup",
         ]
         with patch("sys.argv", argv), \
-             patch("confluence_export.cli.load_config", return_value=_config()), \
+             patch("confluence_export.cli.load_connection_profile", return_value=_profile()), \
              patch("confluence_export.cli.ConfluenceClient", return_value=client), \
              patch("confluence_export.cli.CacheStore", return_value=cache), \
              patch("confluence_export.cli.Exporter") as exporter_cls:
@@ -277,6 +313,21 @@ class TestExportCommand:
 
         assert exporter_cls.call_args.kwargs["skip_author_lookup"] is True
 
+    def test_preflight_failure_before_writing_output(self, tmp_path, capsys):
+        client = _mock_client()
+        client.verify_auth.side_effect = Exception("auth failed")
+        out = tmp_path / "out"
+        with patch("sys.argv", ["confluence-export", "export", "TEST", "-o", str(out), "--no-media", "--no-git"]), \
+             patch("confluence_export.cli.load_connection_profile", return_value=_profile()), \
+             patch("confluence_export.cli.ConfluenceClient", return_value=client), \
+             patch("confluence_export.cli.CacheStore") as cache_cls:
+            with pytest.raises(SystemExit):
+                main()
+
+        assert not out.exists()
+        cache_cls.assert_not_called()
+        assert "Preflight failed" in capsys.readouterr().err
+
 
 class TestRefreshCommand:
     def test_refreshes_and_reports(self, capsys):
@@ -284,7 +335,7 @@ class TestRefreshCommand:
         cache = MagicMock()
         cache.refresh.return_value = _cached_space()
         with patch("sys.argv", ["confluence-export", "refresh", "TEST"]), \
-             patch("confluence_export.cli.load_config", return_value=_config()), \
+             patch("confluence_export.cli.load_connection_profile", return_value=_profile()), \
              patch("confluence_export.cli.ConfluenceClient", return_value=client), \
              patch("confluence_export.cli.CacheStore", return_value=cache):
             main()
@@ -294,67 +345,94 @@ class TestRefreshCommand:
 
 
 class TestConfigureCommand:
-    def test_saves_config(self):
+    def test_saves_config(self, tmp_path):
+        config_file = tmp_path / "config.json"
         inputs = iter(["https://x.atlassian.net", "a@b.com", "my-token"])
         with patch("sys.argv", ["confluence-export", "configure"]), \
              patch("builtins.input", side_effect=inputs), \
-             patch("confluence_export.cli.config_path", return_value=Path("/tmp/nope.json")), \
-             patch("confluence_export.cli.save_config") as mock_save:
+             patch("confluence_export.cli.config_path", return_value=config_file):
             main()
-        cfg = mock_save.call_args[0][0]
-        assert cfg.base_url == "https://x.atlassian.net"
-        assert cfg.email == "a@b.com"
-        assert cfg.api_token == "my-token"
+        data = json.loads(config_file.read_text())
+        assert data["version"] == 2
+        assert data["site_url"] == "https://x.atlassian.net"
+        assert data["auth"]["email"] == "a@b.com"
+        assert data["auth"]["token"] == "my-token"
 
-    def test_missing_base_url_exits(self, capsys):
+    def test_missing_site_url_exits(self, capsys, tmp_path):
         inputs = iter(["", "", "tok"])
+        config_file = tmp_path / "missing.json"
         with patch("sys.argv", ["confluence-export", "configure"]), \
              patch("builtins.input", side_effect=inputs), \
-             patch("confluence_export.cli.config_path", return_value=Path("/tmp/nope.json")):
+             patch("confluence_export.cli.config_path", return_value=config_file):
             with pytest.raises(SystemExit) as exc:
                 main()
             assert exc.value.code == 1
-        assert "base_url" in capsys.readouterr().err
+        assert "site_url" in capsys.readouterr().err
 
-    def test_bearer_mode_when_no_email(self, capsys):
+    def test_bearer_mode_when_no_email(self, capsys, tmp_path):
+        config_file = tmp_path / "config.json"
         inputs = iter(["https://x.atlassian.net", "", "my-pat"])
         with patch("sys.argv", ["confluence-export", "configure"]), \
              patch("builtins.input", side_effect=inputs), \
-             patch("confluence_export.cli.config_path", return_value=Path("/tmp/nope.json")), \
-             patch("confluence_export.cli.save_config"):
+             patch("confluence_export.cli.config_path", return_value=config_file):
             main()
         assert "Bearer token" in capsys.readouterr().out
+        data = json.loads(config_file.read_text())
+        assert data["auth"]["type"] == "bearer_pat"
+
+    def test_configure_local_writes_local_config(self, tmp_path):
+        inputs = iter(["https://x.atlassian.net", "", "session=abc"])
+        with patch("sys.argv", ["confluence-export", "configure", "--local", str(tmp_path)]), \
+             patch("builtins.input", side_effect=inputs):
+            main()
+
+        data = json.loads((tmp_path / ".conex" / "config.json").read_text())
+        assert data["auth"]["type"] == "cookie"
 
 
 # -- Cookie and auth flags ---------------------------------------------------
 
 
 class TestCookieFlag:
-    def test_sets_cookies_and_verifies(self, capsys):
+    def test_cookie_profile_is_first_class(self, capsys):
         client = _mock_client()
+        profile = _profile(
+            auth_mode=AuthMode.COOKIE,
+            api_dialect=ApiDialect.COOKIE_V1,
+            token="",
+            cookie_header="session=abc; tok=xyz",
+        )
         with patch("sys.argv", ["confluence-export", "--cookie", "session=abc; tok=xyz", "spaces"]), \
-             patch("confluence_export.cli.load_config", return_value=_config()), \
+             patch("confluence_export.cli.load_connection_profile", return_value=profile) as mock_load, \
              patch("confluence_export.cli.ConfluenceClient", return_value=client):
             main()
-        client.set_cookies.assert_called_once_with("session=abc; tok=xyz")
-        client.verify_auth.assert_called_once_with()
-        assert "Authenticated" in capsys.readouterr().err
+        assert mock_load.call_args.kwargs["cookie"] == "session=abc; tok=xyz"
+        assert "TEST" in capsys.readouterr().out
 
-    def test_bad_cookie_exits(self, capsys):
+    def test_bad_cookie_export_preflight_exits(self, tmp_path, capsys):
         client = _mock_client()
         client.verify_auth.side_effect = Exception("401")
-        with patch("sys.argv", ["confluence-export", "--cookie", "bad=val", "spaces"]), \
-             patch("confluence_export.cli.load_config", return_value=_config()), \
+        with patch("sys.argv", ["confluence-export", "--cookie", "bad=val", "export", "TEST", "-o", str(tmp_path / "out")]), \
+             patch("confluence_export.cli.load_connection_profile", return_value=_profile(
+                 auth_mode=AuthMode.COOKIE,
+                 api_dialect=ApiDialect.COOKIE_V1,
+                 token="",
+                 cookie_header="bad=val",
+             )), \
              patch("confluence_export.cli.ConfluenceClient", return_value=client):
             with pytest.raises(SystemExit):
                 main()
-        assert "failed" in capsys.readouterr().err
+        assert "Preflight failed" in capsys.readouterr().err
 
     def test_cookie_does_not_route_scoped_token_via_gateway(self):
         client = _mock_client()
-        config = _config(api_token=SCOPED_TOKEN)
         with patch("sys.argv", ["confluence-export", "--cookie", "session=abc", "spaces"]), \
-             patch("confluence_export.cli.load_config", return_value=config), \
+             patch("confluence_export.cli.load_connection_profile", return_value=_profile(
+                 auth_mode=AuthMode.COOKIE,
+                 api_dialect=ApiDialect.COOKIE_V1,
+                 token="",
+                 cookie_header="session=abc",
+             )), \
              patch("confluence_export.cli.ConfluenceClient", return_value=client), \
              patch("confluence_export.cli._maybe_route_via_gateway") as mock_route:
             main()
@@ -362,14 +440,12 @@ class TestCookieFlag:
 
 
 class TestNeedsToken:
-    def test_prompts_when_no_token_configured(self):
-        client = _mock_client()
+    def test_missing_credentials_fails_without_prompt(self, capsys):
         with patch("sys.argv", ["confluence-export", "spaces"]), \
-             patch("confluence_export.cli.load_config", return_value=_config(api_token="")), \
-             patch("confluence_export.cli.ConfluenceClient", return_value=client), \
-             patch("confluence_export.cli._apply_browser_credentials") as mock_apply:
-            main()
-        mock_apply.assert_called_once()
+             patch("confluence_export.cli.load_connection_profile", side_effect=ConnectionProfileError("authentication credentials are required")):
+            with pytest.raises(SystemExit):
+                main()
+        assert "authentication credentials" in capsys.readouterr().err
 
 
 class TestResolveCloudId:
@@ -390,7 +466,7 @@ class TestResolveCloudId:
 
     def test_happy_path_returns_cloud_id(self):
         resp = self._mock_response(body={"cloudId": "abc-123"})
-        with patch("confluence_export.cli.requests.get", return_value=resp) as mock_get:
+        with patch("confluence_export.config.requests.get", return_value=resp) as mock_get:
             assert _resolve_cloud_id("https://acme.atlassian.net/") == "abc-123"
         # Trailing slash stripped, /_edge/tenant_info appended.
         called_url = mock_get.call_args[0][0]
@@ -398,54 +474,52 @@ class TestResolveCloudId:
 
     def test_network_error_returns_none(self):
         with patch(
-            "confluence_export.cli.requests.get",
+            "confluence_export.config.requests.get",
             side_effect=requests.exceptions.ConnectionError("dns"),
         ):
             assert _resolve_cloud_id("https://acme.atlassian.net") is None
 
     def test_http_error_returns_none(self):
         resp = self._mock_response(status=503)
-        with patch("confluence_export.cli.requests.get", return_value=resp):
+        with patch("confluence_export.config.requests.get", return_value=resp):
             assert _resolve_cloud_id("https://acme.atlassian.net") is None
 
     def test_bad_json_returns_none(self):
         resp = self._mock_response(raise_json=True)
-        with patch("confluence_export.cli.requests.get", return_value=resp):
+        with patch("confluence_export.config.requests.get", return_value=resp):
             assert _resolve_cloud_id("https://acme.atlassian.net") is None
 
     def test_missing_cloud_id_field_returns_none(self):
         resp = self._mock_response(body={"someOther": "value"})
-        with patch("confluence_export.cli.requests.get", return_value=resp):
+        with patch("confluence_export.config.requests.get", return_value=resp):
             assert _resolve_cloud_id("https://acme.atlassian.net") is None
 
     def test_non_string_cloud_id_returns_none(self):
         # Defensive: API contract says string, but guard against future drift.
         resp = self._mock_response(body={"cloudId": 12345})
-        with patch("confluence_export.cli.requests.get", return_value=resp):
+        with patch("confluence_export.config.requests.get", return_value=resp):
             assert _resolve_cloud_id("https://acme.atlassian.net") is None
 
     def test_empty_cloud_id_returns_none(self):
         resp = self._mock_response(body={"cloudId": ""})
-        with patch("confluence_export.cli.requests.get", return_value=resp):
+        with patch("confluence_export.config.requests.get", return_value=resp):
             assert _resolve_cloud_id("https://acme.atlassian.net") is None
 
 
 class TestMaybeRouteViaGateway:
-    """Auto-rewrite of site URL to OAuth gateway for scoped tokens."""
+    """Legacy runtime route helper does not persist gateway URLs."""
 
-    def test_scoped_token_on_site_url_rewrites_and_persists(self):
+    def test_scoped_token_on_site_url_returns_runtime_gateway_config(self):
         cfg = Config(
             base_url="https://acme.atlassian.net",
             email="a@b.com",
             api_token=SCOPED_TOKEN,
         )
-        with patch(
-            "confluence_export.cli._resolve_cloud_id", return_value="cloud-uuid-123"
-        ), patch("confluence_export.cli.save_config") as mock_save:
+        with patch("confluence_export.cli._resolve_cloud_id", return_value="cloud-uuid-123"):
             result = _maybe_route_via_gateway(cfg)
 
         assert result.base_url == "https://api.atlassian.com/ex/confluence/cloud-uuid-123"
-        mock_save.assert_called_once_with(cfg)
+        assert cfg.base_url == "https://acme.atlassian.net"
 
     def test_legacy_token_left_alone(self):
         cfg = Config(
@@ -453,13 +527,10 @@ class TestMaybeRouteViaGateway:
             email="a@b.com",
             api_token=LEGACY_TOKEN,
         )
-        with patch("confluence_export.cli._resolve_cloud_id") as mock_resolve, \
-             patch("confluence_export.cli.save_config") as mock_save:
+        with patch("confluence_export.cli._resolve_cloud_id") as mock_resolve:
             result = _maybe_route_via_gateway(cfg)
 
-        # No network call, no rewrite, no save
         mock_resolve.assert_not_called()
-        mock_save.assert_not_called()
         assert result.base_url == "https://acme.atlassian.net"
 
     def test_already_gateway_url_left_alone(self):
@@ -469,12 +540,10 @@ class TestMaybeRouteViaGateway:
             email="a@b.com",
             api_token=SCOPED_TOKEN,
         )
-        with patch("confluence_export.cli._resolve_cloud_id") as mock_resolve, \
-             patch("confluence_export.cli.save_config") as mock_save:
+        with patch("confluence_export.cli._resolve_cloud_id") as mock_resolve:
             result = _maybe_route_via_gateway(cfg)
 
         mock_resolve.assert_not_called()
-        mock_save.assert_not_called()
         assert result.base_url == cfg.base_url
 
     def test_cloud_id_lookup_failure_leaves_url_intact(self):
@@ -487,35 +556,30 @@ class TestMaybeRouteViaGateway:
         )
         with patch(
             "confluence_export.cli._resolve_cloud_id", return_value=None
-        ), patch("confluence_export.cli.save_config") as mock_save:
+        ):
             result = _maybe_route_via_gateway(cfg)
 
-        mock_save.assert_not_called()
         assert result.base_url == "https://acme.atlassian.net"
 
-    def test_persist_failure_does_not_break_run(self, tmp_path):
-        """A read-only filesystem must not stop the rewrite from applying."""
+    def test_runtime_route_does_not_persist(self, tmp_path):
         cfg = Config(
             base_url="https://acme.atlassian.net",
             email="a@b.com",
             api_token=SCOPED_TOKEN,
         )
-        with patch(
-            "confluence_export.cli._resolve_cloud_id", return_value="cloud-uuid"
-        ), patch(
-            "confluence_export.cli.save_config", side_effect=OSError("read-only fs")
-        ):
+        with patch("confluence_export.cli._resolve_cloud_id", return_value="cloud-uuid"):
             result = _maybe_route_via_gateway(cfg)
 
         assert result.base_url.startswith("https://api.atlassian.com/")
+        assert cfg.base_url == "https://acme.atlassian.net"
 
 
 class TestConfigError:
     def test_missing_config_shows_setup_hint(self, capsys):
         with patch("sys.argv", ["confluence-export", "spaces"]), \
-             patch("confluence_export.cli.load_config", side_effect=ValueError("base_url is required")):
+             patch("confluence_export.cli.load_connection_profile", side_effect=ConnectionProfileError("site_url is required")):
             with pytest.raises(SystemExit):
                 main()
         err = capsys.readouterr().err
-        assert "base_url" in err
+        assert "site_url" in err
         assert "configure" in err  # suggests running configure

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -206,6 +206,15 @@ class TestConnectionProfile:
                 resolve_cloud=lambda url: None,
             )
 
+    def test_scoped_token_without_email_is_not_bearer(self):
+        with pytest.raises(ConnectionProfileError, match="email and API token"):
+            load_connection_profile(
+                site_url="https://x.atlassian.net",
+                api_token="ATATT3x_dummy=ADA123",
+                interactive=False,
+                resolve_cloud=lambda url: "cloud-123",
+            )
+
     def test_legacy_token_profile_resolution(self):
         profile = load_connection_profile(
             site_url="https://x.atlassian.net",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,12 +10,19 @@ from unittest.mock import patch
 import pytest
 
 from confluence_export.config import (
+    ApiDialect,
+    AuthConfig,
+    AuthMode,
     Config,
+    ConnectionProfileError,
+    find_local_config,
     gateway_url,
     is_atlassian_site_url,
     is_scoped_token,
+    load_connection_profile,
     load_config,
     save_config,
+    save_connection_config,
 )
 
 
@@ -154,6 +161,141 @@ class TestSaveConfig:
 
         assert path.exists()
         data = json.loads(path.read_text())
-        assert data["base_url"] == "https://x.atlassian.net"
-        assert data["api_token"] == "secret"
+        assert data["version"] == 2
+        assert data["site_url"] == "https://x.atlassian.net"
+        assert data["auth"]["token"] == "secret"
         assert oct(path.stat().st_mode & 0o777) == "0o600"
+
+
+class TestConnectionProfile:
+    def test_cookie_profile_resolution(self):
+        profile = load_connection_profile(
+            site_url="https://x.atlassian.net/",
+            cookie="tenant.session.token=abc",
+            interactive=False,
+        )
+
+        assert profile.site_url == "https://x.atlassian.net"
+        assert profile.api_base_url == "https://x.atlassian.net"
+        assert profile.auth_mode is AuthMode.COOKIE
+        assert profile.api_dialect is ApiDialect.COOKIE_V1
+        assert profile.cloud_id is None
+
+    def test_scoped_token_profile_resolution(self):
+        profile = load_connection_profile(
+            site_url="https://x.atlassian.net",
+            email="a@b.com",
+            api_token="ATATT3x_dummy=ADA123",
+            interactive=False,
+            resolve_cloud=lambda url: "cloud-123",
+        )
+
+        assert profile.site_url == "https://x.atlassian.net"
+        assert profile.cloud_id == "cloud-123"
+        assert profile.api_base_url == gateway_url("cloud-123")
+        assert profile.auth_mode is AuthMode.SCOPED_API_TOKEN
+        assert profile.api_dialect is ApiDialect.GATEWAY_V2
+
+    def test_scoped_token_failure_without_cloud_id(self):
+        with pytest.raises(ConnectionProfileError, match="cloud ID"):
+            load_connection_profile(
+                site_url="https://x.atlassian.net",
+                email="a@b.com",
+                api_token="ATATT3x_dummy=ADA123",
+                interactive=False,
+                resolve_cloud=lambda url: None,
+            )
+
+    def test_legacy_token_profile_resolution(self):
+        profile = load_connection_profile(
+            site_url="https://x.atlassian.net",
+            email="a@b.com",
+            api_token="legacy-token",
+            interactive=False,
+        )
+
+        assert profile.auth_mode is AuthMode.BASIC_API_TOKEN
+        assert profile.api_dialect is ApiDialect.CLOUD_V2
+        assert profile.api_base_url == "https://x.atlassian.net"
+
+    def test_bearer_profile_resolution(self):
+        profile = load_connection_profile(
+            site_url="https://x.atlassian.net",
+            api_token="pat-token",
+            interactive=False,
+        )
+
+        assert profile.auth_mode is AuthMode.BEARER_PAT
+        assert profile.api_dialect is ApiDialect.CLOUD_V2
+
+    def test_v1_config_migration_in_memory(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "base_url": "https://file.atlassian.net/",
+            "email": "file@test.com",
+            "api_token": "file-token",
+        }))
+        monkeypatch.setattr("confluence_export.config.config_path", lambda: config_file)
+
+        profile = load_connection_profile(interactive=False)
+
+        assert profile.site_url == "https://file.atlassian.net"
+        assert profile.api_base_url == "https://file.atlassian.net"
+        assert profile.auth_mode is AuthMode.BASIC_API_TOKEN
+
+    def test_v2_config_roundtrip(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.json"
+        save_connection_config(
+            site_url="https://x.atlassian.net",
+            auth=AuthConfig(type=AuthMode.COOKIE, cookie_header="session=abc"),
+            path=config_file,
+        )
+        monkeypatch.setattr("confluence_export.config.config_path", lambda: config_file)
+
+        profile = load_connection_profile(interactive=False)
+
+        assert profile.auth_mode is AuthMode.COOKIE
+        assert profile.api_dialect is ApiDialect.COOKIE_V1
+
+    def test_local_config_precedence(self, tmp_path, monkeypatch):
+        global_config = tmp_path / "global.json"
+        save_connection_config(
+            site_url="https://global.atlassian.net",
+            auth=AuthConfig(type=AuthMode.BEARER_PAT, token="global"),
+            path=global_config,
+        )
+        local_dir = tmp_path / "docs" / ".conex"
+        local_dir.mkdir(parents=True)
+        save_connection_config(
+            site_url="https://local.atlassian.net",
+            auth=AuthConfig(type=AuthMode.COOKIE, cookie_header="session=abc"),
+            path=local_dir / "config.json",
+        )
+        monkeypatch.setattr("confluence_export.config.config_path", lambda: global_config)
+
+        profile = load_connection_profile(start_dir=tmp_path / "docs" / "export", interactive=False)
+
+        assert profile.site_url == "https://local.atlassian.net"
+        assert profile.auth_mode is AuthMode.COOKIE
+        assert profile.config_source.endswith("docs/.conex/config.json")
+
+    def test_global_fallback(self, tmp_path, monkeypatch):
+        global_config = tmp_path / "global.json"
+        save_connection_config(
+            site_url="https://global.atlassian.net",
+            auth=AuthConfig(type=AuthMode.BEARER_PAT, token="global"),
+            path=global_config,
+        )
+        monkeypatch.setattr("confluence_export.config.config_path", lambda: global_config)
+
+        profile = load_connection_profile(start_dir=tmp_path / "docs", interactive=False)
+
+        assert profile.site_url == "https://global.atlassian.net"
+        assert profile.config_source == str(global_config)
+
+    def test_find_local_config_from_output_upward(self, tmp_path):
+        config_file = tmp_path / "docs" / ".conex" / "config.json"
+        config_file.parent.mkdir(parents=True)
+        config_file.write_text("{}")
+
+        assert find_local_config(tmp_path / "docs" / "export") == config_file

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -293,6 +293,137 @@ class TestConnectionProfile:
         assert profile.auth.email == "a@b.com"
         assert profile.auth.token == "token"
 
+    def test_explicit_cli_bearer_auth_type_is_not_reinferred_from_email(self):
+        profile = load_connection_profile(
+            site_url="https://x.atlassian.net",
+            auth_type=AuthMode.BEARER_PAT,
+            email="a@b.com",
+            api_token="pat-token",
+            interactive=False,
+        )
+
+        assert profile.auth_mode is AuthMode.BEARER_PAT
+        assert profile.api_dialect is ApiDialect.CLOUD_V2
+
+    def test_cli_token_override_reinfers_saved_scoped_as_basic(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.json"
+        save_connection_config(
+            site_url="https://x.atlassian.net",
+            cloud_id="cloud-old",
+            api_base_url=gateway_url("cloud-old"),
+            auth=AuthConfig(
+                type=AuthMode.SCOPED_API_TOKEN,
+                email="a@b.com",
+                token="ATATT3x_dummy=ADA123",
+            ),
+            path=config_file,
+        )
+        monkeypatch.setattr("confluence_export.config.config_path", lambda: config_file)
+
+        profile = load_connection_profile(api_token="legacy-token", interactive=False)
+
+        assert profile.auth_mode is AuthMode.BASIC_API_TOKEN
+        assert profile.api_dialect is ApiDialect.CLOUD_V2
+        assert profile.api_base_url == "https://x.atlassian.net"
+        assert profile.cloud_id is None
+        assert profile.auth.email == "a@b.com"
+        assert profile.auth.token == "legacy-token"
+
+    def test_cli_site_override_drops_cached_gateway_route(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.json"
+        save_connection_config(
+            site_url="https://old.atlassian.net",
+            cloud_id="cloud-old",
+            api_base_url=gateway_url("cloud-old"),
+            auth=AuthConfig(
+                type=AuthMode.SCOPED_API_TOKEN,
+                email="old@test.com",
+                token="ATATT3x_dummy=ADA123",
+            ),
+            path=config_file,
+        )
+        monkeypatch.setattr("confluence_export.config.config_path", lambda: config_file)
+
+        profile = load_connection_profile(
+            site_url="https://new.atlassian.net",
+            email="new@test.com",
+            api_token="legacy-token",
+            interactive=False,
+        )
+
+        assert profile.site_url == "https://new.atlassian.net"
+        assert profile.auth_mode is AuthMode.BASIC_API_TOKEN
+        assert profile.api_base_url == "https://new.atlassian.net"
+        assert profile.cloud_id is None
+
+    def test_cli_token_auth_override_drops_saved_cookie(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.json"
+        save_connection_config(
+            site_url="https://x.atlassian.net",
+            auth=AuthConfig(type=AuthMode.COOKIE, cookie_header="session=abc"),
+            path=config_file,
+        )
+        monkeypatch.setattr("confluence_export.config.config_path", lambda: config_file)
+
+        profile = load_connection_profile(
+            email="a@b.com",
+            api_token="legacy-token",
+            interactive=False,
+        )
+
+        assert profile.auth_mode is AuthMode.BASIC_API_TOKEN
+        assert profile.api_dialect is ApiDialect.CLOUD_V2
+        assert profile.auth.cookie_header == ""
+
+    def test_non_scoped_auth_rejects_gateway_api_base_url(self):
+        with pytest.raises(ConnectionProfileError, match="gateway api_base_url"):
+            load_connection_profile(
+                site_url="https://x.atlassian.net",
+                api_base_url=gateway_url("cloud-123"),
+                email="a@b.com",
+                api_token="legacy-token",
+                interactive=False,
+            )
+
+    def test_scoped_auth_rejects_non_gateway_api_base_url(self):
+        with pytest.raises(ConnectionProfileError, match="OAuth gateway URL"):
+            load_connection_profile(
+                site_url="https://x.atlassian.net",
+                api_base_url="https://x.atlassian.net",
+                email="a@b.com",
+                api_token="ATATT3x_dummy=ADA123",
+                interactive=False,
+                resolve_cloud=lambda url: "cloud-123",
+            )
+
+    def test_explicit_basic_auth_type_inherits_credentials_but_drops_gateway_route(
+        self, tmp_path, monkeypatch
+    ):
+        config_file = tmp_path / "config.json"
+        save_connection_config(
+            site_url="https://x.atlassian.net",
+            cloud_id="cloud-old",
+            api_base_url=gateway_url("cloud-old"),
+            auth=AuthConfig(
+                type=AuthMode.SCOPED_API_TOKEN,
+                email="a@b.com",
+                token="legacy-token",
+            ),
+            path=config_file,
+        )
+        monkeypatch.setattr("confluence_export.config.config_path", lambda: config_file)
+
+        profile = load_connection_profile(
+            auth_type=AuthMode.BASIC_API_TOKEN,
+            interactive=False,
+        )
+
+        assert profile.auth_mode is AuthMode.BASIC_API_TOKEN
+        assert profile.api_base_url == "https://x.atlassian.net"
+        assert profile.cloud_id is None
+        assert profile.auth.email == "a@b.com"
+        assert profile.auth.token == "legacy-token"
+
     def test_v1_config_migration_in_memory(self, tmp_path, monkeypatch):
         config_file = tmp_path / "config.json"
         config_file.write_text(json.dumps({

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,9 +18,11 @@ from confluence_export.config import (
     find_local_config,
     gateway_url,
     is_atlassian_site_url,
+    is_gateway_url,
     is_scoped_token,
     load_connection_profile,
     load_config,
+    resolve_cloud_id,
     save_config,
     save_connection_config,
 )
@@ -136,6 +138,9 @@ class TestIsAtlassianSiteUrl:
         assert is_atlassian_site_url("https://acme.atlassian.net") is True
         assert is_atlassian_site_url("https://acme.atlassian.net/") is True
 
+    def test_requires_https(self):
+        assert is_atlassian_site_url("http://acme.atlassian.net") is False
+
     def test_gateway_url(self):
         assert is_atlassian_site_url("https://api.atlassian.com/ex/confluence/abc") is False
 
@@ -150,6 +155,20 @@ class TestGatewayUrl:
     def test_format(self):
         cid = "6298609d-df12-4367-a2f6-2ead80671779"
         assert gateway_url(cid) == f"https://api.atlassian.com/ex/confluence/{cid}"
+
+    def test_detects_gateway_url(self):
+        assert is_gateway_url("https://api.atlassian.com/ex/confluence/abc") is True
+        assert is_gateway_url("https://acme.atlassian.net") is False
+
+
+class TestResolveCloudId:
+    def test_rejects_non_atlassian_urls_without_request(self):
+        with patch("confluence_export.config.requests.get") as mock_get:
+            assert resolve_cloud_id("http://169.254.169.254") is None
+            assert resolve_cloud_id("http://acme.atlassian.net") is None
+            assert resolve_cloud_id("https://wiki.example.com") is None
+
+        mock_get.assert_not_called()
 
 
 class TestSaveConfig:
@@ -206,6 +225,28 @@ class TestConnectionProfile:
                 resolve_cloud=lambda url: None,
             )
 
+    def test_gateway_site_url_is_rejected(self):
+        with pytest.raises(ConnectionProfileError, match="site_url"):
+            load_connection_profile(
+                site_url="https://api.atlassian.com/ex/confluence/cloud-123",
+                api_base_url="https://api.atlassian.com/ex/confluence/cloud-123",
+                email="a@b.com",
+                api_token="ATATT3x_dummy=ADA123",
+                interactive=False,
+            )
+
+    def test_scoped_token_to_internal_url_does_not_request_cloud_id(self):
+        with patch("confluence_export.config.requests.get") as mock_get:
+            with pytest.raises(ConnectionProfileError, match="cloud ID"):
+                load_connection_profile(
+                    site_url="http://169.254.169.254",
+                    email="a@b.com",
+                    api_token="ATATT3x_dummy=ADA123",
+                    interactive=False,
+                )
+
+        mock_get.assert_not_called()
+
     def test_scoped_token_without_email_is_not_bearer(self):
         with pytest.raises(ConnectionProfileError, match="email and API token"):
             load_connection_profile(
@@ -237,6 +278,21 @@ class TestConnectionProfile:
         assert profile.auth_mode is AuthMode.BEARER_PAT
         assert profile.api_dialect is ApiDialect.CLOUD_V2
 
+    def test_cli_email_reinfers_saved_bearer_as_basic(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.json"
+        save_connection_config(
+            site_url="https://x.atlassian.net",
+            auth=AuthConfig(type=AuthMode.BEARER_PAT, token="token"),
+            path=config_file,
+        )
+        monkeypatch.setattr("confluence_export.config.config_path", lambda: config_file)
+
+        profile = load_connection_profile(email="a@b.com", interactive=False)
+
+        assert profile.auth_mode is AuthMode.BASIC_API_TOKEN
+        assert profile.auth.email == "a@b.com"
+        assert profile.auth.token == "token"
+
     def test_v1_config_migration_in_memory(self, tmp_path, monkeypatch):
         config_file = tmp_path / "config.json"
         config_file.write_text(json.dumps({
@@ -252,6 +308,18 @@ class TestConnectionProfile:
         assert profile.api_base_url == "https://file.atlassian.net"
         assert profile.auth_mode is AuthMode.BASIC_API_TOKEN
 
+    def test_v1_gateway_base_url_fails_with_repair_instruction(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "base_url": "https://api.atlassian.com/ex/confluence/cloud-123",
+            "email": "file@test.com",
+            "api_token": "file-token",
+        }))
+        monkeypatch.setattr("confluence_export.config.config_path", lambda: config_file)
+
+        with pytest.raises(ConnectionProfileError, match="OAuth gateway"):
+            load_connection_profile(interactive=False)
+
     def test_v2_config_roundtrip(self, tmp_path, monkeypatch):
         config_file = tmp_path / "config.json"
         save_connection_config(
@@ -265,6 +333,14 @@ class TestConnectionProfile:
 
         assert profile.auth_mode is AuthMode.COOKIE
         assert profile.api_dialect is ApiDialect.COOKIE_V1
+
+    def test_save_rejects_gateway_site_url(self, tmp_path):
+        with pytest.raises(ConnectionProfileError, match="site_url"):
+            save_connection_config(
+                site_url="https://api.atlassian.com/ex/confluence/cloud-123",
+                auth=AuthConfig(type=AuthMode.SCOPED_API_TOKEN, email="a@b.com", token="tok"),
+                path=tmp_path / "config.json",
+            )
 
     def test_local_config_precedence(self, tmp_path, monkeypatch):
         global_config = tmp_path / "global.json"

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 from confluence_export.git import (
     _chunked_paths,
+    _is_secret_config_relpath,
     commit_export,
     commit_local_changes,
     ensure_repo,
@@ -57,6 +58,17 @@ class TestChunkedPaths:
         # 300 / ~108 → ~2 paths per batch → ~10 batches
         assert len(batches) >= 5
         assert [p for batch in batches for p in batch] == paths
+
+
+class TestSecretConfigPaths:
+    def test_matches_anything_under_conex(self):
+        assert _is_secret_config_relpath(".conex/config.json") is True
+        assert _is_secret_config_relpath(".conex/secrets.yaml") is True
+        assert _is_secret_config_relpath(".conex/profiles/prod.json") is True
+
+    def test_does_not_match_similar_names(self):
+        assert _is_secret_config_relpath("docs/conex/config.json") is False
+        assert _is_secret_config_relpath("docs/.conex-backup/config.json") is False
 
 
 class TestGitAvailable:
@@ -397,8 +409,8 @@ class TestCommitExport:
 
     def test_does_not_stage_local_conex_config(self, tmp_path):
         self._init_repo(tmp_path)
-        secret = tmp_path / ".conex" / "config.json"
-        secret.parent.mkdir()
+        secret = tmp_path / ".conex" / "profiles" / "prod.json"
+        secret.parent.mkdir(parents=True)
         secret.write_text('{"token": "secret"}')
         md = tmp_path / "Page.md"
         md.write_text("# Page")
@@ -407,7 +419,7 @@ class TestCommitExport:
 
         ls = subprocess.run(["git", "ls-files"], cwd=tmp_path, capture_output=True, text=True)
         assert "Page.md" in ls.stdout
-        assert ".conex/config.json" not in ls.stdout
+        assert ".conex/profiles/prod.json" not in ls.stdout
         status = subprocess.run(["git", "status", "--porcelain"], cwd=tmp_path, capture_output=True, text=True)
         assert "?? .conex/" in status.stdout
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -394,3 +394,63 @@ class TestCommitExport:
         ls = subprocess.run(["git", "ls-files"], cwd=tmp_path, capture_output=True, text=True)
         assert "old.md" not in ls.stdout
         assert "New.md" in ls.stdout
+
+    def test_does_not_stage_local_conex_config(self, tmp_path):
+        self._init_repo(tmp_path)
+        secret = tmp_path / ".conex" / "config.json"
+        secret.parent.mkdir()
+        secret.write_text('{"token": "secret"}')
+        md = tmp_path / "Page.md"
+        md.write_text("# Page")
+
+        assert commit_export(tmp_path, [md, secret], "TEST") is True
+
+        ls = subprocess.run(["git", "ls-files"], cwd=tmp_path, capture_output=True, text=True)
+        assert "Page.md" in ls.stdout
+        assert ".conex/config.json" not in ls.stdout
+        status = subprocess.run(["git", "status", "--porcelain"], cwd=tmp_path, capture_output=True, text=True)
+        assert "?? .conex/" in status.stdout
+
+    def test_commit_local_changes_unstages_tracked_conex_config(self, tmp_path):
+        self._init_repo(tmp_path)
+        secret = tmp_path / ".conex" / "config.json"
+        secret.parent.mkdir()
+        secret.write_text('{"token": "old"}')
+        md = tmp_path / "Page.md"
+        md.write_text("# Page")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "tracked"], cwd=tmp_path, capture_output=True)
+
+        secret.write_text('{"token": "new"}')
+        md.write_text("# Page v2")
+
+        assert commit_local_changes(tmp_path) is True
+
+        show = subprocess.run(
+            ["git", "show", "--name-only", "--format=", "HEAD"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+        assert "Page.md" in show.stdout
+        assert ".conex/config.json" not in show.stdout
+        status = subprocess.run(["git", "status", "--porcelain"], cwd=tmp_path, capture_output=True, text=True)
+        assert " M .conex/config.json" in status.stdout
+
+    def test_tracked_conex_config_not_removed_as_stale(self, tmp_path):
+        self._init_repo(tmp_path)
+        secret = tmp_path / ".conex" / "config.json"
+        secret.parent.mkdir()
+        secret.write_text('{"token": "old"}')
+        old = tmp_path / "Old.md"
+        old.write_text("# Old")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "first"], cwd=tmp_path, capture_output=True)
+
+        new = tmp_path / "New.md"
+        new.write_text("# New")
+        commit_export(tmp_path, [new], "TEST")
+
+        ls = subprocess.run(["git", "ls-files"], cwd=tmp_path, capture_output=True, text=True)
+        assert ".conex/config.json" in ls.stdout
+        assert "Old.md" not in ls.stdout

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -63,6 +63,7 @@ class TestChunkedPaths:
 class TestSecretConfigPaths:
     def test_matches_anything_under_conex(self):
         assert _is_secret_config_relpath(".conex/config.json") is True
+        assert _is_secret_config_relpath(".Conex/config.json") is True
         assert _is_secret_config_relpath(".conex/secrets.yaml") is True
         assert _is_secret_config_relpath(".conex/profiles/prod.json") is True
 


### PR DESCRIPTION
## Summary

Introduce an explicit connection/profile layer for Confluence connectivity so commands resolve a clear site URL, API base URL, cloud ID, auth mode, API dialect, and config source before export starts.

## What changed

- Added `ConnectionProfile`, `AuthMode`, `ApiDialect`, v2 config loading/saving, local `.conex/config.json` discovery, and v1 config migration.
- Reworked the client to use `profile.api_base_url` for requests while keeping `profile.site_url` for user-facing/exported links.
- Made cookie auth an explicit first-class mode mapped to Confluence REST v1 compatibility.
- Replaced persisted gateway URL mutation with scoped-token gateway derivation from site URL and cloud ID.
- Added export preflight checks for auth, gateway routing, space/page/attachment access, output writability, and git availability before output writes.
- Prevented export git commits from staging/removing local `.conex/` secret/config files.
- Updated README and tests for the new auth/config behavior.

## Review fixes

- Scoped-looking tokens pasted without an email during `configure` now fail clearly instead of being classified as cookie auth.
- Padded no-email PATs are no longer classified as cookie auth by the `=` heuristic.
- Cloud ID auto-resolution only probes HTTPS `*.atlassian.net` site URLs, avoiding requests to arbitrary user-controlled URLs.
- Gateway URLs are rejected as user-facing `site_url`/v1 `base_url`, with an instruction to rerun `configure` using the Confluence site URL.
- Saved bearer/PAT configs re-infer to API-token auth when CLI/env adds an email alongside the token, while explicit bearer auth remains bearer.
- Higher-priority site/auth credential overrides drop stale cached gateway routes and cloud IDs before auth is re-inferred.
- Explicit non-scoped auth overrides can inherit lower-priority credentials, but cannot retain scoped-token gateway routing.
- Scoped auth rejects non-gateway `api_base_url`; non-scoped auth rejects gateway `api_base_url`.
- Non-gateway profiles no longer retain stale `cloud_id` values.
- Config saves write through a `0600` temporary file and atomic replace.
- `.conex` git protection covers the whole directory at any depth, case-insensitively.
- `api_flavor` is derived from `api_dialect` to avoid parallel mutable state.
- Removed stale gateway-routing compatibility helpers from the CLI path.

## Impact

Users get a compact preflight summary showing exactly which config, auth mode, API mode, site URL, cloud ID, and output path are being used. Non-interactive runs now fail clearly instead of prompting for fallback credentials.

## Validation

- `uv run pytest` -> `342 passed`
- `git diff --check` -> clean
- Narrow Claude `/review` of config overlay/auth inference/gateway routing -> no actionable security or correctness regressions
