### PR TITLE
[codex] add export diagnostics quality gate

### DIFF
--- a/src/confluence_export/cli.py
+++ b/src/confluence_export/cli.py
@@ -37,7 +37,7 @@ from confluence_export.tree import (
     page_path,
 )
 from confluence_export.exporter import Exporter
-from confluence_export.types import Space
+from confluence_export.types import ExportDiagnostic, Space
 
 
 def _is_auth_error(exc: Exception) -> int | None:
@@ -139,6 +139,7 @@ def main() -> None:
     export_p.add_argument("--include-html", action="store_true", help="Save raw HTML alongside markdown")
     export_p.add_argument("--include-archived", action="store_true", help="Include archived pages (skipped by default)")
     export_p.add_argument("--no-git", action="store_true", help="Skip automatic git versioning")
+    export_p.add_argument("--strict", action="store_true", help="Fail when export diagnostics include warnings")
     export_p.add_argument(
         "--no-author-lookup",
         action="store_true",
@@ -208,6 +209,7 @@ def main() -> None:
                 debug=args.include_html,
                 include_archived=args.include_archived,
                 no_git=args.no_git,
+                strict=args.strict,
                 no_author_lookup=args.no_author_lookup,
             )
         case "diff":
@@ -559,6 +561,7 @@ def _cmd_export(
     debug: bool = False,
     include_archived: bool = False,
     no_git: bool = False,
+    strict: bool = False,
     no_author_lookup: bool = False,
 ) -> None:
     """Export page tree as LLM-ready markdown."""
@@ -613,13 +616,86 @@ def _cmd_export(
         include_archived=include_archived,
     )
 
+    diagnostics = getattr(result, "diagnostics", [])
+    has_errors = any(d.severity == "error" for d in diagnostics)
+    has_warnings = any(d.severity == "warning" for d in diagnostics)
+    blocking_diagnostics = has_errors or (strict and has_warnings)
+
     # Git: post-export
-    if use_git and result.written_files:
+    git_committed = False
+    if use_git and result.written_files and not blocking_diagnostics:
         from confluence_export.git import commit_export
 
-        commit_export(out, result.written_files, space_key)
+        git_committed = commit_export(out, result.written_files, space_key)
 
-    print(f"\nExported {result.count} page(s) to {out.resolve()}")
+    _print_export_summary(
+        pages_written=result.count,
+        output_dir=out.resolve(),
+        diagnostics=diagnostics,
+        git_enabled=use_git,
+        git_committed=git_committed,
+        git_blocked=bool(use_git and blocking_diagnostics),
+        validation_failed=blocking_diagnostics,
+    )
+    if blocking_diagnostics:
+        sys.exit(1)
+
+
+def _print_export_summary(
+    *,
+    pages_written: int,
+    output_dir: Path,
+    diagnostics: list[ExportDiagnostic],
+    git_enabled: bool,
+    git_committed: bool,
+    git_blocked: bool,
+    validation_failed: bool,
+) -> None:
+    errors = [d for d in diagnostics if d.severity == "error"]
+    warnings = [d for d in diagnostics if d.severity == "warning"]
+    infos = [d for d in diagnostics if d.severity == "info"]
+
+    if validation_failed:
+        print(
+            f"\nExport validation failed: {len(errors)} error(s), "
+            f"{len(warnings)} warning(s)"
+        )
+    else:
+        print(f"\nExported {pages_written} page(s) to {output_dir}")
+        print(f"Diagnostics: {len(errors)} error(s), {len(warnings)} warning(s)")
+        if infos:
+            print(f"Info: {len(infos)} informational diagnostic(s)")
+
+    if git_enabled:
+        if git_blocked:
+            print("Git: not committed")
+        elif git_committed:
+            print("Git: committed")
+        else:
+            print("Git: no changes")
+    else:
+        print("Git: skipped")
+
+    if errors:
+        print("\nErrors:")
+        for line in _diagnostic_lines(errors):
+            print(f"  - {line}")
+    if warnings:
+        print("\nWarnings:")
+        for line in _diagnostic_lines(warnings):
+            print(f"  - {line}")
+
+
+def _diagnostic_lines(diagnostics: list[ExportDiagnostic], limit: int = 8) -> list[str]:
+    lines = []
+    for diagnostic in diagnostics[:limit]:
+        page = f'Page "{diagnostic.page_title}": ' if diagnostic.page_title else ""
+        path = f" ({diagnostic.path})" if diagnostic.path else ""
+        lines.append(f"{page}{diagnostic.message}{path}")
+    remaining = len(diagnostics) - limit
+    if remaining > 0:
+        lines.append(f"... {remaining} more")
+    return lines
 
 
 def _cmd_diff(

--- a/src/confluence_export/converter.py
+++ b/src/confluence_export/converter.py
@@ -5,17 +5,89 @@ from __future__ import annotations
 import re
 
 import yaml
-from bs4 import BeautifulSoup, NavigableString, Tag
+from bs4 import BeautifulSoup, Tag
+from dataclasses import dataclass, field
 from markdownify import markdownify as md
+from pathlib import Path
 
+from confluence_export.drawio import drawio_name_candidates, find_drawio_attachment
 from confluence_export.media import MEDIA_DIR_NAME
 
 from typing import Callable
 
-from confluence_export.types import Attachment, Page
+from confluence_export.types import Attachment, ExportDiagnostic, Page
 
 # Optional callback: account_id -> {"displayName": ..., "email": ...} or None
 UserResolver = Callable[[str], dict | None] | None
+
+
+@dataclass
+class MacroNeeds:
+    """Resources a macro may need before rendering."""
+
+    drawio_names: set[str] = field(default_factory=set)
+
+
+@dataclass
+class ConversionContext:
+    """State shared by macro handlers during one page conversion."""
+
+    page: Page | None
+    attachments: list[Attachment]
+    user_resolver: UserResolver = None
+    diagnostics: list[ExportDiagnostic] = field(default_factory=list)
+    drawio_rendered: dict[str, Path] = field(default_factory=dict)
+    drawio_failures: dict[str, str] = field(default_factory=dict)
+    render_drawio: bool = True
+    download_media: bool = True
+
+    def add_diagnostic(
+        self,
+        severity: str,
+        code: str,
+        message: str,
+        path: Path | None = None,
+    ) -> None:
+        self.diagnostics.append(
+            ExportDiagnostic(
+                severity=severity,  # type: ignore[arg-type]
+                page_id=self.page.id if self.page else None,
+                page_title=self.page.title if self.page else None,
+                code=code,
+                message=message,
+                path=path,
+            )
+        )
+
+    def drawio_png_for(self, diagram_name: str) -> Path | None:
+        for candidate in drawio_name_candidates(diagram_name):
+            if candidate in self.drawio_rendered:
+                return self.drawio_rendered[candidate]
+        return None
+
+    def drawio_failure_for(self, diagram_name: str) -> str | None:
+        for candidate in drawio_name_candidates(diagram_name):
+            if candidate in self.drawio_failures:
+                return self.drawio_failures[candidate]
+        return None
+
+    def drawio_source_for(self, diagram_name: str) -> Attachment | None:
+        return find_drawio_attachment(self.attachments, diagram_name)
+
+
+class MacroHandler:
+    """Base class for Confluence structured macro handlers."""
+
+    names: set[str] = set()
+
+    def inspect(self, macro: Tag, context: ConversionContext) -> MacroNeeds:
+        return MacroNeeds()
+
+    def render(
+        self, soup: BeautifulSoup, macro: Tag, context: ConversionContext
+    ) -> None:
+        raise NotImplementedError
+
 
 # Confluence emoticon name -> Unicode emoji
 _EMOTICON_MAP = {
@@ -65,12 +137,27 @@ def convert_page(
     path: str,
     attachments: list[Attachment] | None = None,
     user_resolver: UserResolver = None,
+    diagnostics: list[ExportDiagnostic] | None = None,
+    drawio_rendered: dict[str, Path] | None = None,
+    drawio_failures: dict[str, str] | None = None,
+    render_drawio: bool = True,
+    download_media: bool = True,
 ) -> str:
     """Convert a Confluence page to markdown with YAML frontmatter."""
     html = page.body_storage
 
     # Pre-process Confluence-specific HTML
-    html = _preprocess_html(html, attachments or [], user_resolver=user_resolver)
+    html = _preprocess_html(
+        html,
+        attachments or [],
+        user_resolver=user_resolver,
+        page=page,
+        diagnostics=diagnostics,
+        drawio_rendered=drawio_rendered,
+        drawio_failures=drawio_failures,
+        render_drawio=render_drawio,
+        download_media=download_media,
+    )
 
     # Convert to markdown using markdownify
     markdown = md(
@@ -135,9 +222,26 @@ def _preprocess_html(
     html: str,
     attachments: list[Attachment],
     user_resolver: UserResolver = None,
+    *,
+    page: Page | None = None,
+    diagnostics: list[ExportDiagnostic] | None = None,
+    drawio_rendered: dict[str, Path] | None = None,
+    drawio_failures: dict[str, str] | None = None,
+    render_drawio: bool = True,
+    download_media: bool = True,
 ) -> str:
     """Pre-process Confluence storage HTML before markdownify."""
     soup = BeautifulSoup(html, "html.parser")
+    context = ConversionContext(
+        page=page,
+        attachments=attachments,
+        user_resolver=user_resolver,
+        diagnostics=diagnostics if diagnostics is not None else [],
+        drawio_rendered=drawio_rendered or {},
+        drawio_failures=drawio_failures or {},
+        render_drawio=render_drawio,
+        download_media=download_media,
+    )
 
     # Build attachment lookup
     attach_map = {a.title: a for a in attachments}
@@ -208,23 +312,6 @@ def _preprocess_html(
         else:
             tag.decompose()
 
-    # --- User mentions (ri:user inside ac:link or standalone) ---
-    for user_tag in list(soup.find_all("ri:user")):
-        account_id = user_tag.get("ri:account-id", "")
-        parent_link = user_tag.find_parent("ac:link")
-        display_name = None
-        if account_id and user_resolver:
-            info = user_resolver(account_id)
-            if info:
-                display_name = info.get("displayName")
-        name = display_name or account_id
-        if parent_link:
-            span = soup.new_tag("span")
-            span.string = f"@{name}"
-            parent_link.replace_with(span)
-        else:
-            user_tag.replace_with(f"@{name}")
-
     # --- ac:image ---
     for img_tag in list(soup.find_all("ac:image")):
         _replace_ac_image(soup, img_tag, attach_map)
@@ -234,41 +321,11 @@ def _preprocess_html(
         _replace_ac_link(soup, link_tag, attach_map)
 
     # --- Structured macros ---
-    for macro in list(soup.find_all("ac:structured-macro")):
-        macro_name = macro.get("ac:name", "")
-        if macro_name in ("info", "tip", "note", "warning", "panel"):
-            _convert_panel(soup, macro, macro_name)
-        elif macro_name == "code":
-            _convert_code_block(soup, macro)
-        elif macro_name in ("drawio", "inc-drawio"):
-            _convert_drawio_placeholder(soup, macro)
-        elif macro_name == "profile":
-            _convert_profile(soup, macro, user_resolver)
-        elif macro_name == "status":
-            _convert_status(soup, macro)
-        elif macro_name == "expand":
-            _convert_expand(soup, macro)
-        elif macro_name == "jira":
-            _convert_jira(soup, macro)
-        elif macro_name == "view-file":
-            _convert_view_file(soup, macro)
-        elif macro_name in ("excerpt", "section", "column"):
-            # Pure layout/wrapper — keep body, drop wrapper, no placeholder
-            body = macro.find("ac:rich-text-body")
-            if body:
-                body.unwrap()
-            macro.unwrap()
-        else:
-            # Default: if body content exists, preserve it. Otherwise the
-            # macro is dynamic/widget-like (toc, children, recently-updated,
-            # include, future Confluence additions) — emit a visible
-            # placeholder so the reader knows something was there instead
-            # of silently dropping it.
-            body = macro.find("ac:rich-text-body")
-            if body and body.get_text(strip=True):
-                macro.replace_with(*list(body.children))
-            else:
-                _convert_dynamic_macro_placeholder(soup, macro, macro_name)
+    _handle_structured_macros(soup, context)
+
+    # --- User mentions (ri:user inside ac:link or standalone) ---
+    for user_tag in list(soup.find_all("ri:user")):
+        _replace_user_mention(soup, user_tag, user_resolver)
 
     # --- Inline comment markers: just unwrap ---
     for tag in list(soup.find_all("ac:inline-comment-marker")):
@@ -283,6 +340,20 @@ def _preprocess_html(
         tag.unwrap()
 
     return str(soup)
+
+
+def inspect_macros(html: str, attachments: list[Attachment]) -> MacroNeeds:
+    """Inspect structured macros for resources needed before conversion."""
+    soup = BeautifulSoup(html, "html.parser")
+    context = ConversionContext(page=None, attachments=attachments)
+    result = MacroNeeds()
+    handlers = _macro_handler_registry()
+    fallback = DynamicPlaceholderHandler()
+    for macro in list(soup.find_all("ac:structured-macro")):
+        handler = handlers.get(macro.get("ac:name", ""), fallback)
+        needs = handler.inspect(macro, context)
+        result.drawio_names.update(needs.drawio_names)
+    return result
 
 
 def _replace_ac_image(soup: BeautifulSoup, tag: Tag, attach_map: dict[str, Attachment]) -> None:
@@ -339,6 +410,315 @@ def _replace_ac_link(soup: BeautifulSoup, tag: Tag, attach_map: dict[str, Attach
     tag.decompose()
 
 
+def _replace_user_mention(
+    soup: BeautifulSoup, user_tag: Tag, user_resolver: UserResolver
+) -> None:
+    """Replace a Confluence user reference with a stable text mention."""
+    account_id = user_tag.get("ri:account-id", "")
+    parent_link = user_tag.find_parent("ac:link")
+    mention = _resolve_mention_text(account_id, user_resolver)
+    span = soup.new_tag("span")
+    span.string = mention
+    if parent_link:
+        parent_link.replace_with(span)
+    else:
+        user_tag.replace_with(span)
+
+
+def _resolve_mention_text(account_id: str, user_resolver: UserResolver) -> str:
+    display_name = None
+    if account_id and user_resolver:
+        info = user_resolver(account_id)
+        if info:
+            display_name = info.get("displayName")
+    name = display_name or account_id
+    return f"@{name}" if name else "@unknown"
+
+
+def _handle_structured_macros(
+    soup: BeautifulSoup, context: ConversionContext
+) -> None:
+    handlers = _macro_handler_registry()
+    fallback = DynamicPlaceholderHandler()
+    for macro in list(soup.find_all("ac:structured-macro")):
+        if macro.parent is None:
+            continue
+        macro_name = macro.get("ac:name", "")
+        handler = handlers.get(macro_name, fallback)
+        handler.render(soup, macro, context)
+
+
+def _macro_handler_registry() -> dict[str, MacroHandler]:
+    return _MACRO_HANDLER_REGISTRY
+
+
+class ProfileHandler(MacroHandler):
+    names = {"profile", "profile-picture"}
+
+    def render(
+        self, soup: BeautifulSoup, macro: Tag, context: ConversionContext
+    ) -> None:
+        user_tag = macro.find("ri:user")
+        account_id = user_tag.get("ri:account-id", "") if user_tag else ""
+
+        if macro.get("ac:name", "") == "profile-picture":
+            span = soup.new_tag("span")
+            span.string = _resolve_mention_text(account_id, context.user_resolver)
+            macro.replace_with(span)
+            return
+
+        user_info = (
+            context.user_resolver(account_id)
+            if account_id and context.user_resolver
+            else None
+        )
+        li = soup.new_tag("li")
+        if user_info:
+            name = user_info.get("displayName", account_id)
+            email = user_info.get("email")
+            li.string = f"{name} ({email})" if email else name
+        elif account_id:
+            li.string = f"user:{account_id}"
+        else:
+            li.string = "Unknown user"
+
+        macro.replace_with(li)
+
+
+class DrawioHandler(MacroHandler):
+    names = {"drawio", "inc-drawio"}
+
+    def inspect(self, macro: Tag, context: ConversionContext) -> MacroNeeds:
+        diagram_name = _macro_parameter_text(macro, "diagramName") or "diagram"
+        return MacroNeeds(drawio_names={diagram_name})
+
+    def render(
+        self, soup: BeautifulSoup, macro: Tag, context: ConversionContext
+    ) -> None:
+        diagram_name = _macro_parameter_text(macro, "diagramName") or "diagram"
+        source = context.drawio_source_for(diagram_name)
+        source_name = source.title if source else _drawio_source_name(diagram_name)
+        png_path = context.drawio_png_for(diagram_name)
+
+        if png_path:
+            nodes = _drawio_image_nodes(soup, diagram_name, source_name, png_path)
+            macro.replace_with(*nodes)
+            return
+
+        reason = context.drawio_failure_for(diagram_name)
+        severity = "warning"
+        code = "drawio_render_failed"
+        if not context.render_drawio:
+            severity = "info"
+            code = "drawio_render_disabled"
+            reason = "draw.io rendering disabled"
+        elif not context.download_media:
+            severity = "info"
+            code = "drawio_media_disabled"
+            reason = "media download disabled"
+        elif not source:
+            code = "drawio_source_missing"
+            reason = "source attachment not found"
+        else:
+            reason = reason or "render failed"
+
+        context.add_diagnostic(
+            severity,
+            code,
+            f"Draw.io diagram could not be rendered: {diagram_name} ({reason})",
+        )
+        node = _drawio_fallback_node(soup, diagram_name, source_name, source is not None)
+        macro.replace_with(node)
+
+
+class DrawioSketchHandler(MacroHandler):
+    names = {"drawio-sketch"}
+
+    def render(
+        self, soup: BeautifulSoup, macro: Tag, context: ConversionContext
+    ) -> None:
+        context.add_diagnostic(
+            "warning",
+            "unsupported_drawio_sketch",
+            "Unsupported drawio-sketch macro preserved as placeholder.",
+        )
+        node = _placeholder_node(
+            soup,
+            "Unsupported drawio-sketch macro preserved as placeholder.",
+        )
+        macro.replace_with(node)
+
+
+class PanelHandler(MacroHandler):
+    names = {"info", "tip", "note", "warning", "panel"}
+
+    def render(
+        self, soup: BeautifulSoup, macro: Tag, context: ConversionContext
+    ) -> None:
+        _convert_panel(soup, macro, macro.get("ac:name", "panel"))
+
+
+class CodeHandler(MacroHandler):
+    names = {"code"}
+
+    def render(
+        self, soup: BeautifulSoup, macro: Tag, context: ConversionContext
+    ) -> None:
+        _convert_code_block(soup, macro)
+
+
+class StatusHandler(MacroHandler):
+    names = {"status"}
+
+    def render(
+        self, soup: BeautifulSoup, macro: Tag, context: ConversionContext
+    ) -> None:
+        _convert_status(soup, macro)
+
+
+class ExpandHandler(MacroHandler):
+    names = {"expand"}
+
+    def render(
+        self, soup: BeautifulSoup, macro: Tag, context: ConversionContext
+    ) -> None:
+        _convert_expand(soup, macro)
+
+
+class JiraHandler(MacroHandler):
+    names = {"jira"}
+
+    def render(
+        self, soup: BeautifulSoup, macro: Tag, context: ConversionContext
+    ) -> None:
+        _convert_jira(soup, macro)
+
+
+class ViewFileHandler(MacroHandler):
+    names = {"view-file"}
+
+    def render(
+        self, soup: BeautifulSoup, macro: Tag, context: ConversionContext
+    ) -> None:
+        _convert_view_file(soup, macro)
+
+
+class LayoutWrapperHandler(MacroHandler):
+    names = {"excerpt", "section", "column"}
+
+    def render(
+        self, soup: BeautifulSoup, macro: Tag, context: ConversionContext
+    ) -> None:
+        body = macro.find("ac:rich-text-body")
+        if body:
+            body.unwrap()
+        macro.unwrap()
+
+
+_MACRO_HANDLER_REGISTRY: dict[str, MacroHandler] = {
+    name: handler
+    for handler in (
+        ProfileHandler(),
+        DrawioHandler(),
+        DrawioSketchHandler(),
+        PanelHandler(),
+        CodeHandler(),
+        StatusHandler(),
+        ExpandHandler(),
+        JiraHandler(),
+        ViewFileHandler(),
+        LayoutWrapperHandler(),
+    )
+    for name in handler.names
+}
+
+
+class DynamicPlaceholderHandler(MacroHandler):
+    names: set[str] = set()
+
+    def render(
+        self, soup: BeautifulSoup, macro: Tag, context: ConversionContext
+    ) -> None:
+        macro_name = macro.get("ac:name", "")
+        body = macro.find("ac:rich-text-body")
+        if body and body.get_text(strip=True):
+            context.add_diagnostic(
+                "warning",
+                "unsupported_macro_body_preserved",
+                f"Unsupported Confluence macro body preserved visibly: {macro_name or 'unnamed'}",
+            )
+            macro.replace_with(*list(body.children))
+            return
+
+        context.add_diagnostic(
+            "warning",
+            "unsupported_macro",
+            f"Unsupported Confluence macro preserved visibly: {macro_name or 'unnamed'}",
+        )
+        _convert_dynamic_macro_placeholder(soup, macro, macro_name)
+
+
+def _macro_parameter_text(macro: Tag, name: str) -> str:
+    param = macro.find("ac:parameter", attrs={"ac:name": name})
+    return param.get_text().strip() if param else ""
+
+
+def _drawio_source_name(diagram_name: str) -> str:
+    candidates = drawio_name_candidates(diagram_name)
+    for candidate in candidates:
+        if candidate.endswith(".drawio"):
+            return candidate
+    return f"{diagram_name}.drawio"
+
+
+def _drawio_image_nodes(
+    soup: BeautifulSoup, diagram_name: str, source_name: str, png_path: Path
+) -> list[Tag]:
+    img = soup.new_tag(
+        "img",
+        src=f"{MEDIA_DIR_NAME}/{png_path.name}",
+        alt=source_name or diagram_name,
+    )
+    p = soup.new_tag("p")
+    em = soup.new_tag("em")
+    em.append("Draw.io source: ")
+    a = soup.new_tag("a", href=f"{MEDIA_DIR_NAME}/{source_name}")
+    a.string = source_name
+    em.append(a)
+    p.append(em)
+    return [img, p]
+
+
+def _drawio_fallback_node(
+    soup: BeautifulSoup,
+    diagram_name: str,
+    source_name: str,
+    has_source: bool,
+) -> Tag:
+    if has_source:
+        text = f"Draw.io diagram could not be rendered: {diagram_name} - source attachment preserved at "
+        p = soup.new_tag("p")
+        em = soup.new_tag("em")
+        em.append(text)
+        a = soup.new_tag("a", href=f"{MEDIA_DIR_NAME}/{source_name}")
+        a.string = f"{MEDIA_DIR_NAME}/{source_name}"
+        em.append(a)
+        p.append(em)
+        return p
+    return _placeholder_node(
+        soup,
+        f"Draw.io diagram could not be rendered: {diagram_name} - source attachment not found.",
+    )
+
+
+def _placeholder_node(soup: BeautifulSoup, message: str) -> Tag:
+    em = soup.new_tag("em")
+    em.string = f"[{message}]"
+    p = soup.new_tag("p")
+    p.append(em)
+    return p
+
+
 def _convert_panel(soup: BeautifulSoup, macro: Tag, macro_name: str) -> None:
     """Convert info/tip/note/warning/panel to blockquotes."""
     title_param = macro.find("ac:parameter", attrs={"ac:name": "title"})
@@ -360,28 +740,6 @@ def _convert_panel(soup: BeautifulSoup, macro: Tag, macro_name: str) -> None:
             blockquote.append(element)
 
     macro.replace_with(blockquote)
-
-
-def _convert_profile(soup: BeautifulSoup, macro: Tag, user_resolver: UserResolver) -> None:
-    """Convert profile macro to a user mention as a list item."""
-    user_tag = macro.find("ri:user")
-    account_id = user_tag.get("ri:account-id", "") if user_tag else ""
-
-    user_info = None
-    if account_id and user_resolver:
-        user_info = user_resolver(account_id)
-
-    li = soup.new_tag("li")
-    if user_info:
-        name = user_info.get("displayName", account_id)
-        email = user_info.get("email")
-        if email:
-            li.string = f"{name} ({email})"
-        else:
-            li.string = name
-    else:
-        li.string = f"user:{account_id}" if account_id else "Unknown user"
-    macro.replace_with(li)
 
 
 def _convert_status(soup: BeautifulSoup, macro: Tag) -> None:
@@ -474,20 +832,10 @@ def _convert_view_file(soup: BeautifulSoup, macro: Tag) -> None:
         macro.decompose()
 
 
-def _convert_drawio_placeholder(soup: BeautifulSoup, macro: Tag) -> None:
-    """Replace drawio/inc-drawio macro with a placeholder."""
-    name_param = macro.find("ac:parameter", attrs={"ac:name": "diagramName"})
-    diagram_name = name_param.get_text().strip() if name_param else "diagram"
-
-    placeholder = soup.new_tag("p")
-    placeholder.string = f"[drawio:{diagram_name}]"
-    macro.replace_with(placeholder)
-
-
 def _convert_dynamic_macro_placeholder(
     soup: BeautifulSoup, macro: Tag, macro_name: str
 ) -> None:
-    """Emit a visible italic placeholder for content-less macros.
+    """Emit a visible italic placeholder for unsupported dynamic macros.
 
     Captures the macro name plus any non-default parameters (resolving page
     references) so the reader sees what was there without the export trying
@@ -510,4 +858,10 @@ def _convert_dynamic_macro_placeholder(
     em.string = f"[Confluence dynamic content: {macro_name or 'unnamed'}{suffix}]"
     p = soup.new_tag("p")
     p.append(em)
+    body = macro.find("ac:rich-text-body")
+    if body and list(body.children):
+        children = list(body.children)
+        macro.replace_with(p, *children)
+        return
+
     macro.replace_with(p)

--- a/src/confluence_export/drawio.py
+++ b/src/confluence_export/drawio.py
@@ -2,16 +2,24 @@
 
 from __future__ import annotations
 
-import re
 import shutil
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
-from confluence_export.media import MEDIA_DIR_NAME
+from bs4 import BeautifulSoup
 
 from confluence_export.types import Attachment
+
+
+@dataclass(frozen=True)
+class DrawioMacroRef:
+    """Draw.io-like macro reference discovered in Confluence storage HTML."""
+
+    macro_name: str
+    diagram_name: str
 
 
 def find_drawio_attachments(attachments: list[Attachment]) -> list[Attachment]:
@@ -25,14 +33,52 @@ def find_drawio_attachments(attachments: list[Attachment]) -> list[Attachment]:
     ]
 
 
+def find_drawio_macro_refs(html: str) -> list[DrawioMacroRef]:
+    """Extract draw.io macro references from Confluence storage HTML."""
+    soup = BeautifulSoup(html, "html.parser")
+    refs: list[DrawioMacroRef] = []
+    for macro in soup.find_all("ac:structured-macro"):
+        macro_name = macro.get("ac:name", "")
+        if macro_name not in {"drawio", "inc-drawio", "drawio-sketch"}:
+            continue
+        name_param = macro.find("ac:parameter", attrs={"ac:name": "diagramName"})
+        diagram_name = name_param.get_text().strip() if name_param else macro_name
+        refs.append(DrawioMacroRef(macro_name=macro_name, diagram_name=diagram_name))
+    return refs
+
+
 def detect_drawio_macros(html: str) -> list[str]:
     """Extract diagramName values from drawio structured macros in HTML."""
-    pattern = re.compile(
-        r'<ac:structured-macro[^>]*ac:name="drawio"[^>]*>.*?'
-        r'<ac:parameter\s+ac:name="diagramName"[^>]*>([^<]+)</ac:parameter>',
-        re.DOTALL,
-    )
-    return pattern.findall(html)
+    return [
+        ref.diagram_name
+        for ref in find_drawio_macro_refs(html)
+        if ref.macro_name in {"drawio", "inc-drawio"}
+    ]
+
+
+def drawio_name_candidates(diagram_name: str) -> list[str]:
+    """Return likely attachment names for a draw.io macro diagram name."""
+    name = diagram_name.strip()
+    if not name:
+        return []
+    candidates = [name]
+    if name.endswith(".drawio"):
+        candidates.append(name.removesuffix(".drawio"))
+    else:
+        candidates.append(f"{name}.drawio")
+    return list(dict.fromkeys(candidates))
+
+
+def find_drawio_attachment(
+    attachments: list[Attachment], diagram_name: str
+) -> Attachment | None:
+    """Find the source attachment referenced by a draw.io macro."""
+    drawio_attachments = find_drawio_attachments(attachments)
+    for candidate in drawio_name_candidates(diagram_name):
+        for att in drawio_attachments:
+            if att.title == candidate:
+                return att
+    return None
 
 
 def find_drawio_cli() -> str | None:
@@ -111,30 +157,3 @@ def render_drawio_to_png(drawio_path: Path, output_path: Path | None = None) -> 
 
     print(f"  Warning: draw.io produced no output for {drawio_path.name}", file=sys.stderr)
     return None
-
-
-def replace_drawio_placeholders(
-    markdown: str,
-    rendered_diagrams: dict[str, Path],
-    media_dir_name: str = MEDIA_DIR_NAME,
-) -> str:
-    """Replace [drawio:name] placeholders in markdown with image + source link."""
-    for diagram_name, png_path in rendered_diagrams.items():
-        bare_name = diagram_name.removesuffix(".drawio")
-        placeholder = f"[drawio:{diagram_name}]"
-        if placeholder not in markdown:
-            placeholder = f"[drawio:{bare_name}]"
-            if placeholder not in markdown:
-                continue
-
-        drawio_filename = diagram_name if diagram_name.endswith(".drawio") else f"{diagram_name}.drawio"
-        png_filename = png_path.name
-
-        replacement = (
-            f"![{bare_name}]"
-            f"({media_dir_name}/{png_filename})\n"
-            f"*Draw.io source: [{drawio_filename}]({media_dir_name}/{drawio_filename})*"
-        )
-        markdown = markdown.replace(placeholder, replacement)
-
-    return markdown

--- a/src/confluence_export/exporter.py
+++ b/src/confluence_export/exporter.py
@@ -5,16 +5,14 @@ from __future__ import annotations
 import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass, field
 from pathlib import Path
 
 from confluence_export.cache import CacheStore
 from confluence_export.client import ConfluenceClient
-from confluence_export.converter import convert_page, sanitize_filename
+from confluence_export.converter import convert_page, inspect_macros, sanitize_filename
 from confluence_export.drawio import (
-    find_drawio_attachments,
+    find_drawio_attachment,
     render_drawio_to_png,
-    replace_drawio_placeholders,
 )
 from confluence_export.media import download_attachments, ensure_media_dir
 from confluence_export.tree import (
@@ -23,15 +21,35 @@ from confluence_export.tree import (
     format_tree,
     page_path,
 )
-from confluence_export.types import Attachment, CachedSpace, Page, PageNode, Space
+from confluence_export.types import (
+    Attachment,
+    CachedSpace,
+    ExportDiagnostic,
+    ExportReport,
+    Page,
+    PageNode,
+    Space,
+)
+from confluence_export.validation import validate_markdown
 
 
-@dataclass
-class ExportResult:
-    """Result of an export operation."""
+class ExportResult(ExportReport):
+    """Backward-compatible alias for the export report shape."""
 
-    count: int = 0
-    written_files: list[Path] = field(default_factory=list)
+    def __init__(
+        self,
+        count: int = 0,
+        written_files: list[Path] | None = None,
+        pages_written: int | None = None,
+        files_written: int = 0,
+        diagnostics: list[ExportDiagnostic] | None = None,
+    ):
+        super().__init__(
+            pages_written=count if pages_written is None else pages_written,
+            files_written=files_written,
+            diagnostics=diagnostics or [],
+            written_files=written_files or [],
+        )
 
 
 class Exporter:
@@ -64,6 +82,46 @@ class Exporter:
         if account_id not in self._user_cache:
             self._user_cache[account_id] = self.client.get_user_info(account_id)
         return self._user_cache[account_id]
+
+    def _render_drawio_artifacts(
+        self,
+        page: Page,
+        page_dir: Path,
+        attachments: list[Attachment],
+        written: list[Path],
+    ) -> tuple[dict[str, Path], dict[str, str], set[Path]]:
+        """Render draw.io source attachments before markdown conversion."""
+        rendered: dict[str, Path] = {}
+        failures: dict[str, str] = {}
+        generated_media: set[Path] = set()
+        needs = inspect_macros(page.body_storage, attachments)
+        if not needs.drawio_names or not self.render_drawio or not self.download_media:
+            return rendered, failures, generated_media
+
+        media_dir = ensure_media_dir(page_dir)
+        for diagram_name in sorted(needs.drawio_names):
+            source = find_drawio_attachment(attachments, diagram_name)
+            if source is None:
+                failures[diagram_name] = "source attachment not found"
+                continue
+
+            drawio_file = media_dir / source.title
+            if not drawio_file.exists():
+                failures[diagram_name] = "source attachment was not downloaded"
+                failures[source.title] = "source attachment was not downloaded"
+                continue
+
+            png_path = render_drawio_to_png(drawio_file)
+            if png_path:
+                rendered[diagram_name] = png_path
+                rendered[source.title] = png_path
+                generated_media.add(png_path)
+                if png_path not in written:
+                    written.append(png_path)
+            else:
+                failures[diagram_name] = "render failed"
+                failures[source.title] = "render failed"
+        return rendered, failures, generated_media
 
     def _prefetch_bodies(self, cs: CachedSpace) -> None:
         """Pre-fetch page bodies in parallel so the tree walk doesn't block."""
@@ -129,7 +187,17 @@ class Exporter:
             node = find_node_by_path(roots, path_filter)
             if not node:
                 print(f"Error: path '{path_filter}' not found in space {space.key}", file=sys.stderr)
-                return ExportResult()
+                return ExportResult(
+                    diagnostics=[
+                        ExportDiagnostic(
+                            severity="error",
+                            page_id=None,
+                            page_title=None,
+                            code="path_not_found",
+                            message=f"path '{path_filter}' not found in space {space.key}",
+                        )
+                    ]
+                )
             if no_children:
                 nodes_to_export = [node]
             else:
@@ -141,16 +209,16 @@ class Exporter:
                 result = ExportResult()
                 for root in roots:
                     r = self._export_node(root, output_dir, cs, space.key, depth=0)
-                    result.count += r.count
-                    result.written_files.extend(r.written_files)
+                    result.extend(r)
                 return result
 
         # Export flat list (no_children case)
         result = ExportResult()
         for node in nodes_to_export:
-            files = self._export_single_page(node.page, output_dir, cs, space.key)
-            result.count += 1 if files else 0
-            result.written_files.extend(files)
+            files = self._export_single_page(
+                node.page, output_dir, cs, space.key, diagnostics=result.diagnostics
+            )
+            result.add_files(files, page_written=bool(files))
         return result
 
     def _export_node(
@@ -175,13 +243,15 @@ class Exporter:
         indent = "  " * depth
         print(f"{indent}Exporting: {page.title}")
 
-        files = self._export_single_page(page, page_dir, cs, space_key)
-        result = ExportResult(count=1 if files else 0, written_files=list(files))
+        result = ExportResult()
+        files = self._export_single_page(
+            page, page_dir, cs, space_key, diagnostics=result.diagnostics
+        )
+        result.add_files(files, page_written=bool(files))
 
         for child in node.children:
             child_result = self._export_node(child, page_dir, cs, space_key, depth + 1)
-            result.count += child_result.count
-            result.written_files.extend(child_result.written_files)
+            result.extend(child_result)
 
         return result
 
@@ -191,8 +261,10 @@ class Exporter:
         page_dir: Path,
         cs: CachedSpace,
         space_key: str,
+        diagnostics: list[ExportDiagnostic] | None = None,
     ) -> list[Path]:
         """Export a single page. Returns list of files written (empty if skipped)."""
+        diagnostics = diagnostics if diagnostics is not None else []
         # Folders are structural only — no content to export
         if page.status == "folder":
             return []
@@ -208,7 +280,17 @@ class Exporter:
                 if full_page.webui:
                     page.webui = full_page.webui
             except Exception as exc:
-                print(f"  Warning: could not fetch body for {page.title}: {exc}", file=sys.stderr)
+                message = f"could not fetch body for {page.title}: {exc}"
+                print(f"  Warning: {message}", file=sys.stderr)
+                diagnostics.append(
+                    ExportDiagnostic(
+                        severity="error",
+                        page_id=page.id,
+                        page_title=page.title,
+                        code="body_fetch_failed",
+                        message=message,
+                    )
+                )
                 return []
 
         # Get attachments from cache
@@ -223,37 +305,51 @@ class Exporter:
             media_dir = ensure_media_dir(page_dir)
             written.extend(download_attachments(self.client, attachments, media_dir))
 
-        # Convert to markdown
-        markdown = convert_page(
-            page,
-            base_url=self.base_url,
-            space_key=space_key,
-            path=path,
-            attachments=attachments,
-            user_resolver=self._resolve_user,
+        drawio_rendered, drawio_failures, generated_media = self._render_drawio_artifacts(
+            page, page_dir, attachments, written
         )
 
-        # Handle draw.io diagrams
-        if self.render_drawio:
-            drawio_atts = find_drawio_attachments(attachments)
-            if drawio_atts:
-                rendered = {}
-                media_dir = ensure_media_dir(page_dir)
-                for att in drawio_atts:
-                    drawio_file = media_dir / att.title
-                    if drawio_file.exists():
-                        png_path = render_drawio_to_png(drawio_file)
-                        if png_path:
-                            rendered[att.title] = png_path
-                            written.append(png_path)
-                if rendered:
-                    markdown = replace_drawio_placeholders(markdown, rendered)
+        # Convert to markdown after draw.io render results are known.
+        try:
+            markdown = convert_page(
+                page,
+                base_url=self.base_url,
+                space_key=space_key,
+                path=path,
+                attachments=attachments,
+                user_resolver=self._resolve_user,
+                diagnostics=diagnostics,
+                drawio_rendered=drawio_rendered,
+                drawio_failures=drawio_failures,
+                render_drawio=self.render_drawio,
+                download_media=self.download_media,
+            )
+        except Exception as exc:
+            diagnostics.append(
+                ExportDiagnostic(
+                    severity="error",
+                    page_id=page.id,
+                    page_title=page.title,
+                    code="conversion_failed",
+                    message=f"page conversion failed: {exc}",
+                )
+            )
+            return []
 
         # Write markdown file
         base_filename = sanitize_filename(page.title)
         md_path = page_dir / (base_filename + ".md")
         md_path.write_text(markdown, encoding="utf-8")
         written.append(md_path)
+        diagnostics.extend(
+            validate_markdown(
+                markdown,
+                md_path,
+                page,
+                validate_media_refs=self.download_media,
+                generated_media_paths=generated_media,
+            )
+        )
 
         # Debug: save raw HTML alongside markdown
         if self.debug:

--- a/src/confluence_export/types.py
+++ b/src/confluence_export/types.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
 
 
 @dataclass
@@ -231,3 +233,58 @@ class CachedSpace:
             updated_at=data.get("updated_at", ""),
             include_archived=bool(data.get("include_archived", False)),
         )
+
+
+@dataclass
+class ExportDiagnostic:
+    """Structured export diagnostic for conversion and validation issues."""
+
+    severity: Literal["info", "warning", "error"]
+    page_id: str | None
+    page_title: str | None
+    code: str
+    message: str
+    path: Path | None = None
+
+
+@dataclass
+class ExportReport:
+    """Result of an export operation, including written files and diagnostics."""
+
+    pages_written: int = 0
+    files_written: int = 0
+    diagnostics: list[ExportDiagnostic] = field(default_factory=list)
+    written_files: list[Path] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.written_files and not self.files_written:
+            self.files_written = len(self.written_files)
+
+    @property
+    def count(self) -> int:
+        """Backward-compatible page count alias."""
+        return self.pages_written
+
+    @count.setter
+    def count(self, value: int) -> None:
+        self.pages_written = value
+
+    @property
+    def has_errors(self) -> bool:
+        return any(d.severity == "error" for d in self.diagnostics)
+
+    @property
+    def has_warnings(self) -> bool:
+        return any(d.severity == "warning" for d in self.diagnostics)
+
+    def add_files(self, files: list[Path], *, page_written: bool = False) -> None:
+        if page_written:
+            self.pages_written += 1
+        self.written_files.extend(files)
+        self.files_written = len(self.written_files)
+
+    def extend(self, other: ExportReport) -> None:
+        self.pages_written += other.pages_written
+        self.written_files.extend(other.written_files)
+        self.files_written = len(self.written_files)
+        self.diagnostics.extend(other.diagnostics)

--- a/src/confluence_export/validation.py
+++ b/src/confluence_export/validation.py
@@ -1,0 +1,180 @@
+"""Markdown export validation and diagnostic formatting helpers."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+from confluence_export.types import ExportDiagnostic, Page
+
+_DRAWIO_SENTINEL_RE = re.compile(r"\\?\[drawio:[^\]]+\\?\]")
+_INTERNAL_PLACEHOLDER_RES = [
+    re.compile(r"__CONFLUENCE_EXPORT_[A-Z0-9_]+__"),
+    re.compile(r"CONFLUENCE_EXPORT_INTERNAL"),
+    re.compile(r"@@CONFLUENCE_EXPORT_[^@]+@@"),
+]
+_AUTOLINK_MEDIA_REF_RE = re.compile(r"<(\.media/[^>\n]+)>")
+_HTML_MEDIA_REF_RE = re.compile(r"""(?:src|href)=["'](\.media/[^"']+)["']""")
+_REQUIRED_FRONTMATTER = {"title", "page_id", "space_key", "path"}
+
+
+def validate_markdown(
+    markdown: str,
+    md_path: Path,
+    page: Page,
+    *,
+    validate_media_refs: bool = True,
+    generated_media_paths: set[Path] | None = None,
+) -> list[ExportDiagnostic]:
+    """Validate one exported markdown page and return structured diagnostics."""
+    diagnostics: list[ExportDiagnostic] = []
+
+    def add(code: str, message: str) -> None:
+        diagnostics.append(
+            ExportDiagnostic(
+                severity="error",
+                page_id=page.id,
+                page_title=page.title,
+                code=code,
+                message=message,
+                path=md_path,
+            )
+        )
+
+    frontmatter, body = _split_frontmatter(markdown)
+    if frontmatter is None:
+        add("invalid_frontmatter", "missing or invalid YAML frontmatter")
+    else:
+        try:
+            parsed = yaml.safe_load(frontmatter) or {}
+        except yaml.YAMLError as exc:
+            add("invalid_frontmatter", f"frontmatter is not valid YAML: {exc}")
+            parsed = {}
+        if not isinstance(parsed, dict):
+            add("invalid_frontmatter", "frontmatter must be a mapping")
+        else:
+            missing = sorted(k for k in _REQUIRED_FRONTMATTER if not parsed.get(k))
+            if missing:
+                add(
+                    "invalid_frontmatter",
+                    f"frontmatter missing required field(s): {', '.join(missing)}",
+                )
+
+    content = body if frontmatter is not None else markdown
+    if page.status != "folder" and not content.strip():
+        add("empty_markdown", "non-folder page produced empty markdown")
+
+    searchable_markdown = _strip_code_for_placeholder_checks(markdown)
+    if _DRAWIO_SENTINEL_RE.search(searchable_markdown):
+        add(
+            "drawio_sentinel_leaked",
+            "unresolved internal draw.io sentinel leaked into markdown",
+        )
+
+    for pattern in _INTERNAL_PLACEHOLDER_RES:
+        if pattern.search(searchable_markdown):
+            add(
+                "internal_placeholder_leaked",
+                "unresolved internal implementation placeholder leaked into markdown",
+            )
+            break
+
+    generated_media_paths = generated_media_paths or set()
+    for path in generated_media_paths:
+        if not path.exists():
+            add(
+                "missing_generated_media",
+                f"referenced generated media is missing: {path.name}",
+            )
+
+    if validate_media_refs:
+        for ref in sorted(_extract_media_refs(markdown)):
+            ref_path = (md_path.parent / ref).resolve()
+            if not ref_path.exists():
+                add(
+                    "missing_media",
+                    f"markdown references missing media {ref}",
+                )
+
+    return diagnostics
+
+
+def _strip_code_for_placeholder_checks(markdown: str) -> str:
+    """Remove markdown code spans/blocks before implementation placeholder checks."""
+    without_fences = re.sub(r"```.*?```", "", markdown, flags=re.DOTALL)
+    without_fences = re.sub(r"~~~.*?~~~", "", without_fences, flags=re.DOTALL)
+    return re.sub(r"`[^`\n]*`", "", without_fences)
+
+
+def _split_frontmatter(markdown: str) -> tuple[str | None, str]:
+    if not markdown.startswith("---\n"):
+        return None, markdown
+
+    end = markdown.find("\n---", 4)
+    if end == -1:
+        return None, markdown
+
+    frontmatter = markdown[4:end]
+    body = markdown[end + 4 :].strip()
+    return frontmatter, body
+
+
+def _extract_media_refs(markdown: str) -> set[str]:
+    refs: set[str] = set()
+    refs.update(_extract_markdown_media_refs(markdown))
+    for match in _AUTOLINK_MEDIA_REF_RE.finditer(markdown):
+        refs.add(_clean_media_ref(match.group(1)))
+    for match in _HTML_MEDIA_REF_RE.finditer(markdown):
+        refs.add(_clean_media_ref(match.group(1)))
+    return refs
+
+
+def _extract_markdown_media_refs(markdown: str) -> set[str]:
+    refs: set[str] = set()
+    i = 0
+    while i < len(markdown):
+        link_start = markdown.find("](", i)
+        if link_start == -1:
+            break
+        ref_start = link_start + 2
+        if not markdown.startswith(".media/", ref_start):
+            i = ref_start
+            continue
+
+        ref_end = _find_markdown_link_end(markdown, ref_start)
+        if ref_end == -1:
+            i = ref_start
+            continue
+        refs.add(_clean_media_ref(markdown[ref_start:ref_end]))
+        i = ref_end + 1
+    return refs
+
+
+def _find_markdown_link_end(markdown: str, start: int) -> int:
+    depth = 0
+    escaped = False
+    for pos in range(start, len(markdown)):
+        char = markdown[pos]
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == "(":
+            depth += 1
+            continue
+        if char == ")":
+            if depth == 0:
+                return pos
+            depth -= 1
+    return -1
+
+
+def _clean_media_ref(ref: str) -> str:
+    ref = ref.strip().strip("<>").strip()
+    if re.search(r"\s+['\"][^'\"]*['\"]$", ref):
+        ref = ref.rsplit(" ", 1)[0]
+    return ref.split("#", 1)[0].split("?", 1)[0]

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -10,7 +10,7 @@ import pytest
 
 import requests
 
-from confluence_export.cli import _resolve_space, main
+from confluence_export.cli import _diagnostic_lines, _resolve_space, main
 from confluence_export.config import (
     ApiDialect,
     AuthConfig,
@@ -19,7 +19,7 @@ from confluence_export.config import (
     ConnectionProfileError,
     resolve_cloud_id,
 )
-from confluence_export.types import CachedSpace, Page, Space, Version
+from confluence_export.types import CachedSpace, ExportDiagnostic, Page, Space, Version
 
 def _space(key="TEST", name="Test Space"):
     return Space(id="1", key=key, name=name, type="global", status="current")
@@ -225,6 +225,8 @@ class TestExportCommand:
              patch("confluence_export.cli.CacheStore", return_value=cache):
             main()
 
+        assert "Git: committed" in capsys.readouterr().out
+
         # Verify git repo was created and export was committed
         log = subprocess.run(
             ["git", "log", "--oneline"], cwd=out, capture_output=True, text=True
@@ -314,6 +316,106 @@ class TestExportCommand:
         assert not out.exists()
         cache_cls.assert_not_called()
         assert "Preflight failed" in capsys.readouterr().err
+
+    def test_non_strict_warnings_allowed(self, tmp_path, capsys):
+        client = _mock_client()
+        cache = MagicMock()
+        cs = _cached_space()
+        cs.pages = [
+            Page(
+                id="p1",
+                title="Root",
+                space_id="1",
+                parent_type="space",
+                version=Version(number=1),
+                body_storage='<ac:structured-macro ac:name="toc"></ac:structured-macro>',
+            )
+        ]
+        cache.refresh.return_value = cs
+        out = str(tmp_path / "out")
+        with patch("sys.argv", ["confluence-export", "export", "TEST", "-o", out, "--no-media", "--no-git"]), \
+             patch("confluence_export.cli.load_connection_profile", return_value=_profile()), \
+             patch("confluence_export.cli.ConfluenceClient", return_value=client), \
+             patch("confluence_export.cli.CacheStore", return_value=cache):
+            main()
+
+        stdout = capsys.readouterr().out
+        assert "Diagnostics: 0 error(s), 1 warning(s)" in stdout
+        assert "Confluence dynamic content: toc" in Path(out, "Root", "Root.md").read_text()
+
+    def test_strict_warnings_exit_nonzero(self, tmp_path, capsys):
+        client = _mock_client()
+        cache = MagicMock()
+        cs = _cached_space()
+        cs.pages = [
+            Page(
+                id="p1",
+                title="Root",
+                space_id="1",
+                parent_type="space",
+                version=Version(number=1),
+                body_storage='<ac:structured-macro ac:name="toc"></ac:structured-macro>',
+            )
+        ]
+        cache.refresh.return_value = cs
+        out = str(tmp_path / "out")
+        with patch("sys.argv", ["confluence-export", "export", "TEST", "-o", out, "--no-media", "--no-git", "--strict"]), \
+             patch("confluence_export.cli.load_connection_profile", return_value=_profile()), \
+             patch("confluence_export.cli.ConfluenceClient", return_value=client), \
+             patch("confluence_export.cli.CacheStore", return_value=cache):
+            with pytest.raises(SystemExit) as exc:
+                main()
+
+        assert exc.value.code == 1
+        stdout = capsys.readouterr().out
+        assert "Export validation failed: 0 error(s), 1 warning(s)" in stdout
+
+    def test_git_commit_skipped_on_validation_error(self, tmp_path, capsys):
+        import subprocess
+
+        client = _mock_client()
+        cache = MagicMock()
+        cs = _cached_space()
+        cs.pages = [
+            Page(
+                id="p1",
+                title="Root",
+                space_id="1",
+                parent_type="space",
+                version=Version(number=1),
+                body_storage="<p>[drawio:leaked]</p>",
+            )
+        ]
+        cache.refresh.return_value = cs
+        out = str(tmp_path / "out")
+        with patch("sys.argv", ["confluence-export", "export", "TEST", "-o", out, "--no-media"]), \
+             patch("confluence_export.cli.load_connection_profile", return_value=_profile()), \
+             patch("confluence_export.cli.ConfluenceClient", return_value=client), \
+             patch("confluence_export.cli.CacheStore", return_value=cache):
+            with pytest.raises(SystemExit) as exc:
+                main()
+
+        assert exc.value.code == 1
+        assert "Git: not committed" in capsys.readouterr().out
+        log = subprocess.run(
+            ["git", "log", "--oneline"], cwd=out, capture_output=True, text=True
+        )
+        assert "Export Confluence space TEST" not in log.stdout
+
+    def test_page_level_diagnostics_formatting(self, tmp_path):
+        lines = _diagnostic_lines([
+            ExportDiagnostic(
+                severity="error",
+                page_id="p1",
+                page_title="Architecture",
+                code="drawio_sentinel_leaked",
+                message="unresolved internal draw.io sentinel leaked into markdown",
+                path=tmp_path / "Architecture.md",
+            )
+        ])
+        assert lines == [
+            f'Page "Architecture": unresolved internal draw.io sentinel leaked into markdown ({tmp_path / "Architecture.md"})'
+        ]
 
 
 class TestRefreshCommand:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,6 +1,11 @@
 """Tests for HTML to markdown conversion."""
 
-from confluence_export.converter import convert_page, sanitize_filename, _preprocess_html
+from confluence_export.converter import (
+    convert_page,
+    inspect_macros,
+    sanitize_filename,
+    _preprocess_html,
+)
 from confluence_export.types import Attachment, Page, Version
 
 
@@ -99,5 +104,129 @@ def test_preprocess_drawio_placeholder():
         '<ac:parameter ac:name="diagramName">architecture</ac:parameter>'
         "</ac:structured-macro>"
     )
-    result = _preprocess_html(html, [])
-    assert "[drawio:architecture]" in result
+    diagnostics = []
+    result = _preprocess_html(html, [], diagnostics=diagnostics)
+    assert "Draw.io diagram could not be rendered: architecture" in result
+    assert "[drawio:architecture]" not in result
+    assert diagnostics[0].code == "drawio_source_missing"
+
+
+def test_drawio_rendered_before_markdown_handles_underscore(tmp_path):
+    html = (
+        '<ac:structured-macro ac:name="drawio">'
+        '<ac:parameter ac:name="diagramName">system_arch.drawio</ac:parameter>'
+        "</ac:structured-macro>"
+    )
+    page = Page(id="p1", title="Arch", body_storage=html, version=Version(number=1))
+    png = tmp_path / "system_arch.drawio.png"
+    png.write_bytes(b"png")
+    diagnostics = []
+    md = convert_page(
+        page,
+        base_url="",
+        space_key="TEST",
+        path="/Arch",
+        attachments=[Attachment(id="a1", title="system_arch.drawio")],
+        diagnostics=diagnostics,
+        drawio_rendered={"system_arch.drawio": png},
+    )
+
+    assert "system_arch.drawio.png" in md
+    assert "Draw.io source:" in md
+    assert "[drawio:" not in md
+    assert diagnostics == []
+
+
+def test_drawio_render_failure_fallback_warns():
+    html = (
+        '<ac:structured-macro ac:name="drawio">'
+        '<ac:parameter ac:name="diagramName">arch.drawio</ac:parameter>'
+        "</ac:structured-macro>"
+    )
+    page = Page(id="p1", title="Arch", body_storage=html, version=Version(number=1))
+    diagnostics = []
+    md = convert_page(
+        page,
+        base_url="",
+        space_key="TEST",
+        path="/Arch",
+        attachments=[Attachment(id="a1", title="arch.drawio")],
+        diagnostics=diagnostics,
+        drawio_failures={"arch.drawio": "render failed"},
+    )
+
+    assert "Draw.io diagram could not be rendered: arch.drawio" in md
+    assert ".media/arch.drawio" in md
+    assert "[drawio:" not in md
+    assert diagnostics[0].severity == "warning"
+    assert diagnostics[0].code == "drawio_render_failed"
+
+
+def test_profile_macro_preserves_user_details():
+    html = (
+        '<ac:structured-macro ac:name="profile">'
+        '<ri:user ri:account-id="abc"/>'
+        "</ac:structured-macro>"
+    )
+    result = _preprocess_html(
+        html,
+        [],
+        user_resolver=lambda _: {"displayName": "Alice", "email": "alice@example.com"},
+    )
+    assert "<li>Alice (alice@example.com)</li>" in result
+
+
+def test_profile_picture_macro_renders_user_mention():
+    html = (
+        '<ac:structured-macro ac:name="profile-picture">'
+        '<ac:parameter ac:name="User"><ri:user ri:account-id="abc"/></ac:parameter>'
+        "</ac:structured-macro>"
+    )
+    result = _preprocess_html(html, [], user_resolver=lambda _: {"displayName": "Alice"})
+    assert "@Alice" in result
+    assert "Confluence dynamic content" not in result
+
+
+def test_unsupported_macro_visible_and_warns():
+    diagnostics = []
+    html = '<ac:structured-macro ac:name="future-widget"></ac:structured-macro>'
+    result = _preprocess_html(html, [], diagnostics=diagnostics)
+    assert "Confluence dynamic content: future-widget" in result
+    assert diagnostics[0].severity == "warning"
+    assert diagnostics[0].code == "unsupported_macro"
+
+
+def test_unsupported_macro_with_body_preserves_body_and_warns():
+    diagnostics = []
+    html = (
+        '<ac:structured-macro ac:name="custom-wrapper">'
+        '<ac:rich-text-body><p>Keep this content</p></ac:rich-text-body>'
+        "</ac:structured-macro>"
+    )
+    result = _preprocess_html(html, [], diagnostics=diagnostics)
+    assert "Keep this content" in result
+    assert "Confluence dynamic content: custom-wrapper" not in result
+    assert diagnostics[0].severity == "warning"
+    assert diagnostics[0].code == "unsupported_macro_body_preserved"
+
+
+def test_drawio_sketch_visible_and_warns():
+    diagnostics = []
+    html = '<ac:structured-macro ac:name="drawio-sketch"></ac:structured-macro>'
+    result = _preprocess_html(html, [], diagnostics=diagnostics)
+    assert "Unsupported drawio-sketch macro preserved as placeholder" in result
+    assert diagnostics[0].severity == "warning"
+    assert diagnostics[0].code == "unsupported_drawio_sketch"
+
+
+def test_inspect_macros_reports_drawio_needs():
+    html = (
+        '<ac:structured-macro ac:name="drawio">'
+        '<ac:parameter ac:name="diagramName">arch</ac:parameter>'
+        "</ac:structured-macro>"
+        '<ac:structured-macro ac:name="drawio-sketch">'
+        '<ac:parameter ac:name="diagramName">sketch</ac:parameter>'
+        "</ac:structured-macro>"
+    )
+    needs = inspect_macros(html, [Attachment(id="a1", title="arch.drawio")])
+    assert needs.drawio_names == {"arch"}

--- a/tests/test_converter_extra.py
+++ b/tests/test_converter_extra.py
@@ -81,7 +81,12 @@ PREPROCESS_CASES = [
     ("view-file via ri:attachment", '<ac:structured-macro ac:name="view-file"><ri:attachment ri:filename="report.pdf"/></ac:structured-macro>', [".media/report.pdf"], []),
     ("view-file via name param", '<ac:structured-macro ac:name="view-file"><ac:parameter ac:name="name">doc.pdf</ac:parameter></ac:structured-macro>', [".media/doc.pdf"], []),
     ("view-file empty", '<ac:structured-macro ac:name="view-file"></ac:structured-macro>', [], ["ac:structured-macro"]),
-    ("drawio placeholder", '<ac:structured-macro ac:name="drawio"><ac:parameter ac:name="diagramName">arch</ac:parameter></ac:structured-macro>', ["[drawio:arch]"], []),
+    (
+        "drawio placeholder",
+        '<ac:structured-macro ac:name="drawio"><ac:parameter ac:name="diagramName">arch</ac:parameter></ac:structured-macro>',
+        ["Draw.io diagram could not be rendered: arch"],
+        ["[drawio:arch]"],
+    ),
 
     # Structural macros
     ("toc placeholder", '<ac:structured-macro ac:name="toc"></ac:structured-macro>', ["[Confluence dynamic content: toc]"], ["ac:structured-macro"]),

--- a/tests/test_drawio.py
+++ b/tests/test_drawio.py
@@ -1,11 +1,11 @@
 """Tests for draw.io diagram detection and processing."""
 
-from pathlib import Path
-
 from confluence_export.drawio import (
     detect_drawio_macros,
+    drawio_name_candidates,
+    find_drawio_attachment,
     find_drawio_attachments,
-    replace_drawio_placeholders,
+    find_drawio_macro_refs,
 )
 from confluence_export.types import Attachment
 
@@ -48,34 +48,44 @@ def test_detect_drawio_macros_none():
     assert detect_drawio_macros(html) == []
 
 
-def test_replace_drawio_placeholders(tmp_path):
-    markdown = (
-        "# Page\n\n"
-        "Some text\n\n"
-        "[drawio:architecture]\n\n"
-        "More text\n"
+def test_find_drawio_macro_refs_includes_inc_and_sketch():
+    html = (
+        '<ac:structured-macro ac:name="inc-drawio">'
+        '<ac:parameter ac:name="diagramName">arch.drawio</ac:parameter>'
+        '</ac:structured-macro>'
+        '<ac:structured-macro ac:name="drawio-sketch">'
+        '<ac:parameter ac:name="diagramName">sketch</ac:parameter>'
+        '</ac:structured-macro>'
     )
-    png = tmp_path / "architecture.drawio.png"
-    png.touch()
-
-    result = replace_drawio_placeholders(
-        markdown,
-        {"architecture": png},
-    )
-    assert "![architecture](.media/architecture.drawio.png)" in result
-    assert "Draw.io source:" in result
-    assert "architecture.drawio" in result
-    assert "[drawio:" not in result
+    refs = find_drawio_macro_refs(html)
+    assert [(r.macro_name, r.diagram_name) for r in refs] == [
+        ("inc-drawio", "arch.drawio"),
+        ("drawio-sketch", "sketch"),
+    ]
 
 
-def test_replace_drawio_placeholders_with_extension(tmp_path):
-    markdown = "Some [drawio:arch.drawio] diagram\n"
-    png = tmp_path / "arch.drawio.png"
-    png.touch()
+def test_drawio_name_candidates():
+    assert drawio_name_candidates("arch") == ["arch", "arch.drawio"]
+    assert drawio_name_candidates("arch.drawio") == ["arch.drawio", "arch"]
 
-    result = replace_drawio_placeholders(
-        markdown,
-        {"arch.drawio": png},
-    )
-    assert "arch.drawio.png" in result
-    assert "[drawio:" not in result
+
+def test_find_drawio_attachment_by_macro_name():
+    attachments = [Attachment(id="1", title="arch.drawio", media_type="")]
+    assert find_drawio_attachment(attachments, "arch") == attachments[0]
+
+
+def test_find_drawio_attachment_prefers_exact_drawio_source_over_bare_collision():
+    bare = Attachment(id="1", title="arch", media_type="application/x-drawio")
+    exact = Attachment(id="2", title="arch.drawio", media_type="application/x-drawio")
+    assert find_drawio_attachment([bare, exact], "arch.drawio") == exact
+
+
+def test_find_drawio_attachment_ignores_non_drawio_bare_collision():
+    bare = Attachment(id="1", title="arch", media_type="application/octet-stream")
+    exact = Attachment(id="2", title="arch.drawio", media_type="application/x-drawio")
+    assert find_drawio_attachment([bare, exact], "arch.drawio") == exact
+
+
+def test_find_drawio_attachment_does_not_guess_wrong_single_attachment():
+    attachments = [Attachment(id="1", title="other.drawio", media_type="application/x-drawio")]
+    assert find_drawio_attachment(attachments, "arch") is None

--- a/tests/test_drawio_extra.py
+++ b/tests/test_drawio_extra.py
@@ -1,4 +1,4 @@
-"""Tests for draw.io detection, rendering, and placeholder replacement."""
+"""Tests for draw.io detection, storage inspection, and rendering."""
 
 from __future__ import annotations
 
@@ -7,10 +7,11 @@ from unittest.mock import MagicMock, patch
 
 from confluence_export.drawio import (
     detect_drawio_macros,
+    find_drawio_attachment,
     find_drawio_attachments,
     find_drawio_cli,
+    find_drawio_macro_refs,
     render_drawio_to_png,
-    replace_drawio_placeholders,
 )
 from confluence_export.types import Attachment
 
@@ -46,6 +47,33 @@ class TestDetectDrawioMacros:
 
     def test_no_macros(self):
         assert detect_drawio_macros("<p>no diagrams</p>") == []
+
+    def test_finds_inc_drawio_names(self):
+        html = (
+            '<ac:structured-macro ac:name="inc-drawio">'
+            '<ac:parameter ac:name="diagramName">included_arch</ac:parameter>'
+            '</ac:structured-macro>'
+        )
+        assert detect_drawio_macros(html) == ["included_arch"]
+
+    def test_macro_refs_preserve_macro_name(self):
+        html = (
+            '<ac:structured-macro ac:name="drawio">'
+            '<ac:parameter ac:name="diagramName">arch</ac:parameter>'
+            '</ac:structured-macro>'
+            '<ac:structured-macro ac:name="drawio-sketch">'
+            '<ac:parameter ac:name="diagramName">sketch</ac:parameter>'
+            '</ac:structured-macro>'
+        )
+        refs = find_drawio_macro_refs(html)
+        assert [(r.macro_name, r.diagram_name) for r in refs] == [
+            ("drawio", "arch"),
+            ("drawio-sketch", "sketch"),
+        ]
+
+    def test_find_attachment_from_macro_name_without_extension(self):
+        attachments = [Attachment(id="1", title="arch.drawio", media_type="")]
+        assert find_drawio_attachment(attachments, "arch") == attachments[0]
 
 
 class TestFindDrawioCli:
@@ -211,24 +239,3 @@ class TestRenderDrawioToPng:
              patch("confluence_export.drawio.time.sleep"):
             result = render_drawio_to_png(drawio)
             assert result == expected_png
-
-
-class TestReplaceDrawioPlaceholders:
-    def test_replace_with_extension(self):
-        md = "# Diagram\n\n[drawio:arch.drawio]\n\nMore text"
-        rendered = {"arch.drawio": Path(".media/arch.drawio.png")}
-        result = replace_drawio_placeholders(md, rendered)
-        assert "![arch](.media/arch.drawio.png)" in result
-        assert "arch.drawio" in result  # source link
-
-    def test_replace_without_extension(self):
-        md = "# Diagram\n\n[drawio:arch]\n\nMore text"
-        rendered = {"arch.drawio": Path(".media/arch.drawio.png")}
-        result = replace_drawio_placeholders(md, rendered)
-        assert "![arch](.media/arch.drawio.png)" in result
-
-    def test_no_matching_placeholder(self):
-        md = "# No diagrams here"
-        rendered = {"other.drawio": Path(".media/other.drawio.png")}
-        result = replace_drawio_placeholders(md, rendered)
-        assert result == md

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -178,9 +178,12 @@ class TestBodyFetching:
         client.get_page_by_id.side_effect = Exception("timeout")
         cs = _make_cached_space(pages=[page])
 
-        files = exporter._export_single_page(page, tmp_path, cs, "TEST")
+        diagnostics = []
+        files = exporter._export_single_page(page, tmp_path, cs, "TEST", diagnostics=diagnostics)
         assert files == []
         assert "Warning" in capsys.readouterr().err
+        assert diagnostics[0].severity == "error"
+        assert diagnostics[0].code == "body_fetch_failed"
 
     def test_prefetch_fills_bodies_before_export(self):
         exporter, client, _ = _make_exporter()
@@ -242,6 +245,34 @@ class TestDrawioRendering:
         md = list(tmp_path.glob("*.md"))[0].read_text()
         assert "arch.drawio.png" in md
         assert "arch.drawio" in md
+        assert "[drawio:" not in md
+
+    def test_drawio_render_failure_writes_fallback_and_warning(self, tmp_path):
+        exporter, _, _ = _make_exporter(download_media=True, render_drawio=True)
+        att = Attachment(id="a1", title="arch.drawio", media_type="application/x-drawio",
+                         file_size=100, page_id="p1",
+                         download_link="/wiki/download/a1")
+        page = _make_page(body=(
+            '<ac:structured-macro ac:name="drawio">'
+            '<ac:parameter ac:name="diagramName">arch.drawio</ac:parameter>'
+            "</ac:structured-macro>"
+        ))
+        cs = _make_cached_space(attachments={"p1": [att]})
+
+        media_dir = tmp_path / ".media"
+        media_dir.mkdir()
+        (media_dir / "arch.drawio").write_text("<xml/>")
+
+        diagnostics = []
+        with patch("confluence_export.exporter.download_attachments", return_value=[]), \
+             patch("confluence_export.exporter.render_drawio_to_png", return_value=None):
+            exporter._export_single_page(page, tmp_path, cs, "TEST", diagnostics=diagnostics)
+
+        md = list(tmp_path.glob("*.md"))[0].read_text()
+        assert "Draw.io diagram could not be rendered: arch.drawio" in md
+        assert ".media/arch.drawio" in md
+        assert "[drawio:" not in md
+        assert any(d.code == "drawio_render_failed" for d in diagnostics)
 
 
 class TestUserResolution:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,114 @@
+"""Tests for post-export markdown validation."""
+
+from pathlib import Path
+
+from confluence_export.types import Page, Version
+from confluence_export.validation import validate_markdown
+
+
+def _page():
+    return Page(id="p1", title="Architecture", version=Version(number=1))
+
+
+def _valid_markdown(body: str = "# Architecture\n\nContent") -> str:
+    return (
+        "---\n"
+        "title: Architecture\n"
+        "page_id: p1\n"
+        "space_key: TEST\n"
+        "path: /Architecture\n"
+        "---\n\n"
+        f"{body}\n"
+    )
+
+
+def test_drawio_sentinel_validation_error(tmp_path):
+    md_path = tmp_path / "Architecture.md"
+    diagnostics = validate_markdown(
+        _valid_markdown("[drawio:arch]"),
+        md_path,
+        _page(),
+    )
+    assert any(d.code == "drawio_sentinel_leaked" for d in diagnostics)
+
+
+def test_drawio_sentinel_in_code_is_allowed(tmp_path):
+    md_path = tmp_path / "Architecture.md"
+    diagnostics = validate_markdown(
+        _valid_markdown("```text\n[drawio:arch]\n```\n\n`[drawio:inline]`"),
+        md_path,
+        _page(),
+    )
+    assert not any(d.code == "drawio_sentinel_leaked" for d in diagnostics)
+
+
+def test_missing_generated_media_validation_error(tmp_path):
+    md_path = tmp_path / "Architecture.md"
+    missing = tmp_path / ".media" / "arch.drawio.png"
+    diagnostics = validate_markdown(
+        _valid_markdown("![arch](.media/arch.drawio.png)"),
+        md_path,
+        _page(),
+        generated_media_paths={missing},
+    )
+    codes = {d.code for d in diagnostics}
+    assert "missing_generated_media" in codes
+    assert "missing_media" in codes
+
+
+def test_missing_autolinked_media_validation_error(tmp_path):
+    md_path = tmp_path / "Architecture.md"
+    diagnostics = validate_markdown(
+        _valid_markdown("<.media/arch.drawio>"),
+        md_path,
+        _page(),
+    )
+    assert any(d.code == "missing_media" for d in diagnostics)
+    assert any(".media/arch.drawio" in d.message for d in diagnostics)
+
+
+def test_invalid_frontmatter_validation_error(tmp_path):
+    diagnostics = validate_markdown("# Architecture\n\nContent", tmp_path / "Architecture.md", _page())
+    assert any(d.code == "invalid_frontmatter" for d in diagnostics)
+
+
+def test_empty_markdown_validation_error(tmp_path):
+    diagnostics = validate_markdown(
+        (
+            "---\n"
+            "title: Architecture\n"
+            "page_id: p1\n"
+            "space_key: TEST\n"
+            "path: /Architecture\n"
+            "---\n\n"
+        ),
+        tmp_path / "Architecture.md",
+        _page(),
+    )
+    assert any(d.code == "empty_markdown" for d in diagnostics)
+
+
+def test_media_validation_allows_spaces_in_filenames(tmp_path):
+    md_path = tmp_path / "Architecture.md"
+    media = tmp_path / ".media"
+    media.mkdir()
+    (media / "team photo.png").write_bytes(b"png")
+    diagnostics = validate_markdown(
+        _valid_markdown("![team](.media/team photo.png)"),
+        md_path,
+        _page(),
+    )
+    assert diagnostics == []
+
+
+def test_media_validation_allows_parentheses_in_filenames(tmp_path):
+    md_path = tmp_path / "Architecture.md"
+    media = tmp_path / ".media"
+    media.mkdir()
+    (media / "team (final).png").write_bytes(b"png")
+    diagnostics = validate_markdown(
+        _valid_markdown("![team](.media/team (final).png)"),
+        md_path,
+        _page(),
+    )
+    assert diagnostics == []


### PR DESCRIPTION
## Summary

Adds structured export diagnostics and a post-export markdown quality gate so broken conversions fail visibly instead of silently landing in committed markdown.

## What changed

- Added `ExportDiagnostic` and `ExportReport` with warning/error helpers and written-file tracking for git commits.
- Added per-page markdown validation for leaked draw.io sentinels, internal placeholders, missing media references, invalid frontmatter, and empty markdown output.
- Reworked draw.io conversion to inspect storage macros and render source attachments before markdown conversion; removed the old post-markdown `[drawio:...]` replacement path from source.
- Added a macro handler registry covering profile/profile-picture, drawio/inc-drawio, drawio-sketch fallback, panels, code, status, expand, jira, view-file, layout wrappers, and unsupported macro degradation.
- Added CLI diagnostics summary plus `--strict`; validation errors skip the export commit, and strict mode treats warnings as failure.
- Rebased onto the connection-profile/preflight mainline so the quality gate works with the new profile/preflight flow.

## Architecture challenge notes

- Draw.io sentinels are no longer used as converter/exporter internal state. The only `[drawio:...]` handling left is validation/test coverage that rejects leaked sentinels outside code spans/blocks.
- Draw.io rendering now happens before `convert_page()`, and rendered/failure state is passed into macro rendering so markdownify still runs once.
- Macro inspection is wired into pre-rendering, and the registry keeps structured macro handling explicit.
- `profile` preserves existing profile details; `profile-picture` renders as a user mention without relying on a fragile pre-pass.
- Body-bearing unsupported macros preserve their body and emit diagnostics; body-less dynamic macros degrade as visible placeholders.
- The scope stays on conversion/artifact quality: no path manifests, rename logic, auth/config movement, or workspace migration.

## Review loops

- Local audit pass found and fixed body-fetch failures as errors, draw.io attachment mis-guessing, and media validation for filenames with spaces/parentheses.
- Claude `/review`-style external review pass found profile regression, unused macro abstractions, body-bearing unsupported macro pollution, and validation false-positive risks; addressed the actionable findings.
- Final Claude review pass: `No findings.`

## Validation

- `uv run pytest` -> 364 passed
- `python -m compileall -q src`
- `git diff --check`