### PR TITLE
Fix #5: render profile-picture macro as an inline user mention

### DIFF
--- a/src/confluence_export/converter.py
+++ b/src/confluence_export/converter.py
@@ -220,6 +220,13 @@ def _preprocess_html(
 
     # --- User mentions (ri:user inside ac:link or standalone) ---
     for user_tag in list(soup.find_all("ri:user")):
+        # The profile-picture macro renders its own inline mention in the
+        # structured-macro pass below; leave its ri:user intact so that handler
+        # can resolve it, instead of it being consumed here and the macro then
+        # falling through to a noisy dynamic-content placeholder (issue #5).
+        parent_macro = user_tag.find_parent("ac:structured-macro")
+        if parent_macro is not None and parent_macro.get("ac:name") == "profile-picture":
+            continue
         account_id = user_tag.get("ri:account-id", "")
         parent_link = user_tag.find_parent("ac:link")
         display_name = None
@@ -254,6 +261,8 @@ def _preprocess_html(
             _convert_drawio_placeholder(soup, macro)
         elif macro_name == "profile":
             _convert_profile(soup, macro, user_resolver)
+        elif macro_name == "profile-picture":
+            _convert_profile_picture(soup, macro, user_resolver)
         elif macro_name == "status":
             _convert_status(soup, macro)
         elif macro_name == "expand":
@@ -392,6 +401,29 @@ def _convert_profile(soup: BeautifulSoup, macro: Tag, user_resolver: UserResolve
     else:
         li.string = f"user:{account_id}" if account_id else "Unknown user"
     macro.replace_with(li)
+
+
+def _convert_profile_picture(soup: BeautifulSoup, macro: Tag, user_resolver: UserResolver) -> None:
+    """Render the lightweight profile-picture macro as an inline @mention.
+
+    The macro embeds an ``<ri:user>`` (its ``ri:user`` is left intact for us by the
+    user-mention pre-pass). Resolve the account id to a display name and emit
+    ``@Name`` inline, matching how standalone user mentions render — instead of the
+    generic dynamic-content placeholder. If there is no user, drop it silently
+    rather than leaving noise (issue #5)."""
+    user_tag = macro.find("ri:user")
+    account_id = user_tag.get("ri:account-id", "") if user_tag else ""
+    if not account_id:
+        macro.decompose()
+        return
+    name = account_id
+    if user_resolver:
+        info = user_resolver(account_id)
+        if info and info.get("displayName"):
+            name = info["displayName"]
+    span = soup.new_tag("span")
+    span.string = f"@{name}"
+    macro.replace_with(span)
 
 
 def _convert_status(soup: BeautifulSoup, macro: Tag) -> None:

--- a/tests/test_converter_extra.py
+++ b/tests/test_converter_extra.py
@@ -124,6 +124,8 @@ PREPROCESS_CASES = [
 
     # Profile macro (ri:user consumed by mention handler first)
     ("profile macro no user", '<ac:structured-macro ac:name="profile"></ac:structured-macro>', ["Unknown user"], []),
+    # profile-picture with no user: dropped silently, never a dynamic-content placeholder (#5)
+    ("profile-picture no user dropped", '<ac:structured-macro ac:name="profile-picture"></ac:structured-macro>', [], ["Confluence dynamic content"]),
 ]
 
 
@@ -148,6 +150,34 @@ def test_user_mention_unresolved_shows_id():
     html = '<ac:link><ri:user ri:account-id="abc"/></ac:link>'
     result = _preprocess_html(html, [])
     assert "@abc" in result
+
+
+# -- profile-picture macro renders as an inline mention, not a placeholder (#5) --
+
+_PROFILE_PIC = (
+    '<ac:structured-macro ac:name="profile-picture">'
+    '<ac:parameter ac:name="User"><ri:user ri:account-id="abc"/></ac:parameter>'
+    "</ac:structured-macro>"
+)
+
+
+def test_profile_picture_renders_resolved_mention():
+    result = _preprocess_html(_PROFILE_PIC, [], user_resolver=lambda aid: {"displayName": "Alice"})
+    assert "@Alice" in result
+    assert "Confluence dynamic content" not in result  # no placeholder noise
+
+
+def test_profile_picture_unresolved_shows_id():
+    result = _preprocess_html(_PROFILE_PIC, [])
+    assert "@abc" in result
+    assert "Confluence dynamic content" not in result
+
+
+def test_profile_picture_resolver_without_name_falls_back_to_id():
+    # Resolver present but can't resolve the account id → fall back to the id.
+    result = _preprocess_html(_PROFILE_PIC, [], user_resolver=lambda aid: None)
+    assert "@abc" in result
+    assert "Confluence dynamic content" not in result
 
 
 # -- Full pipeline test: HTML → markdown with frontmatter --------------------


### PR DESCRIPTION
Closes #5.

## Problem
The `profile-picture` macro fell through to the dynamic-content placeholder fallback, so member tables rendered noisy text like:

```
*[Confluence dynamic content: profile-picture (User=@Some Name)]*
```

instead of a clean mention.

## Why it wasn't a one-liner
The user-mention pre-pass (`_preprocess_html`) runs **before** the structured-macro dispatch and replaces every `<ri:user>` with `@Name` text — including the one inside the macro's `User` parameter. By dispatch time the macro has no `<ri:user>` left, so it lands in the generic placeholder branch with the name baked into the param text.

## Fix (issue's recommended option 2, scoped to profile-picture)
- In the pre-pass, **skip** the `<ri:user>` replacement when the tag is inside a `profile-picture` macro, leaving it for the handler.
- Add `_convert_profile_picture`: resolve the account id to a display name and emit `@Name` inline; drop silently when there's no user (never a placeholder).

The existing `profile` macro behavior is deliberately **not** touched (the issue warned that reordering/altering the shared pre-pass risks a `profile` regression). The change only affects `profile-picture`.

## Tests
- `profile-picture no user dropped` (parametrized): no placeholder emitted.
- resolved → `@Alice`; unresolved (no resolver) → `@abc`; resolver-can't-resolve → `@abc`. All assert no `Confluence dynamic content` noise.
- Full suite: 418 passing. My new handler has full line coverage; the remaining converter gaps are pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
