### PR TITLE
Fix #17: detect-and-warn on moved pages (no sidecar relocation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ output/Space-Name/Page-A/.workspace/draft-notes.md
 
 Both `.workspace/` and `.media/` use a dot-prefix to avoid name collisions with Confluence pages. Since each page title becomes a directory name, a page titled "workspace" or "media" would clash with a non-prefixed directory. The dot-prefix is safe because page titles are sanitized to only contain word characters, spaces, and hyphens, so no page can produce a directory name starting with a dot.
 
+### When a page is moved or renamed in Confluence
+
+A page's on-disk path follows its position in the Confluence tree, so reparenting or renaming a page changes where it is exported. On the next full export, conex rewrites the page's markdown at its new path (git's rename detection keeps `git log --follow` history across the move) and re-downloads its `.media/` there.
+
+Your `.workspace/` prep files are **deliberately not moved automatically.** Auto-carrying them would mean reconciling the filesystem against git's index on every export to serve a rare event — a fragile trade conex does not make. Instead, when a page with workspace content moves, conex leaves the `.workspace/` at the old path untouched and prints a note telling you the new location, e.g.:
+
+```
+Note: "Page-A" moved to 'New-Parent/Page-A'; your prep files at
+'Old-Parent/Page-A/.workspace' do not move automatically — relocate them if
+you still need them.
+```
+
+Move the folder yourself if you still want those files. (An empty, auto-created `.workspace/` carries nothing and is cleaned up silently.)
+
+One caveat for `--no-media`: a normal export re-downloads a moved page's `.media/` at its new path, but `--no-media` does not. So if a page moves during a `--no-media` export, its cached attachments are dropped (conex prints a note); re-run a full export with media to restore them.
+
 ## Install
 
 ```bash

--- a/src/confluence_export/cache.py
+++ b/src/confluence_export/cache.py
@@ -50,6 +50,23 @@ class CacheStore:
         pages = client.get_pages_in_space(space.id, include_archived=include_archived)
         print(f"Found {len(pages)} pages.", file=sys.stderr)
 
+        # A 0-page response over a populated cache is ambiguous: the space may be
+        # genuinely empty, or the API may be hiccupping. Warn loudly but proceed,
+        # so a genuinely-emptied space stays representable. Acting on an empty
+        # result is safe — the reconciler leaves every on-disk page that is absent
+        # from the plan untouched, and an export with no written files prunes
+        # nothing, so no data is lost either way.
+        if not pages:
+            prior = self.load(space.key)
+            if prior is not None and any(p.status != "folder" for p in prior.pages):
+                print(
+                    f"Warning: the API returned 0 pages for space {space.key}, "
+                    "but a populated cache exists. Treating the space as empty — "
+                    "if this is a transient API issue rather than a genuinely "
+                    "emptied space, re-run to refresh.",
+                    file=sys.stderr,
+                )
+
         # Resolve folders: pages may reference parent IDs that are folders,
         # not pages. Fetch these as synthetic Page entries so the tree is complete.
         pages = self._resolve_folders(client, pages)

--- a/src/confluence_export/cli.py
+++ b/src/confluence_export/cli.py
@@ -36,7 +36,7 @@ from confluence_export.tree import (
     format_tree,
     page_path,
 )
-from confluence_export.exporter import Exporter
+from confluence_export.exporter import Exporter, is_full_export
 from confluence_export.types import Space
 
 
@@ -613,11 +613,15 @@ def _cmd_export(
         include_archived=include_archived,
     )
 
-    # Git: post-export
+    # Git: post-export. A partial export (subtree / single page / no-children)
+    # writes only part of the tree, so it must not prune the rest of the repo:
+    # commit only adds in that mode (is_full=False). Shared predicate with the
+    # exporter (is_full_export) so the relocation gate and the prune gate agree.
+    is_full = is_full_export(path_filter, no_children)
     if use_git and result.written_files:
         from confluence_export.git import commit_export
 
-        commit_export(out, result.written_files, space_key)
+        commit_export(out, result.written_files, space_key, is_full=is_full)
 
     print(f"\nExported {result.count} page(s) to {out.resolve()}")
 

--- a/src/confluence_export/diff.py
+++ b/src/confluence_export/diff.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
 import yaml
 
+from confluence_export.media import MEDIA_DIR_NAME, WORKSPACE_DIR_NAME
 from confluence_export.tree import page_path
 from confluence_export.types import Page
 
@@ -54,30 +56,72 @@ def _parse_frontmatter(file_path: Path) -> dict | None:
     return None
 
 
-def scan_export_dir(export_dir: Path, space_key: str) -> dict[str, ExportedPage]:
-    """Scan .md files in export_dir, return dict keyed by page_id for matching space_key."""
-    result: dict[str, ExportedPage] = {}
+# Directory names that are not page directories and must never be scanned for
+# page frontmatter: user prep files (.workspace may legitimately contain .md
+# notes that are NOT pages), attachment trees (.media), local secrets (.conex),
+# and git internals. Excluding them up front also avoids descending huge media
+# trees on large exports.
+_NON_PAGE_DIRS = frozenset({WORKSPACE_DIR_NAME, MEDIA_DIR_NAME, ".conex", ".git"})
+
+
+def _coerce_int(value: object) -> int:
+    """Coerce a frontmatter version to int, degrading a garbled/None value to 0
+    (oldest) rather than crashing the whole scan."""
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0
+
+
+def scan_export_dir_grouped(
+    export_dir: Path, space_key: str
+) -> dict[str, list[ExportedPage]]:
+    """Scan page markdown files, grouped by page_id.
+
+    Returns ``page_id -> [ExportedPage, ...]``. Unlike a plain dict keyed by id,
+    this never silently drops a second copy: the old collision-overwrite (#11)
+    and orphaned-move (#17) bugs can leave two markdown files carrying the same
+    page_id on disk, and the reconciler needs to see both to heal them. Each
+    list is sorted so the canonical copy is first: highest version, then path
+    order for a deterministic tiebreak across operating systems / rglob order.
+    """
+    grouped: dict[str, list[ExportedPage]] = {}
     skipped_spaces: set[str] = set()
 
-    for md_file in export_dir.rglob("*.md"):
-        fm = _parse_frontmatter(md_file)
-        if not fm or "page_id" not in fm:
-            continue
+    # Walk with os.walk (not rglob) so the ignored sidecar/internal trees are
+    # pruned DURING traversal: a full export must never descend the (potentially
+    # huge) .media/.workspace/.conex/.git directories just to discard their
+    # contents afterward.
+    for dirpath, dirnames, filenames in os.walk(export_dir):
+        dirnames[:] = [d for d in dirnames if d not in _NON_PAGE_DIRS]
+        for filename in filenames:
+            if not filename.endswith(".md"):
+                continue
+            md_file = Path(dirpath) / filename
 
-        file_space = fm.get("space_key", "")
-        if file_space.upper() != space_key.upper():
-            skipped_spaces.add(file_space)
-            continue
+            fm = _parse_frontmatter(md_file)
+            if not fm or "page_id" not in fm:
+                continue
 
-        page_id = str(fm["page_id"])
-        result[page_id] = ExportedPage(
-            page_id=page_id,
-            version=int(fm.get("version", 0)),
-            title=fm.get("title", ""),
-            path=fm.get("path", ""),
-            file_path=md_file,
-            space_key=file_space,
-        )
+            file_space = fm.get("space_key", "")
+            if file_space.upper() != space_key.upper():
+                skipped_spaces.add(file_space)
+                continue
+
+            page_id = str(fm["page_id"])
+            grouped.setdefault(page_id, []).append(
+                ExportedPage(
+                    page_id=page_id,
+                    version=_coerce_int(fm.get("version", 0)),
+                    title=fm.get("title", ""),
+                    path=fm.get("path", ""),
+                    file_path=md_file,
+                    space_key=file_space,
+                )
+            )
+
+    for entries in grouped.values():
+        entries.sort(key=lambda e: (-e.version, str(e.file_path)))
 
     if skipped_spaces:
         print(
@@ -85,7 +129,20 @@ def scan_export_dir(export_dir: Path, space_key: str) -> dict[str, ExportedPage]
             file=sys.stderr,
         )
 
-    return result
+    return grouped
+
+
+def scan_export_dir(export_dir: Path, space_key: str) -> dict[str, ExportedPage]:
+    """Scan .md files in export_dir, return dict keyed by page_id for matching space_key.
+
+    Thin wrapper over :func:`scan_export_dir_grouped` returning the canonical
+    (first) copy per id, preserving the historical single-copy contract used by
+    the diff command.
+    """
+    return {
+        page_id: entries[0]
+        for page_id, entries in scan_export_dir_grouped(export_dir, space_key).items()
+    }
 
 
 def compute_diff(

--- a/src/confluence_export/exporter.py
+++ b/src/confluence_export/exporter.py
@@ -17,9 +17,10 @@ from confluence_export.drawio import (
     render_drawio_to_png,
     replace_drawio_placeholders,
 )
-from confluence_export.media import download_attachments, ensure_media_dir
+from confluence_export.media import WORKSPACE_DIR_NAME, download_attachments, ensure_media_dir
 from confluence_export.tree import (
     build_tree,
+    collect_subtree,
     find_node_by_path,
     format_tree,
     page_path,
@@ -33,6 +34,15 @@ class ExportResult:
 
     count: int = 0
     written_files: list[Path] = field(default_factory=list)
+
+
+def is_full_export(path_filter: str | None, no_children: bool) -> bool:
+    """Whether this export writes the COMPLETE space tree (the only mode with
+    full visibility). The single source of truth for the predicate that gates
+    BOTH move/orphan reconciliation (exporter) and git stale-file pruning (cli):
+    a partial export must do neither. Used by export_space and by cli's
+    commit_export call so the two can never diverge."""
+    return path_filter is None and not no_children
 
 
 class Exporter:
@@ -135,16 +145,75 @@ class Exporter:
 
         self._prefetch_bodies(cs)
 
-        roots = build_tree(cs.pages)
+        roots_full = build_tree(cs.pages)
 
+        roots = roots_full
         if not include_archived:
-            roots = [r for r in roots if r.page.id != "__archived__"]
+            roots = [r for r in roots_full if r.page.id != "__archived__"]
 
-        # Plan the collision-free on-disk layout once, up front. Both the
-        # directory name and the markdown filename of every page are read from
-        # this plan, so two pages whose titles sanitize to the same name get
-        # distinct, stable paths instead of silently overwriting (issue #11).
-        self._plan = plan_layout(roots)
+        # Plan the collision-free on-disk layout once, up front, over the FULL
+        # tree (including the synthetic __archived__ subtree). Both the directory
+        # name and the markdown filename of every page are read from this plan,
+        # so two pages whose titles sanitize to the same name get distinct,
+        # stable paths instead of silently overwriting (issue #11). Planning over
+        # the full tree also keeps an archived page's plan entry alive at its
+        # _archived/ target, so it is relocated into / out of _archived/ when
+        # archived or unarchived instead of being stranded at its old path.
+        self._plan = plan_layout(roots_full)
+
+        # Reconcile moved pages and heal orphans BEFORE writing — but only on a
+        # full, freshly-fetched export, the one mode with complete tree
+        # visibility. Filtered / single-subtree / no-children runs never
+        # reconcile, nor prune (commit_export is_full=False). A --cached full
+        # export also skips reconcile here (stale tree), though git pruning still
+        # runs on it via commit_export.
+        is_full = is_full_export(path_filter, no_children)
+        if is_full and force_refresh:
+            from confluence_export.reconcile import reconcile
+
+            # Reconcile only over what this run actually writes. When archived
+            # pages are out of scope (no --include-archived) they are left
+            # untouched on disk rather than relocated into _archived/. Restrict
+            # the full plan by removing the archived page ids (rather than
+            # re-running plan_layout over a different tree) so every retained
+            # page's target is byte-identical to the write walk's — otherwise a
+            # real page titled "_archived" could get a different target in the two
+            # plans and be seen as a spurious move.
+            if include_archived:
+                reconcile_plan = self._plan
+            else:
+                archived_node = next(
+                    (r for r in roots_full if r.page.id == "__archived__"), None
+                )
+                archived_ids = (
+                    {n.page.id for n in collect_subtree(archived_node)}
+                    if archived_node else set()
+                )
+                reconcile_plan = {
+                    pid: t for pid, t in self._plan.items() if pid not in archived_ids
+                }
+            try:
+                reconcile(
+                    reconcile_plan, output_dir, space.key,
+                    media_will_redownload=self.download_media,
+                )
+            except Exception as exc:
+                # Reconciliation is a best-effort relayout; never let it abort the
+                # export. The write walk still produces correct content at the
+                # planned paths, and a transient failure heals on the next run
+                # (reconcile is idempotent). Surface the error and continue.
+                print(f"Warning: layout reconciliation skipped ({exc})", file=sys.stderr)
+        elif is_full:
+            print(
+                "Note: orphan/move healing runs on a fresh full export; "
+                "re-run with --force-refresh to heal a stale layout.",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                "Note: orphan/move healing happens on a full export of the space.",
+                file=sys.stderr,
+            )
 
         # Resolve subtree if path given
         if path_filter:
@@ -185,14 +254,17 @@ class Exporter:
     ) -> ExportResult:
         """Recursively export a node and its children."""
         page = node.page
-        dir_name = self._planned_segment(page)
-        page_dir = parent_dir / dir_name
+        page_dir = parent_dir / self._planned_segment(page)
         page_dir.mkdir(parents=True, exist_ok=True)
 
-        # Create workspace directory for user's preparation files
+        # Create workspace directory for user's preparation files. Folders are
+        # structural-only and never hold prep files, so they get no .workspace —
+        # this also means a renamed folder leaves a genuinely-empty directory the
+        # reconciler can prune instead of a stranded .workspace orphan.
         # Dot-prefix avoids collision with a Confluence page titled "workspace"
         # (sanitize_filename strips dots, so no page can produce ".workspace")
-        (page_dir / ".workspace").mkdir(exist_ok=True)
+        if page.status != "folder":
+            (page_dir / WORKSPACE_DIR_NAME).mkdir(exist_ok=True)
 
         indent = "  " * depth
         print(f"{indent}Exporting: {page.title}")

--- a/src/confluence_export/git.py
+++ b/src/confluence_export/git.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import sys
+import tempfile
 from collections.abc import Iterator
 from datetime import datetime, timezone
 from pathlib import Path
+
+from confluence_export.media import WORKSPACE_DIR_NAME
 
 # Conservative per-call argv budget for git add / git rm path lists. macOS
 # ARG_MAX is 1 MiB (and includes the environment block), so 100 KiB leaves
@@ -117,12 +121,30 @@ def commit_local_changes(output_dir: Path) -> bool:
     return _run_git(output_dir, "commit", "-m", "Local changes before Confluence export") is not None
 
 
-def commit_export(output_dir: Path, written_files: list[Path], space_key: str) -> bool:
+def commit_export(
+    output_dir: Path,
+    written_files: list[Path],
+    space_key: str,
+    *,
+    is_full: bool = True,
+) -> bool:
     """Stage exporter-written files and remove stale tracked files.
 
-    Stages written_files, then removes any tracked files under output_dir that
-    are not in written_files (handles upstream deletions, renames, and moves).
-    Returns True if a commit was made.
+    Stages written_files, then (only on a full export) removes any tracked files
+    under output_dir that are not in written_files (handles upstream deletions,
+    renames, and moves). Returns True if a commit was made.
+
+    ``is_full`` must be False for filtered / single-subtree / no-children
+    exports: those write only part of the tree, so written_files covers only
+    that subset. Pruning then would ``git rm`` the entire rest of the repo. A
+    partial export is therefore strictly add-only.
+
+    A moved page is handled as a plain delete + add: the reconciler drops the old
+    path's markdown/.media and the write walk regenerates them at the new path,
+    so the stale-file prune removes the old path and git's own rename detection
+    makes history follow — no sidecar relocation or index patching needed (issue
+    #17, Option B). The user's ``.workspace`` is never moved; it is preserved by
+    the prune skip below and stays where the user put it.
     """
     # Stage only the files the exporter wrote. Chunk to avoid hitting the
     # OS argv limit on big spaces (thousands of paths joined into one exec
@@ -133,8 +155,10 @@ def commit_export(output_dir: Path, written_files: list[Path], space_key: str) -
             return False
     _unstage_secret_configs(output_dir)
 
-    # Remove stale tracked files (deletions/renames/moves upstream)
-    _remove_stale_files(output_dir, written_files)
+    # Remove stale tracked files (deletions/renames/moves upstream). Only on a
+    # full export — a partial export's written_files is not the whole tree.
+    if is_full:
+        _remove_stale_files(output_dir, written_files)
 
     # Check if anything was staged
     result = _run_git(output_dir, "diff", "--cached", "--quiet", check=False)
@@ -146,7 +170,38 @@ def commit_export(output_dir: Path, written_files: list[Path], space_key: str) -
     return _run_git(output_dir, "commit", "-m", msg) is not None
 
 
-def _remove_stale_files(output_dir: Path, written_files: list[Path]) -> None:
+def _fs_is_case_insensitive(output_dir: Path) -> bool:
+    """Whether output_dir's filesystem folds case (macOS/Windows default), by
+    probing it live. git's core.ignorecase is NOT a reliable oracle here: it is
+    fixed at init/clone time and drifts from reality when a repo created on one
+    filesystem is later exported on another (e.g. a Linux/CI clone opened on a
+    Mac, or vice versa) — getting it wrong either re-introduces the stale-prune
+    churn or wrongly spares a genuinely-deleted file. Measuring the actual
+    filesystem is what governs whether a write and the index share an inode.
+
+    The probe is a uniquely-named temp file created with O_EXCL (via mkstemp), so
+    it can never clobber or be spoofed by a real user file: it tests whether an
+    upper-cased variant of *that unique name* resolves to the same file."""
+    try:
+        fd, probe_name = tempfile.mkstemp(dir=output_dir, prefix=".conex-case-")
+    except OSError:
+        return False
+    os.close(fd)
+    probe = Path(probe_name)
+    try:
+        variant = probe.with_name(probe.name.upper())
+        return variant != probe and variant.exists()
+    finally:
+        try:
+            probe.unlink()
+        except OSError:
+            pass
+
+
+def _remove_stale_files(
+    output_dir: Path,
+    written_files: list[Path],
+) -> None:
     """Remove tracked files that are no longer part of the export."""
     if not _has_commits(output_dir):
         return
@@ -155,24 +210,45 @@ def _remove_stale_files(output_dir: Path, written_files: list[Path]) -> None:
     if result is None or not result.stdout.strip("\0"):
         return
 
-    written_resolved = {f.resolve() for f in written_files}
+    # On a case-insensitive filesystem a fresh write and the index can differ
+    # only in case (a re-cased title, or legacy content from another machine).
+    # git folds those to one path, so we must too — otherwise the same file is
+    # both git-added (new case) and flagged stale (old case), and `git rm` then
+    # fails on its staged content, leaving a "survived the prune" warning that
+    # only clears on the next export.
+    fold = (lambda s: s.casefold()) if _fs_is_case_insensitive(output_dir) else (lambda s: s)
+    written_keys = {fold(str(f.resolve())) for f in written_files}
+
     stale = []
     for rel_path in result.stdout.strip("\0").split("\0"):
-        # Preserve user workspace directories across re-exports
+        # Preserve user workspace directories across re-exports. On a move conex
+        # leaves a committed .workspace tracked at its old path (it is never
+        # relocated — issue #17, Option B); the user moves it themselves.
         parts = Path(rel_path).parts
-        if ".workspace" in parts:
+        if WORKSPACE_DIR_NAME in parts:
             continue
         if _is_secret_config_relpath(rel_path):
             continue
         full = (output_dir / rel_path).resolve()
-        if full not in written_resolved:
+        if fold(str(full)) not in written_keys:
             stale.append(rel_path)
 
     if stale:
         # Same chunking rationale as commit_export: a large stale list can
-        # exceed argv limits when passed to a single git rm call.
+        # exceed argv limits when passed to a single git rm call. If a batch
+        # fails (e.g. one path has a staged rename from reconcile), fall back to
+        # per-path removal so one un-removable path can't block pruning the rest.
         for batch in _chunked_paths(stale):
-            _run_git(output_dir, "rm", "--quiet", "--", *batch)
+            result = _run_git(output_dir, "rm", "--quiet", "--", *batch, check=False)
+            if result is None or result.returncode != 0:
+                for path in batch:
+                    r = _run_git(output_dir, "rm", "--quiet", "--", path, check=False)
+                    if r is None or r.returncode != 0:
+                        print(
+                            f"  Warning: could not remove stale file '{path}'; "
+                            "it survived the prune",
+                            file=sys.stderr,
+                        )
 
 
 def _unstage_secret_configs(output_dir: Path) -> None:

--- a/src/confluence_export/media.py
+++ b/src/confluence_export/media.py
@@ -12,6 +12,11 @@ from confluence_export.types import Attachment
 
 _VERSIONS_FILE = ".versions.json"
 MEDIA_DIR_NAME = ".media"
+# User preparation files attached to a page (scripts, notes). Preserved across
+# re-exports and, when a page moves, deliberately left in place (never
+# auto-relocated — issue #17, Option B); the user is told where the page went.
+# Shared here so the exporter, reconciler, git prune, and frontmatter scan agree.
+WORKSPACE_DIR_NAME = ".workspace"
 
 
 def ensure_media_dir(page_dir: Path) -> Path:

--- a/src/confluence_export/reconcile.py
+++ b/src/confluence_export/reconcile.py
@@ -1,0 +1,305 @@
+"""Reconcile the on-disk export layout with the planned layout (issue #17).
+
+Runs before the write walk on full exports. When a page is reparented or renamed
+in Confluence its computed path changes, and its old exported directory would
+become an orphan.
+
+Design (issue #17, **Option B — "detect and warn"**, a deliberate product call;
+see ``PR24-PR25-REFLECTION.md`` for why auto-carry was abandoned):
+
+A full export REGENERATES every page's markdown from the API at the page's new
+path, and git records a rename from a plain delete+add (no ``git mv`` is needed
+for ``git log --follow``). So page markdown is **disposable** — it is dropped at
+the old path, never moved. ``.media`` is disposable too: it re-downloads at the
+new path (and git's rename detection links the dropped + re-added attachments by
+content similarity), so it is also just dropped at the old path.
+
+The only content that cannot be recomputed is the user's ``.workspace`` (prep
+files conex never generates and never commits). conex **deliberately does NOT
+relocate it.** Carrying a tree-derived sidecar across a move forces a perpetual
+filesystem/git-index/plan reconciliation that proved to be an unbounded
+edge-case stream for a rare event. Instead, on a move a non-empty ``.workspace``
+is left untouched at the old path and a one-line note tells the user where the
+page went, so they can move their prep files if they still want them. An empty
+auto-created ``.workspace`` carries no data and is simply removed.
+
+Pipeline (no holding area, no relocation, no quarantine, no git-index patching):
+  0. Heal legacy duplicates (two ``.md`` with one ``page_id``): keep the
+     canonical copy (at-target preferred, else highest version); drop the stale
+     copy's markdown + ``.media``; warn if it holds a non-empty ``.workspace``.
+  1. For each moved page: drop the stale markdown (rewritten fresh at the new
+     path) and the disposable ``.media``; warn-and-leave a non-empty
+     ``.workspace``, remove an empty one.
+  2. Prune directories left empty by the moves/deletes (``rmdir`` only, so it can
+     never delete user content).
+
+State is derived entirely from frontmatter via
+:func:`diff.scan_export_dir_grouped`; reconcile holds no transient on-disk state,
+so re-running it is safe. Note the recovery model: reconcile drops a moved page's
+old markdown *before* the write walk regenerates it at the new path, so a crash
+between the two leaves the page absent on disk for that run. It is restored on the
+next full export because the **write walk re-fetches it from the API** — not
+because reconcile "heals" it (the dropped page has no frontmatter left to scan).
+Markdown and ``.media`` are recomputable from Confluence; only the user's
+``.workspace`` is never touched, so nothing irreplaceable is at risk in that window.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path, PurePosixPath
+
+from confluence_export.diff import ExportedPage, scan_export_dir_grouped
+from confluence_export.media import MEDIA_DIR_NAME, WORKSPACE_DIR_NAME
+
+
+def _abs_target(output_dir: Path, target_dir: PurePosixPath) -> Path:
+    return output_dir.joinpath(*target_dir.parts).resolve()
+
+
+def _rel_str(path: Path, output_dir: Path) -> str:
+    try:
+        return str(path.relative_to(output_dir))
+    except ValueError:
+        return str(path)
+
+
+def _same_dir(a: Path, b: Path) -> bool:
+    """True when a and b are the same directory, treating a case-only difference
+    on a case-insensitive filesystem as the same (so a case-only title change is
+    a no-op, not a churn-every-run "move")."""
+    if a == b:
+        return True
+    try:
+        return a.exists() and b.exists() and a.samefile(b)
+    except OSError:
+        return False
+
+
+def _choose_canonical(entries: list[ExportedPage], target_abs: Path) -> ExportedPage:
+    """Pick the copy to keep. A copy already sitting at the plan target wins (so
+    a stale lower-version duplicate elsewhere does not displace the live page and
+    destroy its content); otherwise the highest-version, path-ordered copy."""
+    return min(
+        entries,
+        key=lambda e: (
+            e.file_path.parent.resolve() != target_abs,  # at-target first
+            -e.version,                                   # then highest version
+            str(e.file_path),                             # then deterministic path
+        ),
+    )
+
+
+def _rmdir_if_empty(d: Path) -> None:
+    try:
+        if d.is_dir() and not any(d.iterdir()):
+            d.rmdir()
+    except OSError:
+        pass
+
+
+def _remove_artifacts(md_path: Path) -> None:
+    """Drop a page's disposable artifacts at a stale path: its markdown (and debug
+    ``.html``) and its ``.media`` directory. Markdown is rewritten and ``.media``
+    is re-downloaded fresh at the new path; in a git dir the staged delete + add
+    is recorded as a rename by git's content-similarity detection."""
+    for art in (md_path, md_path.with_suffix(".html")):
+        try:
+            if art.exists():
+                art.unlink()
+        except OSError:
+            pass
+    media = md_path.parent / MEDIA_DIR_NAME
+    if media.is_dir():
+        shutil.rmtree(media, ignore_errors=True)
+
+
+def _warn_or_clear_workspace(page_dir: Path, note: str) -> None:
+    """Handle a moved/duplicate page's ``.workspace`` at a stale path. A non-empty
+    one is the user's own prep work: conex does NOT relocate it (see module
+    docstring) — it is left in place and the user is told (``note``) where the
+    page moved. An empty auto-created one carries no data and is removed so the
+    old shell can be pruned."""
+    ws = page_dir / WORKSPACE_DIR_NAME
+    if not ws.is_dir():
+        return
+    if any(ws.iterdir()):
+        print(note, file=sys.stderr)
+    else:
+        _rmdir_if_empty(ws)
+
+
+def _execute_deletes(
+    delete_copies: list[ExportedPage], output_dir: Path, canonical_dirs: set[Path]
+) -> None:
+    """Narrow-delete non-canonical duplicate copies (legacy collision/orphan
+    state): remove the stale markdown and (unless it shares the canonical copy's
+    directory) its ``.media``. A non-empty ``.workspace`` is left in place with a
+    warning rather than destroying prep work."""
+    for e in delete_copies:
+        page_dir = e.file_path.parent
+        try:
+            if e.file_path.exists():
+                e.file_path.unlink()
+        except OSError:
+            # Match every other delete in this module (all swallow OSError): a
+            # read-only/locked stale copy must not abort the whole reconcile and
+            # strand the move/prune phases that run after it.
+            pass
+        if page_dir.resolve() in canonical_dirs:
+            continue  # shared with the canonical copy — never touch its media/workspace
+        media = page_dir / MEDIA_DIR_NAME
+        if media.is_dir():
+            shutil.rmtree(media, ignore_errors=True)
+        _warn_or_clear_workspace(
+            page_dir,
+            f"  Warning: orphaned workspace left at "
+            f"'{_rel_str(page_dir, output_dir)}'; move it manually",
+        )
+
+
+def _vacate_moved_page(
+    canonical: ExportedPage,
+    target_abs: Path,
+    output_dir: Path,
+    *,
+    media_will_redownload: bool,
+) -> None:
+    """Clear a moved page's old directory: drop the disposable markdown and
+    ``.media`` (both regenerate at the new path, and git's rename detection
+    follows them), and handle the irreplaceable ``.workspace`` per Option B —
+    a non-empty one is left in place with a note pointing at the new path.
+
+    ``media_will_redownload`` is False on a ``--no-media`` run: the old ``.media``
+    is still dropped (it cannot be cleanly carried), but the page then has no
+    attachments on disk until a full export with media restores them, so the drop
+    is announced instead of silent."""
+    src_dir = canonical.file_path.parent
+    title = canonical.title or src_dir.name
+    media = src_dir / MEDIA_DIR_NAME
+    if not media_will_redownload and media.is_dir() and any(media.iterdir()):
+        print(
+            f'  Note: cached attachments for "{title}" at '
+            f"'{_rel_str(media, output_dir)}' were not carried to the new path; "
+            "re-run a full export with media to restore them.",
+            file=sys.stderr,
+        )
+    note = (
+        f'  Note: "{title}" moved to '
+        f"'{_rel_str(target_abs, output_dir)}'; your prep files at "
+        f"'{_rel_str(src_dir / WORKSPACE_DIR_NAME, output_dir)}' do not move "
+        "automatically — relocate them if you still need them."
+    )
+    _remove_artifacts(canonical.file_path)
+    _warn_or_clear_workspace(src_dir, note)
+
+
+def _prune_empty_dirs(output_dir: Path, candidates: list[Path]) -> None:
+    """Remove directories left empty by moves/deletes, bottom-up. Uses ``rmdir``
+    only (which refuses non-empty directories), so it can never delete user
+    content."""
+    seen: set[Path] = set()
+    for d in candidates:
+        cur = d
+        while cur != output_dir and output_dir in cur.parents:
+            seen.add(cur)
+            cur = cur.parent
+    for d in sorted(seen, key=lambda p: len(p.parts), reverse=True):
+        _rmdir_if_empty(d)
+
+
+def _heal_folder_workspaces(output_dir: Path, move_sources: list[Path]) -> None:
+    """Handle a legacy ``.workspace`` stranded in a FOLDER directory after its
+    child pages moved out. Older exports created a ``.workspace`` under every
+    node, including folders; a folder emits no frontmatter so it generates no
+    move of its own. An empty one is legacy cruft and is removed; a non-empty one
+    holds real user files and is left in place with a warning."""
+    seen: set[Path] = set()
+    for src in move_sources:
+        cur = src.parent
+        while cur != output_dir and output_dir in cur.parents:
+            seen.add(cur)
+            cur = cur.parent
+    for d in sorted(seen, key=lambda p: len(p.parts), reverse=True):
+        ws = d / WORKSPACE_DIR_NAME
+        if not ws.is_dir():
+            continue
+        has_page = any(
+            WORKSPACE_DIR_NAME not in md.relative_to(d).parts for md in d.rglob("*.md")
+        )
+        if has_page:
+            continue
+        if not any(ws.iterdir()):
+            try:
+                ws.rmdir()
+                d.rmdir()
+            except OSError:
+                pass
+        else:
+            print(
+                f"  Warning: user .workspace left at '{_rel_str(ws, output_dir)}' "
+                "(its folder was renamed/reparented); move it manually",
+                file=sys.stderr,
+            )
+
+
+def reconcile(
+    plan: dict[str, PurePosixPath],
+    output_dir: Path,
+    space_key: str,
+    *,
+    media_will_redownload: bool = True,
+) -> None:
+    """Bring the on-disk layout in line with the plan before the write walk:
+    heal legacy duplicates, drop each moved page's stale disposable artifacts so
+    the writer can regenerate them at the new path, warn about (without moving)
+    any user ``.workspace``, and prune emptied shells.
+
+    No git interaction and no relocation: page markdown and ``.media`` are
+    rewritten / re-downloaded at the new path by the write walk, and git's own
+    rename detection makes history follow the plain delete + add.
+    ``media_will_redownload`` (False under ``--no-media``) only controls whether a
+    dropped ``.media`` is announced — see :func:`_vacate_moved_page`.
+
+    Known limitation: identity is keyed solely on frontmatter ``page_id``. Two
+    ``.md`` carrying the *same* ``page_id`` are treated as duplicates of one page
+    and the non-canonical copy's markdown/``.media`` are healed away — the intended
+    recovery for legacy #11/#17 duplicates. A same-``page_id`` collision from
+    hand-edited frontmatter or an in-tree copy of a page directory would therefore
+    drop that copy; a genuinely live page self-heals because the write walk
+    regenerates every in-plan page right after this runs, and a user ``.workspace``
+    is never deleted, so nothing irreplaceable is at risk."""
+    output_dir = output_dir.resolve()
+    grouped = scan_export_dir_grouped(output_dir, space_key)
+
+    # Collect duplicates + moves.
+    delete_copies: list[ExportedPage] = []
+    canonical_dirs: set[Path] = set()
+    moves: list[tuple[Path, Path, ExportedPage]] = []  # (src_dir, target_abs, canonical)
+
+    for page_id, entries in grouped.items():
+        target_dir = plan.get(page_id)
+        if target_dir is None:
+            # Page absent from the plan (upstream deletion, or filtered/archived
+            # out of this run): leave ALL on-disk copies untouched.
+            continue
+        target_abs = _abs_target(output_dir, target_dir)
+        canonical = _choose_canonical(entries, target_abs)
+        src_dir = canonical.file_path.parent.resolve()
+        canonical_dirs.add(src_dir)
+        delete_copies.extend(e for e in entries if e is not canonical)
+        if not _same_dir(src_dir, target_abs):
+            moves.append((src_dir, target_abs, canonical))
+
+    _execute_deletes(delete_copies, output_dir, canonical_dirs)
+
+    for _src_dir, target_abs, canonical in moves:
+        _vacate_moved_page(
+            canonical, target_abs, output_dir,
+            media_will_redownload=media_will_redownload,
+        )
+
+    move_sources = [src for src, _, _ in moves]
+    _prune_empty_dirs(output_dir, move_sources + [e.file_path.parent for e in delete_copies])
+    _heal_folder_workspaces(output_dir, move_sources)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -179,3 +179,51 @@ class TestCacheStore:
             cs = store.refresh(client, _make_space(), include_archived=True)
 
             assert cs.include_archived is True
+
+
+class TestEmptyResponse:
+    def test_zero_pages_over_populated_cache_warns_but_proceeds(self, tmp_path, capsys):
+        # A 0-page response over a populated cache warns loudly (could be a
+        # transient hiccup) but proceeds — so a genuinely-emptied space stays
+        # representable. Acting on an empty result is safe (nothing is pruned).
+        with patch("confluence_export.cache.cache_dir", return_value=tmp_path):
+            store = CacheStore()
+            store.save(_make_cached_space())  # prior populated snapshot
+            client = MagicMock()
+            client.returns_archived_pages = False
+            client.get_pages_in_space.return_value = []
+
+            result = store.refresh(client, _make_space())
+
+            assert result.pages == []  # reflects the API, not the stale cache
+            assert store.load("TEST").pages == []  # empty snapshot saved
+            assert "returned 0 pages" in capsys.readouterr().err
+
+    def test_zero_pages_with_no_prior_cache_proceeds(self, tmp_path):
+        with patch("confluence_export.cache.cache_dir", return_value=tmp_path):
+            store = CacheStore()
+            client = MagicMock()
+            client.returns_archived_pages = False
+            client.get_pages_in_space.return_value = []
+            client.get_attachments.return_value = []
+
+            result = store.refresh(client, _make_space())
+
+            assert result.pages == []  # legitimately empty space, no guard fires
+
+
+def test_resolve_folders_skips_unresolvable_parent():
+    # A parent folder that the API cannot return (get_folder_by_id -> None) is
+    # skipped, and the resolution loop terminates instead of hanging.
+    from unittest.mock import MagicMock
+
+    from confluence_export.cache import CacheStore
+    from confluence_export.types import Page
+
+    client = MagicMock()
+    client.get_folder_by_id.return_value = None
+    pages = [Page(id="c", title="C", parent_id="ghost", parent_type="folder")]
+
+    result = CacheStore._resolve_folders(client, pages)
+
+    assert [p.id for p in result] == ["c"]

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -11,6 +11,7 @@ from confluence_export.diff import (
     compute_diff,
     format_diff,
     scan_export_dir,
+    scan_export_dir_grouped,
 )
 from confluence_export.types import Page, Version
 
@@ -85,6 +86,50 @@ def test_scan_skips_invalid(tmp_path: Path):
     result = scan_export_dir(tmp_path, "TST")
     assert len(result) == 1
     assert "1" in result
+
+
+# -- scan_export_dir_grouped ---------------------------------------------------
+
+
+def test_scan_grouped_surfaces_duplicate_ids(tmp_path: Path):
+    # Two markdown files carrying the same page_id (legacy collision/orphan
+    # state) must both surface, canonical (higher version) first.
+    _write_page(tmp_path, "A/A.md", "1", 1, title="A", path="/A")
+    _write_page(tmp_path, "B/B.md", "1", 5, title="B", path="/B")
+
+    grouped = scan_export_dir_grouped(tmp_path, "TST")
+    assert len(grouped["1"]) == 2
+    assert grouped["1"][0].version == 5  # canonical first
+
+
+def test_scan_grouped_excludes_workspace_and_media(tmp_path: Path):
+    # A user markdown note inside .workspace/, or a stray .md under .media/, is
+    # not a page and must never be scanned, moved, or deleted.
+    _write_page(tmp_path, "P/.workspace/note.md", "ws", 1)
+    _write_page(tmp_path, "P/.media/leak.md", "media", 1)
+    _write_page(tmp_path, "P/P.md", "real", 1)
+
+    grouped = scan_export_dir_grouped(tmp_path, "TST")
+    assert set(grouped) == {"real"}
+
+
+def test_scan_grouped_skips_other_space_with_warning(tmp_path: Path, capsys):
+    _write_page(tmp_path, "A/A.md", "1", 1, space_key="TST")
+    _write_page(tmp_path, "B/B.md", "9", 1, space_key="OTHER")
+
+    grouped = scan_export_dir_grouped(tmp_path, "TST")
+    assert set(grouped) == {"1"}
+    assert "OTHER" in capsys.readouterr().err
+
+
+def test_scan_grouped_tolerates_garbled_version(tmp_path: Path):
+    # A non-integer / null version must degrade to 0, not crash the whole scan.
+    (tmp_path / "P").mkdir()
+    (tmp_path / "P" / "P.md").write_text(
+        "---\ntitle: P\npage_id: '1'\nspace_key: TST\nversion: not-a-number\n---\n\nBody\n"
+    )
+    grouped = scan_export_dir_grouped(tmp_path, "TST")
+    assert grouped["1"][0].version == 0
 
 
 # -- compute_diff --------------------------------------------------------------
@@ -183,3 +228,19 @@ def test_format_diff_empty():
     result = DiffResult(unchanged_count=5)
     output = format_diff(result, [])
     assert output == "Unchanged: 5 page(s)"
+
+
+def test_parse_frontmatter_unterminated_block_returns_none(tmp_path: Path):
+    from confluence_export.diff import _parse_frontmatter
+
+    f = tmp_path / "x.md"
+    f.write_text("---\ntitle: X\nbody with no closing fence\n")
+    assert _parse_frontmatter(f) is None
+
+
+def test_scan_skips_non_markdown_and_markdown_without_page_id(tmp_path: Path):
+    # A non-.md file is skipped during the walk; a .md with frontmatter but no
+    # page_id is not a page and is also skipped.
+    (tmp_path / "ignore.txt").write_text("not markdown")
+    (tmp_path / "Note.md").write_text("---\ntitle: Note\nspace_key: TST\n---\n\nbody\n")
+    assert scan_export_dir_grouped(tmp_path, "TST") == {}

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from unittest.mock import MagicMock, patch
+
+import yaml
 
 from confluence_export.exporter import ExportResult, Exporter
 from confluence_export.types import (
@@ -356,3 +358,257 @@ class TestForceRefresh:
             client, _make_space(), include_archived=True
         )
         cache.refresh.assert_not_called()
+
+
+def _seed_export_page(output_dir, rel, page_id, *, workspace=None):
+    """Write a minimal prior-export page directory (frontmatter + optional workspace)."""
+    rp = PurePosixPath(rel)
+    leaf = rp.name
+    page_dir = output_dir.joinpath(*rp.parts)
+    page_dir.mkdir(parents=True, exist_ok=True)
+    meta = {"title": leaf, "page_id": page_id, "space_key": "TEST",
+            "path": "/" + rel, "version": 1}
+    (page_dir / f"{leaf}.md").write_text(
+        f"---\n{yaml.dump(meta, sort_keys=False)}---\n\n# {leaf}\n\nold body\n"
+    )
+    if workspace is not None:
+        ws = page_dir / ".workspace"
+        ws.mkdir(exist_ok=True)
+        (ws / "u.txt").write_text(workspace)
+    return page_dir
+
+
+class TestMoveHealingEndToEnd:
+    def test_reparented_page_rewritten_at_new_path_workspace_left(self, tmp_path, capsys):
+        # A user who exported with an old version has P under A, with workspace
+        # content. After P is reparented under B, a normal full export rewrites the
+        # page at B/P; the user's .workspace is NOT carried (Option B) — it is left
+        # at the old path and the user is told where the page went.
+        exporter, _, cache = _make_exporter()
+        _seed_export_page(tmp_path, "A", "a")
+        _seed_export_page(tmp_path, "A/P", "p", workspace="mine")
+
+        a = _make_page(id="a", title="A")
+        b = _make_page(id="b", title="B")
+        p = _make_page(id="p", title="P", parent_id="b", parent_type="page")
+        cs = _make_cached_space(pages=[a, b, p])
+        cache.refresh.return_value = cs
+
+        exporter.export_space(_make_space(), tmp_path, force_refresh=True)
+
+        assert (tmp_path / "B" / "P" / "P.md").exists()             # rewritten at new path
+        assert not (tmp_path / "A" / "P" / "P.md").exists()         # stale md dropped
+        assert (tmp_path / "A" / "P" / ".workspace" / "u.txt").read_text() == "mine"  # left
+        assert "do not move automatically" in capsys.readouterr().err
+
+
+class TestSelfNestEndToEnd:
+    def test_reparent_into_own_name_no_crash_leaves_workspace(self, tmp_path):
+        # p2 was the top-level "Eps"; a different new page p1 is now titled "Eps"
+        # and p2 is reparented under it (target Eps/Bar). The export must not
+        # crash or lose data: reconcile drops p2's stale md and leaves its
+        # .workspace at the old path; the write walk recreates both pages fresh.
+        exporter, _, cache = _make_exporter()
+        _seed_export_page(tmp_path, "Eps", "p2", workspace="keep")
+        p1 = _make_page(id="p1", title="Eps", body="<p>parent</p>")
+        p2 = _make_page(id="p2", title="Bar", parent_id="p1", parent_type="page",
+                        body="<p>child</p>")
+        cs = _make_cached_space(pages=[p1, p2])
+        cache.refresh.return_value = cs
+
+        exporter.export_space(_make_space(), tmp_path, force_refresh=True)
+
+        assert "parent" in (tmp_path / "Eps" / "Eps.md").read_text()        # p1
+        assert "child" in (tmp_path / "Eps" / "Bar" / "Bar.md").read_text()  # p2 written at new path
+        # p2's workspace stays at its old path (now under p1's dir), not carried.
+        assert (tmp_path / "Eps" / ".workspace" / "u.txt").read_text() == "keep"
+
+
+class TestReconcileWriterHandshake:
+    def test_swap_writes_each_page_at_its_new_path_workspaces_stay_put(self, tmp_path):
+        # Two siblings swap names. Each page's content is rewritten fresh at its NEW
+        # path, but the user workspaces are NOT swapped — each stays at its old
+        # physical path (Option B; the user is warned).
+        exporter, _, cache = _make_exporter()
+        _seed_export_page(tmp_path, "Alpha", "a", workspace="A-ws")
+        _seed_export_page(tmp_path, "Beta", "b", workspace="B-ws")
+        a = _make_page(id="a", title="Beta", body="<p>content A</p>")
+        b = _make_page(id="b", title="Alpha", body="<p>content B</p>")
+        cs = _make_cached_space(pages=[a, b])
+        cache.refresh.return_value = cs
+
+        exporter.export_space(_make_space(), tmp_path, force_refresh=True)
+
+        # Content swaps (a -> Beta, b -> Alpha); workspaces stay where they were.
+        assert "content A" in (tmp_path / "Beta" / "Beta.md").read_text()
+        assert "content B" in (tmp_path / "Alpha" / "Alpha.md").read_text()
+        assert (tmp_path / "Alpha" / ".workspace" / "u.txt").read_text() == "A-ws"
+        assert (tmp_path / "Beta" / ".workspace" / "u.txt").read_text() == "B-ws"
+
+    def test_git_move_preserves_follow_history_workspace_left_at_old_path(self, tmp_path):
+        # End-to-end proof of the Option B design in a git dir: a reparented page is
+        # rewritten fresh at its new path + the old path git-rm'd, and git's own
+        # rename detection makes `git log --follow` cross the move — no `git mv`,
+        # no sidecar relocation. The user's .workspace is left at the old path.
+        import subprocess
+
+        from confluence_export.git import commit_export, ensure_repo
+
+        ensure_repo(tmp_path)
+        exporter, _, cache = _make_exporter()
+        body = "<p>" + "a substantial body of content for git rename detection. " * 4 + "</p>"
+
+        # Export 1: P under A.
+        cache.refresh.return_value = _make_cached_space(pages=[
+            _make_page(id="a", title="A", body="<p>parent</p>"),
+            _make_page(id="p", title="P", parent_id="a", parent_type="page", body=body),
+        ])
+        r1 = exporter.export_space(_make_space(), tmp_path, force_refresh=True)
+        commit_export(tmp_path, r1.written_files, "TEST")
+        (tmp_path / "A" / "P" / ".workspace" / "prep.py").write_text("print(1)")
+
+        # Export 2: P reparented under a new page B.
+        cache.refresh.return_value = _make_cached_space(pages=[
+            _make_page(id="a", title="A", body="<p>parent</p>"),
+            _make_page(id="b", title="B", body="<p>new parent</p>"),
+            _make_page(id="p", title="P", parent_id="b", parent_type="page", body=body),
+        ])
+        r2 = exporter.export_space(_make_space(), tmp_path, force_refresh=True)
+        commit_export(tmp_path, r2.written_files, "TEST")
+
+        assert (tmp_path / "B" / "P" / "P.md").exists()
+        # The user's prep files are left at the old path (not carried to B/P).
+        assert (tmp_path / "A" / "P" / ".workspace" / "prep.py").read_text() == "print(1)"
+        assert not (tmp_path / "A" / "P" / "P.md").exists()  # stale md dropped
+        follow = subprocess.run(
+            ["git", "log", "--follow", "--oneline", "--", "B/P/P.md"],
+            cwd=tmp_path, capture_output=True, text=True,
+        ).stdout
+        assert len(follow.strip().splitlines()) >= 2  # history crosses the move (rename detected)
+
+    def test_committed_workspace_stays_tracked_at_old_path_on_move(self, tmp_path):
+        # Option B is deliberate even for a COMMITTED .workspace: conex does not
+        # move it. On a page move the committed workspace stays tracked at its old
+        # path (the prune skips .workspace); the user moves it themselves if they
+        # want. The page markdown still follows the move as a git rename.
+        import subprocess
+
+        from confluence_export.git import commit_export, ensure_repo
+
+        def _git(*a):
+            subprocess.run(["git", *a], cwd=tmp_path, capture_output=True)
+
+        ensure_repo(tmp_path)
+        exporter, _, cache = _make_exporter()
+        body = "<p>" + "a substantial body for git rename detection. " * 4 + "</p>"
+        cache.refresh.return_value = _make_cached_space(pages=[
+            _make_page(id="a", title="A", body="<p>p</p>"),
+            _make_page(id="p", title="P", parent_id="a", parent_type="page", body=body),
+        ])
+        r1 = exporter.export_space(_make_space(), tmp_path, force_refresh=True)
+        commit_export(tmp_path, r1.written_files, "TEST")
+        # The user commits a workspace prep file.
+        (tmp_path / "A" / "P" / ".workspace" / "prep.py").write_text("print(1)")
+        _git("add", "A/P/.workspace")
+        _git("commit", "-m", "track workspace")
+
+        # Reparent P under B.
+        cache.refresh.return_value = _make_cached_space(pages=[
+            _make_page(id="a", title="A", body="<p>p</p>"),
+            _make_page(id="b", title="B", body="<p>np</p>"),
+            _make_page(id="p", title="P", parent_id="b", parent_type="page", body=body),
+        ])
+        r2 = exporter.export_space(_make_space(), tmp_path, force_refresh=True)
+        commit_export(tmp_path, r2.written_files, "TEST")
+
+        ls = subprocess.run(["git", "ls-files"], cwd=tmp_path, capture_output=True, text=True).stdout
+        assert "A/P/.workspace/prep.py" in ls        # stays tracked at the OLD path
+        assert "B/P/.workspace/prep.py" not in ls     # NOT carried to the new path
+        assert "B/P/P.md" in ls                       # the page itself moved
+        assert "A/P/P.md" not in ls
+
+    def test_real_page_titled_archived_not_spuriously_moved(self, tmp_path):
+        # A real live page titled "_archived" loses the bare name to the synthetic
+        # __archived__ container (gets "_archived-2"). The reconcile plan must
+        # agree with the write-walk plan on its target, or it churns its workspace.
+        exporter, _, cache = _make_exporter()
+        _seed_export_page(tmp_path, "_archived-2", "r", workspace="keep")
+        live = _make_page(id="r", title="_archived", body="<p>real</p>")
+        archived = _make_page(id="z", title="Zarch", body="<p>old</p>")
+        archived.status = "archived"
+        cache.refresh.return_value = _make_cached_space(pages=[live, archived])
+
+        exporter.export_space(_make_space(), tmp_path, force_refresh=True)  # no include_archived
+
+        assert (tmp_path / "_archived-2" / ".workspace" / "u.txt").read_text() == "keep"
+        assert not (tmp_path / "_archived" / ".workspace").exists()  # not relocated into the container
+
+    def test_reconcile_failure_does_not_abort_export(self, tmp_path):
+        # A reconcile exception must never abort the export; the write walk still
+        # produces correct content at planned paths.
+        exporter, _, cache = _make_exporter()
+        cs = _make_cached_space()
+        cache.refresh.return_value = cs
+
+        with patch("confluence_export.reconcile.reconcile", side_effect=RuntimeError("boom")):
+            exporter.export_space(_make_space(), tmp_path, force_refresh=True)
+
+        assert (tmp_path / "Test-Page" / "Test-Page.md").exists()
+
+
+class TestFolderWorkspace:
+    def test_folder_gets_no_workspace_but_pages_do(self, tmp_path):
+        exporter, _, cache = _make_exporter()
+        folder = _make_page(id="f", title="Section")
+        folder.status = "folder"
+        child = _make_page(id="c", title="Doc", parent_id="f", parent_type="page")
+        cs = _make_cached_space(pages=[folder, child])
+        cache.ensure_loaded.return_value = cs
+
+        exporter.export_space(_make_space(), tmp_path)
+
+        assert (tmp_path / "Section").is_dir()
+        assert not (tmp_path / "Section" / ".workspace").exists()
+        assert (tmp_path / "Section" / "Doc" / ".workspace").is_dir()
+
+
+class TestExporterDefensiveBranches:
+    def test_prefetch_body_failure_warns_and_continues(self, tmp_path, capsys):
+        # A page with no cached body triggers a prefetch; if the API call fails the
+        # export warns and continues rather than aborting.
+        exporter, client, cache = _make_exporter()
+        cache.ensure_loaded.return_value = _make_cached_space(
+            pages=[_make_page(id="p", title="P", body="")]
+        )
+        client.get_page_by_id.side_effect = RuntimeError("api down")
+
+        exporter.export_space(_make_space(), tmp_path)
+
+        assert "could not fetch body for P" in capsys.readouterr().err
+
+    def test_reconcile_uses_full_plan_when_include_archived(self, tmp_path):
+        # A full, force-refresh export with include_archived=True exercises the
+        # reconcile_plan = self._plan branch (no archived-id filtering).
+        exporter, _, cache = _make_exporter()
+        cache.refresh.return_value = _make_cached_space(pages=[_make_page(id="p", title="P")])
+
+        exporter.export_space(
+            _make_space(), tmp_path, force_refresh=True, include_archived=True
+        )
+
+        assert (tmp_path / "P" / "P.md").exists()
+
+    def test_single_page_export_with_path_filter_and_no_children(self, tmp_path):
+        # path_filter + no_children exports just the matched node (nodes_to_export
+        # = [node]) and none of its children.
+        exporter, _, cache = _make_exporter()
+        cache.ensure_loaded.return_value = _make_cached_space(pages=[
+            _make_page(id="r", title="Root"),
+            _make_page(id="c", title="Child", parent_id="r", parent_type="page"),
+        ])
+
+        result = exporter.export_space(
+            _make_space(), tmp_path, path_filter="/Root", no_children=True
+        )
+
+        assert result.count == 1  # only Root, children excluded

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -248,6 +248,117 @@ class TestCommitExport:
         assert "Old-Name.md" not in ls.stdout
         assert "New-Name.md" in ls.stdout
 
+    def test_recased_page_does_not_trigger_stale_prune_warning(self, tmp_path, capsys):
+        """On a case-insensitive FS a title whose only change is case must not be
+        seen as both written (new case) and stale (old case): that makes git rm
+        fail on staged content and leaves a 'survived the prune' warning that only
+        clears on the next export (the real-export finding on PR #25)."""
+        import pytest
+
+        from confluence_export.git import _fs_is_case_insensitive
+
+        self._init_repo(tmp_path)
+        if not _fs_is_case_insensitive(tmp_path):
+            pytest.skip("requires a case-insensitive filesystem")
+
+        page = tmp_path / "Foo"
+        page.mkdir()
+        (page / "Foo.md").write_text("# Foo")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "first export"], cwd=tmp_path, capture_output=True)
+
+        # The title is re-cased: the writer now produces "foo/foo.md" (same files
+        # on a case-insensitive FS). A single full export must converge.
+        (page / "foo.md").write_text("# Foo v2")
+        commit_export(tmp_path, [page / "foo.md"], "TEST")
+
+        assert "survived the prune" not in capsys.readouterr().err
+        ls = subprocess.run(["git", "ls-files"], cwd=tmp_path, capture_output=True, text=True).stdout
+        assert ls.lower().count("foo/foo.md") == 1  # one tracked copy, no case-dup churn
+
+    def test_recase_converges_even_when_core_ignorecase_lies(self, tmp_path, capsys):
+        """We must probe the real FS, not trust git's core.ignorecase: that value
+        is fixed at init and drifts (a Linux/CI clone opened on a Mac carries
+        ignorecase=false). With it forced false on a case-insensitive FS, the
+        re-case must STILL converge in one export — the case the unit relies on."""
+        import pytest
+
+        from confluence_export.git import _fs_is_case_insensitive
+
+        self._init_repo(tmp_path)
+        if not _fs_is_case_insensitive(tmp_path):
+            pytest.skip("requires a case-insensitive filesystem")
+        # Force git's recorded verdict to disagree with the real (insensitive) FS.
+        subprocess.run(["git", "config", "core.ignorecase", "false"], cwd=tmp_path, capture_output=True)
+
+        page = tmp_path / "Bar"
+        page.mkdir()
+        (page / "Bar.md").write_text("# Bar")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "first export"], cwd=tmp_path, capture_output=True)
+
+        (page / "bar.md").write_text("# Bar v2")
+        commit_export(tmp_path, [page / "bar.md"], "TEST")
+
+        assert "survived the prune" not in capsys.readouterr().err  # FS probe, not config
+
+    def test_moved_media_re_downloaded_at_new_path_follows_as_rename(self, tmp_path):
+        """A moved page's .media is disposable (Option B): the reconciler drops it
+        at the old path and the write walk re-downloads it at the new path. The
+        stale-file prune removes the old tracked copy and git's own rename
+        detection links the dropped + re-added attachment — no relocation."""
+        self._init_repo(tmp_path)
+        old = tmp_path / "A" / "P"
+        (old / ".media").mkdir(parents=True)
+        (old / "P.md").write_text("# P")
+        (old / ".media" / "img.png").write_bytes(b"\x89PNG-bytes-for-rename-detection")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "first export"], cwd=tmp_path, capture_output=True)
+
+        # Simulate the export of the moved page: old markdown + media dropped (by
+        # the reconciler), both rewritten/re-downloaded fresh at the new path.
+        new = tmp_path / "B" / "P"
+        (new / ".media").mkdir(parents=True)
+        import shutil
+
+        shutil.rmtree(old / ".media")
+        (old / "P.md").unlink()
+        old.rmdir()
+        (new / "P.md").write_text("# P")
+        (new / ".media" / "img.png").write_bytes(b"\x89PNG-bytes-for-rename-detection")
+
+        commit_export(tmp_path, [new / "P.md", new / ".media" / "img.png"], "TEST")
+
+        ls = subprocess.run(["git", "ls-files"], cwd=tmp_path, capture_output=True, text=True).stdout
+        assert "B/P/.media/img.png" in ls          # tracked at the new path
+        assert "A/P/.media/img.png" not in ls       # old tracked copy pruned
+        follow = subprocess.run(
+            ["git", "log", "--follow", "--oneline", "--", "B/P/.media/img.png"],
+            cwd=tmp_path, capture_output=True, text=True,
+        ).stdout
+        assert len(follow.strip().splitlines()) >= 2  # history follows the rename
+
+    def test_partial_export_does_not_prune(self, tmp_path):
+        """is_full=False (filtered/subtree export) must NOT git-rm files outside
+        the written subset — otherwise a subtree export wipes the rest of the repo."""
+        self._init_repo(tmp_path)
+        kept = tmp_path / "Sub" / "Sub.md"
+        kept.parent.mkdir()
+        kept.write_text("# Sub")
+        rest = tmp_path / "Other" / "Other.md"
+        rest.parent.mkdir()
+        rest.write_text("# Other")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "full export"], cwd=tmp_path, capture_output=True)
+
+        # A filtered re-export writes only the Sub subtree.
+        kept.write_text("# Sub v2")
+        commit_export(tmp_path, [kept], "TEST", is_full=False)
+
+        ls = subprocess.run(["git", "ls-files"], cwd=tmp_path, capture_output=True, text=True)
+        assert "Other/Other.md" in ls.stdout  # untouched by a partial export
+        assert (tmp_path / "Other" / "Other.md").exists()
+
     def test_commit_message_contains_timestamp(self, tmp_path):
         self._init_repo(tmp_path)
         md = tmp_path / "Page.md"
@@ -467,3 +578,158 @@ class TestCommitExport:
         ls = subprocess.run(["git", "ls-files"], cwd=tmp_path, capture_output=True, text=True)
         assert ".conex/config.json" in ls.stdout
         assert "Old.md" not in ls.stdout
+
+
+def _raise_filenotfound(*args, **kwargs):
+    raise FileNotFoundError("git missing")
+
+
+class TestGitDefensiveBranches:
+    """Cover the error/fallback branches of the git helpers (no pragma policy in
+    this repo — defensive paths are exercised with monkeypatched failures)."""
+
+    def test_is_secret_config_path_outside_output_dir(self, tmp_path):
+        from confluence_export.git import _is_secret_config_path
+
+        # A path that is NOT under output_dir hits the ValueError fallback, which
+        # inspects the raw path string instead of the relative one.
+        assert _is_secret_config_path(tmp_path, Path("/elsewhere/.conex/c.json")) is True
+        assert _is_secret_config_path(tmp_path, Path("/elsewhere/page.md")) is False
+
+    def test_run_git_returns_none_when_binary_missing(self, tmp_path, monkeypatch, capsys):
+        from confluence_export import git as G
+
+        monkeypatch.setattr(subprocess, "run", _raise_filenotfound)
+        assert G._run_git(tmp_path, "status") is None
+        assert "git status failed" in capsys.readouterr().err
+
+    def test_ensure_repo_false_when_init_fails(self, tmp_path, monkeypatch):
+        from confluence_export import git as G
+
+        real = G._run_git
+
+        def fake(repo, *args, **kwargs):
+            if args and args[0] == "init":
+                return None
+            return real(repo, *args, **kwargs)
+
+        monkeypatch.setattr(G, "_run_git", fake)
+        assert G.ensure_repo(tmp_path) is False
+
+    def test_commit_local_changes_false_when_add_fails(self, tmp_path, monkeypatch):
+        from confluence_export import git as G
+
+        ensure_repo(tmp_path)
+        (tmp_path / "a.md").write_text("x")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "i"], cwd=tmp_path, capture_output=True)
+
+        real = G._run_git
+
+        def fake(repo, *args, **kwargs):
+            if args[:2] == ("add", "-u"):
+                return None
+            return real(repo, *args, **kwargs)
+
+        monkeypatch.setattr(G, "_run_git", fake)
+        assert commit_local_changes(tmp_path) is False
+
+    def test_fs_case_probe_false_when_mkstemp_fails(self, tmp_path, monkeypatch):
+        import tempfile
+
+        from confluence_export import git as G
+
+        def _boom(*args, **kwargs):
+            raise OSError("no temp")
+
+        monkeypatch.setattr(tempfile, "mkstemp", _boom)
+        assert G._fs_is_case_insensitive(tmp_path) is False
+
+    def test_fs_case_probe_swallows_unlink_error(self, tmp_path, monkeypatch):
+        from confluence_export import git as G
+
+        def _boom(self, *args, **kwargs):
+            raise OSError("locked")
+
+        # mkstemp succeeds; the finally's probe.unlink() raises and is swallowed.
+        monkeypatch.setattr(Path, "unlink", _boom)
+        assert G._fs_is_case_insensitive(tmp_path) in (True, False)
+
+    def test_remove_stale_files_returns_early_when_index_empty(self, tmp_path, monkeypatch):
+        from confluence_export import git as G
+
+        ensure_repo(tmp_path)
+        (tmp_path / "a.md").write_text("x")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "i"], cwd=tmp_path, capture_output=True)
+
+        real = G._run_git
+
+        class _Empty:
+            stdout = ""
+            returncode = 0
+
+        def fake(repo, *args, **kwargs):
+            if args and args[0] == "ls-files":
+                return _Empty()
+            return real(repo, *args, **kwargs)
+
+        monkeypatch.setattr(G, "_run_git", fake)
+        G._remove_stale_files(tmp_path, [])  # hits the empty-index guard; no raise
+
+    def test_remove_stale_files_warns_when_rm_fails(self, tmp_path, monkeypatch, capsys):
+        from confluence_export import git as G
+
+        ensure_repo(tmp_path)
+        (tmp_path / "old.md").write_text("x")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "i"], cwd=tmp_path, capture_output=True)
+
+        real = G._run_git
+
+        class _Fail:
+            stdout = ""
+            returncode = 1
+
+        def fake(repo, *args, **kwargs):
+            if args and args[0] == "rm":
+                return _Fail()
+            return real(repo, *args, **kwargs)
+
+        monkeypatch.setattr(G, "_run_git", fake)
+        # old.md is tracked but not in written_files -> stale -> rm attempted ->
+        # batch fails -> per-path fallback also fails -> warning.
+        G._remove_stale_files(tmp_path, [])
+        assert "survived the prune" in capsys.readouterr().err
+
+    def test_remove_stale_files_per_path_fallback_succeeds(self, tmp_path, monkeypatch, capsys):
+        # The point of the per-path fallback: a batch `git rm` fails but the
+        # individual paths then succeed, so the stale files ARE pruned and no
+        # warning is printed. (Previously only the all-fail path was covered.)
+        from confluence_export import git as G
+
+        ensure_repo(tmp_path)
+        (tmp_path / "old.md").write_text("x")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "i"], cwd=tmp_path, capture_output=True)
+
+        real = G._run_git
+        state = {"rm_calls": 0}
+
+        class _Fail:
+            stdout = ""
+            returncode = 1
+
+        def fake(repo, *args, **kwargs):
+            if args and args[0] == "rm":
+                state["rm_calls"] += 1
+                if state["rm_calls"] == 1:
+                    return _Fail()  # fail the first (batch) rm
+            return real(repo, *args, **kwargs)  # the per-path rm runs for real
+
+        monkeypatch.setattr(G, "_run_git", fake)
+        G._remove_stale_files(tmp_path, [])
+
+        ls = subprocess.run(["git", "ls-files"], cwd=tmp_path, capture_output=True, text=True).stdout
+        assert "old.md" not in ls  # pruned via the per-path fallback
+        assert "survived the prune" not in capsys.readouterr().err

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -241,3 +241,10 @@ class TestMigrateMediaDirs:
     def test_empty_tree(self, tmp_path):
         """No media/ dirs at all — returns empty list."""
         assert migrate_media_dirs(tmp_path) == []
+
+
+def test_load_versions_returns_empty_on_corrupt_json(tmp_path):
+    from confluence_export.media import _VERSIONS_FILE, _load_versions
+
+    (tmp_path / _VERSIONS_FILE).write_text("{ not valid json")
+    assert _load_versions(tmp_path) == {}

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1,0 +1,345 @@
+"""Tests for the move reconciler (issue #17, Option B — detect-and-warn).
+
+The reconciler never moves page directories or sidecars. A full export rewrites
+every page's markdown fresh at its new path and git detects the rename, and
+``.media`` re-downloads at the new path, so on a move the reconciler only: drops
+the stale old markdown + ``.media`` (disposable), leaves a non-empty user
+``.workspace`` in place with a note (conex deliberately does NOT auto-carry it),
+removes an empty auto-created ``.workspace``, heals legacy duplicates, and prunes
+emptied shells.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+
+import yaml
+
+from confluence_export.layout import plan_layout
+from confluence_export.reconcile import reconcile
+from confluence_export.tree import build_tree
+from confluence_export.types import Page
+
+
+def _page(id, title, parent_id="", position=0, status="page"):
+    return Page(id=id, title=title, parent_id=parent_id,
+                parent_type="page" if parent_id else "space",
+                position=position, status=status)
+
+
+def _plan(pages):
+    return plan_layout(build_tree(pages))
+
+
+def _frontmatter(page_id, title, version=1, space_key="TEST"):
+    meta = {"title": title, "page_id": page_id, "space_key": space_key,
+            "path": f"/{title}", "version": version}
+    return f"---\n{yaml.dump(meta, sort_keys=False, allow_unicode=True)}---\n\n# {title}\n\nbody\n"
+
+
+def _seed(output_dir, rel, page_id, *, title=None, version=1, workspace=None, media=None):
+    """Create a page directory on disk; its markdown stem is rel's final segment."""
+    rel_path = PurePosixPath(rel)
+    leaf = rel_path.name
+    title = leaf if title is None else title
+    page_dir = output_dir.joinpath(*rel_path.parts)
+    page_dir.mkdir(parents=True, exist_ok=True)
+    (page_dir / f"{leaf}.md").write_text(_frontmatter(page_id, title, version))
+    if workspace is not None:
+        ws = page_dir / ".workspace"
+        ws.mkdir(exist_ok=True)
+        (ws / "note.txt").write_text(workspace)
+    if media is not None:
+        m = page_dir / ".media"
+        m.mkdir(exist_ok=True)
+        (m / "img.png").write_text(media)
+    return page_dir
+
+
+class TestMovedPage:
+    def test_reparent_drops_old_md_and_media_and_leaves_workspace_with_note(self, tmp_path, capsys):
+        _seed(tmp_path, "A", "a")
+        _seed(tmp_path, "A/P", "p", workspace="user script", media="png-bytes")
+        plan = _plan([_page("a", "A"), _page("b", "B"), _page("p", "P", parent_id="b")])
+
+        reconcile(plan, tmp_path, "TEST")
+
+        # The user's .workspace is NOT carried — left in place at the old path...
+        assert (tmp_path / "A" / "P" / ".workspace" / "note.txt").read_text() == "user script"
+        # ...the disposable markdown + media are dropped (regenerated at B/P)...
+        assert not (tmp_path / "A" / "P" / "P.md").exists()
+        assert not (tmp_path / "A" / "P" / ".media").exists()
+        # ...reconcile does NOT write the page at the new path (the writer does)...
+        assert not (tmp_path / "B" / "P" / "P.md").exists()
+        assert (tmp_path / "A" / "A.md").exists()  # untouched sibling parent
+        # ...and the user is told where the page went.
+        err = capsys.readouterr().err
+        assert "moved to" in err and "B/P" in err and "do not move automatically" in err
+
+    def test_note_points_at_new_path_and_old_workspace(self, tmp_path, capsys):
+        _seed(tmp_path, "Old", "p", title="Old", workspace="keep")
+        reconcile(_plan([_page("q", "New-Parent"), _page("p", "Old", parent_id="q")]),
+                  tmp_path, "TEST")
+        err = capsys.readouterr().err
+        assert "New-Parent/Old" in err            # new location
+        assert "Old/.workspace" in err            # where the prep files are
+
+    def test_no_media_move_announces_dropped_attachments(self, tmp_path, capsys):
+        # Under --no-media (media_will_redownload=False) the old .media is still
+        # dropped, but the loss is announced, not silent.
+        _seed(tmp_path, "A/P", "p", media="png-bytes")
+        reconcile(_plan([_page("q", "B"), _page("p", "P", parent_id="q")]),
+                  tmp_path, "TEST", media_will_redownload=False)
+        assert not (tmp_path / "A" / "P" / ".media").exists()  # still dropped
+        err = capsys.readouterr().err
+        assert "cached attachments" in err and "re-run a full export with media" in err
+
+    def test_with_media_move_does_not_announce_attachments(self, tmp_path, capsys):
+        # The default (media_will_redownload=True) re-downloads at the new path,
+        # so dropping the old .media is a non-event — no attachment note.
+        _seed(tmp_path, "A/P", "p", media="png-bytes")
+        reconcile(_plan([_page("q", "B"), _page("p", "P", parent_id="q")]), tmp_path, "TEST")
+        assert "cached attachments" not in capsys.readouterr().err
+
+    def test_sidecarless_move_just_drops_old_markdown(self, tmp_path):
+        # A page with no .workspace/.media: nothing to leave behind; reconcile only
+        # removes the stale old .md and prunes the emptied shell.
+        _seed(tmp_path, "A", "a")
+        _seed(tmp_path, "A/P", "p")
+        reconcile(_plan([_page("a", "A"), _page("b", "B"), _page("p", "P", parent_id="b")]),
+                  tmp_path, "TEST")
+        assert not (tmp_path / "A" / "P").exists()
+
+    def test_move_with_only_empty_workspace_leaves_no_orphan_dir(self, tmp_path):
+        # Every page gets an auto-created EMPTY .workspace on export. Moving a page
+        # with no user content must still fully remove the old dir — the empty
+        # .workspace must not keep the old shell alive (rmdir-only prune).
+        _seed(tmp_path, "A", "a")
+        page_dir = _seed(tmp_path, "A/P", "p")
+        (page_dir / ".workspace").mkdir()  # auto-created, empty
+        reconcile(_plan([_page("a", "A"), _page("b", "B"), _page("p", "P", parent_id="b")]),
+                  tmp_path, "TEST")
+        assert not (tmp_path / "A" / "P").exists()  # no old/path/.workspace/ orphan
+
+    def test_no_return_value(self, tmp_path):
+        # reconcile is a side-effecting relayout; it returns nothing (no git
+        # relocation list to stage anymore).
+        _seed(tmp_path, "A/P", "p")
+        assert reconcile(_plan([_page("p", "P")]), tmp_path, "TEST") is None
+
+
+class TestCaseOnlyRename:
+    def test_case_only_target_is_noop(self, tmp_path):
+        # A case-only title change ("Page" -> "page") must not be seen as a move
+        # on a case-insensitive FS (same dir) — otherwise it churns every export.
+        (tmp_path / "CaseProbe").mkdir()
+        case_insensitive = (tmp_path / "caseprobe").exists()
+        (tmp_path / "CaseProbe").rmdir()
+        if not case_insensitive:
+            import pytest
+
+            pytest.skip("requires a case-insensitive filesystem")
+
+        _seed(tmp_path, "Page", "p1", workspace="keep")
+        reconcile(_plan([_page("p1", "page")]), tmp_path, "TEST")
+
+        assert (tmp_path / "Page" / ".workspace" / "note.txt").read_text() == "keep"
+        assert (tmp_path / "Page" / "Page.md").exists()  # not dropped — not a move
+
+
+class TestDuplicateHealAtTarget:
+    def test_at_target_copy_wins_over_higher_version_off_target(self, tmp_path):
+        # A stale lower-version copy sits AT the target; a higher-version copy is
+        # off-target. The at-target copy must be canonical (no move), so the live
+        # target content is not destroyed; the off-target duplicate is pruned.
+        _seed(tmp_path, "Page", "p1", version=1)
+        _seed(tmp_path, "Old", "p1", title="Old", version=2, workspace="w")
+        reconcile(_plan([_page("p1", "Page")]), tmp_path, "TEST")
+
+        assert (tmp_path / "Page" / "Page.md").exists()        # at-target copy kept
+        assert not (tmp_path / "Old" / "Old.md").exists()      # off-target duplicate's md deleted
+        # The off-target duplicate's user .workspace is preserved (never destroyed).
+        assert (tmp_path / "Old" / ".workspace" / "note.txt").read_text() == "w"
+
+
+class TestSwap:
+    def test_workspace_swap_leaves_each_at_its_old_path(self, tmp_path):
+        # Two siblings swap names AND both have user workspace. conex does NOT swap
+        # the workspaces — each stays at its old physical path with a note; only
+        # the disposable markdown is dropped (the writer rewrites it swapped).
+        _seed(tmp_path, "Alpha", "a", title="Alpha", workspace="A-ws")
+        _seed(tmp_path, "Beta", "b", title="Beta", workspace="B-ws")
+        plan = _plan([_page("a", "Beta", position=0), _page("b", "Alpha", position=1)])
+
+        reconcile(plan, tmp_path, "TEST")
+
+        assert (tmp_path / "Alpha" / ".workspace" / "note.txt").read_text() == "A-ws"
+        assert (tmp_path / "Beta" / ".workspace" / "note.txt").read_text() == "B-ws"
+        assert not (tmp_path / "Alpha" / "Alpha.md").exists()
+        assert not (tmp_path / "Beta" / "Beta.md").exists()
+
+
+class TestSelfNest:
+    def test_reparent_into_own_subtree_leaves_workspace_with_note(self, tmp_path, capsys):
+        # p2 ("Eps") is reparented under a NEW page p1 that takes its old name, so
+        # p2's target Eps/Bar is INSIDE p2's own old dir. The old .workspace is left
+        # at Eps/ (where p1 will be written) with a note; the stale md is dropped.
+        _seed(tmp_path, "Eps", "p2", workspace="keep")
+        plan = _plan([_page("p1", "Eps"), _page("p2", "Bar", parent_id="p1")])
+
+        reconcile(plan, tmp_path, "TEST")
+
+        assert (tmp_path / "Eps" / ".workspace" / "note.txt").read_text() == "keep"
+        assert not (tmp_path / "Eps" / "Eps.md").exists()  # stale md dropped
+        assert "do not move automatically" in capsys.readouterr().err
+
+
+class TestFolderRename:
+    def test_legacy_empty_folder_workspace_tidied(self, tmp_path):
+        (tmp_path / "Docs").mkdir()
+        (tmp_path / "Docs" / ".workspace").mkdir()
+        _seed(tmp_path, "Docs/Guide", "guide", workspace="g")
+        plan = _plan([
+            _page("f", "Manuals", status="folder"),
+            _page("guide", "Guide", parent_id="f"),
+        ])
+
+        reconcile(plan, tmp_path, "TEST")
+
+        # Guide's own .workspace is left at the old path (warn-and-leave)...
+        assert (tmp_path / "Docs" / "Guide" / ".workspace" / "note.txt").read_text() == "g"
+        # ...but the empty legacy FOLDER .workspace is tidied away.
+        assert not (tmp_path / "Docs" / ".workspace").exists()
+
+    def test_legacy_nonempty_folder_workspace_preserved_and_warned(self, tmp_path, capsys):
+        (tmp_path / "Docs").mkdir()
+        ws = tmp_path / "Docs" / ".workspace"
+        ws.mkdir()
+        (ws / "prep.txt").write_text("mine")
+        _seed(tmp_path, "Docs/Guide", "guide")
+        plan = _plan([
+            _page("f", "Manuals", status="folder"),
+            _page("guide", "Guide", parent_id="f"),
+        ])
+
+        reconcile(plan, tmp_path, "TEST")
+
+        assert (tmp_path / "Docs" / ".workspace" / "prep.txt").read_text() == "mine"
+        assert "user .workspace left" in capsys.readouterr().err
+
+
+class TestArchiveToggle:
+    def test_archive_leaves_workspace_at_old_path_with_note(self, tmp_path, capsys):
+        _seed(tmp_path, "Page", "p1", workspace="keep")
+        plan = _plan([_page("p1", "Page", status="archived")])
+
+        reconcile(plan, tmp_path, "TEST")
+
+        # The page's target moves into _archived/, so its old md is dropped, but the
+        # user .workspace is left at the old path with a note (not carried).
+        assert (tmp_path / "Page" / ".workspace" / "note.txt").read_text() == "keep"
+        assert not (tmp_path / "Page" / "Page.md").exists()
+        assert "_archived" in capsys.readouterr().err
+
+
+class TestLegacyDuplicateHeal:
+    def test_canonical_kept_duplicate_pruned_workspace_preserved(self, tmp_path, capsys):
+        _seed(tmp_path, "Page", "p1", version=2)
+        _seed(tmp_path, "OldPage", "p1", title="OldPage", version=1,
+              workspace="keep me", media="x")
+        plan = _plan([_page("p1", "Page")])
+
+        reconcile(plan, tmp_path, "TEST")
+
+        assert (tmp_path / "Page" / "Page.md").exists()  # canonical (at target) untouched
+        assert not (tmp_path / "OldPage" / "OldPage.md").exists()
+        assert not (tmp_path / "OldPage" / ".media").exists()
+        assert (tmp_path / "OldPage" / ".workspace" / "note.txt").read_text() == "keep me"
+        assert "orphaned workspace" in capsys.readouterr().err
+
+    def test_duplicate_without_workspace_pruned(self, tmp_path):
+        _seed(tmp_path, "Page", "p1", version=2)
+        _seed(tmp_path, "OldPage", "p1", title="OldPage", version=1)
+        reconcile(_plan([_page("p1", "Page")]), tmp_path, "TEST")
+        assert (tmp_path / "Page" / "Page.md").exists()
+        assert not (tmp_path / "OldPage").exists()
+
+
+class TestNoOp:
+    def test_absent_page_left_in_place(self, tmp_path):
+        _seed(tmp_path, "Gone", "gone", workspace="mine")
+        reconcile(_plan([_page("other", "Other")]), tmp_path, "TEST")
+        assert (tmp_path / "Gone" / "Gone.md").exists()
+        assert (tmp_path / "Gone" / ".workspace" / "note.txt").read_text() == "mine"
+
+    def test_idempotent_second_run_is_noop(self, tmp_path):
+        _seed(tmp_path, "A", "a")
+        _seed(tmp_path, "A/P", "p", workspace="w")
+        plan = _plan([_page("a", "A"), _page("b", "B"), _page("p", "P", parent_id="b")])
+
+        reconcile(plan, tmp_path, "TEST")
+        before = {str(p.relative_to(tmp_path)) for p in tmp_path.rglob("*")}
+        reconcile(plan, tmp_path, "TEST")
+        after = {str(p.relative_to(tmp_path)) for p in tmp_path.rglob("*")}
+        assert before == after
+
+
+def _raise_oserror(*args, **kwargs):
+    raise OSError("forced")
+
+
+class TestHelperBranches:
+    def test_rel_str_falls_back_when_not_under_output_dir(self, tmp_path):
+        from confluence_export.reconcile import _rel_str
+
+        outside = tmp_path.parent / "elsewhere"
+        assert _rel_str(outside, tmp_path) == str(outside)
+
+    def test_same_dir_returns_false_on_oserror(self, tmp_path, monkeypatch):
+        from confluence_export.reconcile import _same_dir
+
+        a, b = tmp_path / "a", tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        monkeypatch.setattr(Path, "samefile", _raise_oserror)
+        assert _same_dir(a, b) is False
+
+    def test_rmdir_if_empty_swallows_oserror(self, tmp_path, monkeypatch):
+        from confluence_export.reconcile import _rmdir_if_empty
+
+        d = tmp_path / "d"
+        d.mkdir()
+        monkeypatch.setattr(Path, "rmdir", _raise_oserror)
+        _rmdir_if_empty(d)  # must not raise
+        assert d.exists()
+
+    def test_remove_artifacts_swallows_unlink_oserror(self, tmp_path, monkeypatch):
+        from confluence_export.reconcile import _remove_artifacts
+
+        md = tmp_path / "P.md"
+        md.write_text("x")
+        monkeypatch.setattr(Path, "unlink", _raise_oserror)
+        _remove_artifacts(md)  # must not raise
+        assert md.exists()  # the unlink was blocked but swallowed
+
+    def test_execute_deletes_swallows_unlink_oserror(self, tmp_path, monkeypatch):
+        # A read-only/locked stale duplicate must not abort the reconcile: the
+        # unlink in _execute_deletes swallows OSError like its sibling deletes.
+        _seed(tmp_path, "Page", "p1", version=2)
+        _seed(tmp_path, "OldPage", "p1", title="OldPage", version=1)
+        monkeypatch.setattr(Path, "unlink", _raise_oserror)
+        reconcile(_plan([_page("p1", "Page")]), tmp_path, "TEST")  # must not raise
+
+    def test_duplicate_sharing_canonical_dir_keeps_its_sidecars(self, tmp_path):
+        # Two markdown files with the same page_id in the SAME directory: the
+        # non-canonical copy shares the canonical's dir, so its .media/.workspace
+        # must never be touched (the canonical lives there too).
+        page_dir = _seed(tmp_path, "Page", "p1", version=2, media="m", workspace="w")
+        (page_dir / "legacy.md").write_text(_frontmatter("p1", "Page", version=1))
+
+        reconcile(_plan([_page("p1", "Page")]), tmp_path, "TEST")
+
+        assert (page_dir / "Page.md").exists()              # canonical kept
+        assert not (page_dir / "legacy.md").exists()        # duplicate md removed
+        assert (page_dir / ".media" / "img.png").exists()   # shared dir untouched
+        assert (page_dir / ".workspace" / "note.txt").exists()


### PR DESCRIPTION
Closes #17.

## Problem
When a previously-exported page is reparented or renamed in Confluence, its old on-disk directory orphans: stale markdown, an empty directory, and the user's `.workspace/` prep files stranded at a dead path.

## Approach — Option B: detect and warn (a deliberate product decision)
Two facts make page-directory and sidecar relocation unnecessary:
- A full export **regenerates** every page's markdown from the API at the new path, and git detects a rename from a plain `git rm` + `git add` by content similarity, so `git log --follow` survives **without `git mv`**. Markdown is disposable.
- `.media` re-downloads at the new path (the dropped + re-added attachment is linked by the same rename detection). Disposable too.

The only content that cannot be recomputed is the user's `.workspace`. conex **deliberately does NOT relocate it.** Auto-carrying a tree-derived sidecar forces a filesystem / git-index / plan reconciliation on every export to serve a rare event, which — over four review rounds, including a Codex pass — proved to be an unbounded edge-case stream. Instead, on a move conex drops the disposable artifacts, **leaves a non-empty `.workspace` at the old path with a note** pointing at the new location, and prunes the emptied shell. Legacy duplicate / orphan exports heal the same way.

This supersedes the earlier sidecar-relocation reconciler (Option A); the commit message carries the full rationale (and `PR24-PR25-REFLECTION.md` records the B-vs-C decision).

## What ships
- `reconcile.py` (new): detect moves + legacy duplicates from frontmatter → drop stale markdown / `.media` → warn-and-leave a non-empty `.workspace` (remove an empty one) → prune. No holding area, no park/place/quarantine, no git-index patching. Under `--no-media` the dropped `.media` is announced, not silent.
- `git.py`: relocation plumbing removed; the stale-file prune skips `.workspace` so a committed one stays tracked at its old path; the FS case probe uses a unique `mkstemp` name (no user-file clobber).
- `diff.py`: `os.walk` scan that prunes `.workspace`/`.media`/`.conex`/`.git` during traversal instead of rglob-then-filter.
- `exporter.py` / `cli.py`: reconcile runs only on a full + force-refresh export, wrapped so a failure never aborts the export; removed a dead `use_git` param.

## Safety invariant
A non-empty user `.workspace` is never deleted — verified across moves, swaps, self-nest, folder-rename, and the git prune (cross-model: Claude + Codex agree). Every `.workspace` removal is emptiness-gated `rmdir`; every `rmtree` is `.media`-scoped.

## Tests
100% line coverage on reconcile / git / diff / exporter. Covers move, swap, self-nest, duplicate-heal, folder-rename, idempotency, the `--no-media` announcement, and an end-to-end git test proving `git log --follow` crosses the move with the old path gone and the `.workspace` left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
