### PR TITLE
Fix #15: normalize attachment paths to NFC before the stale-file prune

### DIFF
--- a/src/confluence_export/git.py
+++ b/src/confluence_export/git.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import unicodedata
 from collections.abc import Iterator
 from datetime import datetime, timezone
 from pathlib import Path
@@ -210,13 +211,23 @@ def _remove_stale_files(
     if result is None or not result.stdout.strip("\0"):
         return
 
-    # On a case-insensitive filesystem a fresh write and the index can differ
-    # only in case (a re-cased title, or legacy content from another machine).
-    # git folds those to one path, so we must too — otherwise the same file is
-    # both git-added (new case) and flagged stale (old case), and `git rm` then
-    # fails on its staged content, leaving a "survived the prune" warning that
-    # only clears on the next export.
-    fold = (lambda s: s.casefold()) if _fs_is_case_insensitive(output_dir) else (lambda s: s)
+    # Normalize the comparison key on two axes that git itself folds but
+    # Path.resolve() does not:
+    #   - Unicode form: a macOS attachment title can arrive NFD (decomposed); git
+    #     with core.precomposeunicode (the macOS default) stores it NFC, so
+    #     `git ls-files` returns NFC while `written_files` is still NFD. Comparing
+    #     raw strings flags the file stale and `git rm` then fails on its just-
+    #     staged content (issue #15). Fold both sides to NFC.
+    #   - Case: on a case-insensitive filesystem a fresh write and the index can
+    #     differ only in case (a re-cased title, or legacy content from another
+    #     machine); git folds those to one path, so we must too, or the same file
+    #     is both git-added (new case) and flagged stale (old case).
+    _nfc = lambda s: unicodedata.normalize("NFC", s)  # noqa: E731
+    fold = (
+        (lambda s: _nfc(s).casefold())
+        if _fs_is_case_insensitive(output_dir)
+        else _nfc
+    )
     written_keys = {fold(str(f.resolve())) for f in written_files}
 
     stale = []

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -733,3 +733,43 @@ class TestGitDefensiveBranches:
         ls = subprocess.run(["git", "ls-files"], cwd=tmp_path, capture_output=True, text=True).stdout
         assert "old.md" not in ls  # pruned via the per-path fallback
         assert "survived the prune" not in capsys.readouterr().err
+
+    def test_remove_stale_files_nfd_attachment_matched_as_nfc(self, tmp_path, monkeypatch, capsys):
+        # macOS: an attachment title arrives NFD (decomposed); git with
+        # core.precomposeunicode stores it NFC, so `git ls-files` returns NFC while
+        # written_files still holds the NFD path. They must compare equal (folded
+        # to NFC) so the file is not wrongly flagged stale and git-rm'd (issue #15).
+        # Deterministic on any OS: ls-files is stubbed to the NFC form.
+        import unicodedata
+
+        from confluence_export import git as G
+
+        ensure_repo(tmp_path)
+        (tmp_path / "seed.md").write_text("x")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "i"], cwd=tmp_path, capture_output=True)
+
+        name_nfd = unicodedata.normalize("NFD", "Übersicht.txt")
+        name_nfc = unicodedata.normalize("NFC", "Übersicht.txt")
+        assert name_nfd != name_nfc  # sanity: the two Unicode forms differ
+
+        written = [tmp_path / ".media" / name_nfd]  # written_files in NFD form
+        real = G._run_git
+        rm_calls = []
+
+        class _LsFiles:
+            returncode = 0
+            stdout = f".media/{name_nfc}\0"  # git returns NFC
+
+        def fake(repo, *args, **kwargs):
+            if args and args[0] == "ls-files":
+                return _LsFiles()
+            if args and args[0] == "rm":
+                rm_calls.append(args)
+            return real(repo, *args, **kwargs)
+
+        monkeypatch.setattr(G, "_run_git", fake)
+        G._remove_stale_files(tmp_path, written)
+
+        assert rm_calls == []  # NFD written == NFC tracked → not stale → no git rm
+        assert "survived the prune" not in capsys.readouterr().err


### PR DESCRIPTION
Closes #15.

## Problem
On macOS, a Confluence attachment whose title contains a non-ASCII char (e.g. a German umlaut) can arrive from the API in **NFD** (decomposed) form. `download_attachments` writes it NFD; `git add` with `core.precomposeunicode=true` (the macOS default) stores it **NFC** in the index. On the next export, `_remove_stale_files` calls `git ls-files` (returns NFC) and compares against `written_files` (still NFD). `Path.resolve()` does not normalize Unicode form, so NFC ∉ {NFD} → the attachment is wrongly flagged stale and `git rm` refuses it (the path was just staged), printing on every re-export:

```
Warning: could not remove stale file '.media/Übersicht.txt'; it survived the prune
```

No data loss — just recurring noise.

## Fix
Compose NFC normalization into the existing comparison key in `_remove_stale_files`, next to the case-fold added for #17 — so both sides match exactly what git already folds:

```python
_nfc = lambda s: unicodedata.normalize("NFC", s)
fold = (lambda s: _nfc(s).casefold()) if _fs_is_case_insensitive(output_dir) else _nfc
```

## Test
`test_remove_stale_files_nfd_attachment_matched_as_nfc` stubs `git ls-files` to return the NFC form while `written_files` holds the NFD path, and asserts the file is not flagged stale (no `git rm`). It is deterministic on any OS and **fails without the fix** (verified — it reproduces the exact `survived the prune` warning). Full suite: 414 passing; `git.py` at 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
