### PR TITLE
Fix #9: render draw.io diagrams before conversion (closes #8)

### DIFF
--- a/src/confluence_export/converter.py
+++ b/src/confluence_export/converter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import urllib.parse
 from pathlib import Path
 
 import yaml
@@ -554,19 +555,31 @@ def _convert_drawio_placeholder(
             break
     source_tracked = drawio_filename in attach_map or diagram_name in attach_map
 
+    # diagramName is API-controlled and can contain spaces / parens / brackets.
+    # Once markdownify renders the emitted <img>/<a>, an unencoded URL with a space
+    # or `(` truncates, and a `]` in the visible text closes the image/link syntax
+    # early (broken output, and a `](javascript:…)`-style injection vector). So
+    # percent-encode the URL path and strip markdown-structural chars from labels.
+    def _label(text: str) -> str:
+        return re.sub(r"[\[\]()\r\n]", "", text)
+
     p = soup.new_tag("p")
     if png_path is not None:
-        p.append(soup.new_tag("img", src=f"{MEDIA_DIR_NAME}/{png_path.name}", alt=bare))
+        p.append(soup.new_tag(
+            "img",
+            src=f"{MEDIA_DIR_NAME}/{urllib.parse.quote(png_path.name)}",
+            alt=_label(bare),
+        ))
     else:
         em = soup.new_tag("em")
-        em.string = f"[Draw.io diagram not rendered: {drawio_filename}]"
+        em.string = f"[Draw.io diagram not rendered: {_label(drawio_filename)}]"
         p.append(em)
     if source_tracked:
         p.append(soup.new_tag("br"))
         src_em = soup.new_tag("em")
         src_em.append("Draw.io source: ")
-        link = soup.new_tag("a", href=f"{MEDIA_DIR_NAME}/{drawio_filename}")
-        link.string = drawio_filename
+        link = soup.new_tag("a", href=f"{MEDIA_DIR_NAME}/{urllib.parse.quote(drawio_filename)}")
+        link.string = _label(drawio_filename)
         src_em.append(link)
         p.append(src_em)
     macro.replace_with(p)

--- a/src/confluence_export/converter.py
+++ b/src/confluence_export/converter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
 import yaml
 from bs4 import BeautifulSoup, NavigableString, Tag
@@ -75,12 +76,20 @@ def convert_page(
     path: str,
     attachments: list[Attachment] | None = None,
     user_resolver: UserResolver = None,
+    rendered: dict[str, Path] | None = None,
 ) -> str:
-    """Convert a Confluence page to markdown with YAML frontmatter."""
+    """Convert a Confluence page to markdown with YAML frontmatter.
+
+    ``rendered`` maps a draw.io diagram/attachment name to its rendered PNG path
+    (built by the exporter BEFORE conversion). The drawio macro handler uses it to
+    emit a real ``<img>`` inline, so no escapable ``[drawio:NAME]`` sentinel ever
+    round-trips through markdownify (issues #9, #8)."""
     html = page.body_storage
 
     # Pre-process Confluence-specific HTML
-    html = _preprocess_html(html, attachments or [], user_resolver=user_resolver)
+    html = _preprocess_html(
+        html, attachments or [], user_resolver=user_resolver, rendered=rendered or {}
+    )
 
     # Convert to markdown using markdownify
     markdown = md(
@@ -145,9 +154,11 @@ def _preprocess_html(
     html: str,
     attachments: list[Attachment],
     user_resolver: UserResolver = None,
+    rendered: dict[str, Path] | None = None,
 ) -> str:
     """Pre-process Confluence storage HTML before markdownify."""
     soup = BeautifulSoup(html, "html.parser")
+    rendered = rendered or {}
 
     # Build attachment lookup
     attach_map = {a.title: a for a in attachments}
@@ -258,7 +269,7 @@ def _preprocess_html(
         elif macro_name == "code":
             _convert_code_block(soup, macro)
         elif macro_name in ("drawio", "inc-drawio"):
-            _convert_drawio_placeholder(soup, macro)
+            _convert_drawio_placeholder(soup, macro, rendered, attach_map)
         elif macro_name == "profile":
             _convert_profile(soup, macro, user_resolver)
         elif macro_name == "profile-picture":
@@ -516,14 +527,49 @@ def _convert_view_file(soup: BeautifulSoup, macro: Tag) -> None:
         macro.decompose()
 
 
-def _convert_drawio_placeholder(soup: BeautifulSoup, macro: Tag) -> None:
-    """Replace drawio/inc-drawio macro with a placeholder."""
+def _convert_drawio_placeholder(
+    soup: BeautifulSoup,
+    macro: Tag,
+    rendered: dict[str, Path],
+    attach_map: dict[str, Attachment],
+) -> None:
+    """Replace a drawio/inc-drawio macro with its rendered PNG (image + source
+    link), or a graceful "not rendered" note when no PNG is available.
+
+    Emitting real ``<img>``/``<a>`` here — rather than a ``[drawio:NAME]`` text
+    sentinel resolved by a post-markdownify string replace — means markdownify
+    can no longer escape the diagram name (``_`` -> ``\\_``) and break the lookup
+    (#9), and a failed render can no longer leak a raw sentinel into the output
+    (#8). The render is done by the exporter before conversion and handed in via
+    ``rendered``."""
     name_param = macro.find("ac:parameter", attrs={"ac:name": "diagramName"})
     diagram_name = name_param.get_text().strip() if name_param else "diagram"
+    bare = diagram_name.removesuffix(".drawio")
+    drawio_filename = f"{bare}.drawio"
 
-    placeholder = soup.new_tag("p")
-    placeholder.string = f"[drawio:{diagram_name}]"
-    macro.replace_with(placeholder)
+    png_path = None
+    for key in (diagram_name, drawio_filename, bare):
+        if key in rendered:
+            png_path = rendered[key]
+            break
+    source_tracked = drawio_filename in attach_map or diagram_name in attach_map
+
+    p = soup.new_tag("p")
+    if png_path is not None:
+        p.append(soup.new_tag("img", src=f"{MEDIA_DIR_NAME}/{png_path.name}", alt=bare))
+    else:
+        em = soup.new_tag("em")
+        em.string = f"[Draw.io diagram not rendered: {drawio_filename}]"
+        p.append(em)
+    if source_tracked:
+        p.append(soup.new_tag("br"))
+        src_em = soup.new_tag("em")
+        src_em.append("Draw.io source: ")
+        link = soup.new_tag("a", href=f"{MEDIA_DIR_NAME}/{drawio_filename}")
+        link.string = drawio_filename
+        src_em.append(link)
+        p.append(src_em)
+    macro.replace_with(p)
 
 
 def _convert_dynamic_macro_placeholder(

--- a/src/confluence_export/drawio.py
+++ b/src/confluence_export/drawio.py
@@ -9,8 +9,6 @@ import sys
 import time
 from pathlib import Path
 
-from confluence_export.media import MEDIA_DIR_NAME
-
 from confluence_export.types import Attachment
 
 
@@ -111,30 +109,3 @@ def render_drawio_to_png(drawio_path: Path, output_path: Path | None = None) -> 
 
     print(f"  Warning: draw.io produced no output for {drawio_path.name}", file=sys.stderr)
     return None
-
-
-def replace_drawio_placeholders(
-    markdown: str,
-    rendered_diagrams: dict[str, Path],
-    media_dir_name: str = MEDIA_DIR_NAME,
-) -> str:
-    """Replace [drawio:name] placeholders in markdown with image + source link."""
-    for diagram_name, png_path in rendered_diagrams.items():
-        bare_name = diagram_name.removesuffix(".drawio")
-        placeholder = f"[drawio:{diagram_name}]"
-        if placeholder not in markdown:
-            placeholder = f"[drawio:{bare_name}]"
-            if placeholder not in markdown:
-                continue
-
-        drawio_filename = diagram_name if diagram_name.endswith(".drawio") else f"{diagram_name}.drawio"
-        png_filename = png_path.name
-
-        replacement = (
-            f"![{bare_name}]"
-            f"({media_dir_name}/{png_filename})\n"
-            f"*Draw.io source: [{drawio_filename}]({media_dir_name}/{drawio_filename})*"
-        )
-        markdown = markdown.replace(placeholder, replacement)
-
-    return markdown

--- a/src/confluence_export/exporter.py
+++ b/src/confluence_export/exporter.py
@@ -15,7 +15,6 @@ from confluence_export.layout import plan_layout
 from confluence_export.drawio import (
     find_drawio_attachments,
     render_drawio_to_png,
-    replace_drawio_placeholders,
 )
 from confluence_export.media import WORKSPACE_DIR_NAME, download_attachments, ensure_media_dir
 from confluence_export.tree import (
@@ -313,26 +312,21 @@ class Exporter:
 
         # Download media
         written: list[Path] = []
+        media_dir: Path | None = None
         if self.download_media and attachments:
             media_dir = ensure_media_dir(page_dir)
             written.extend(download_attachments(self.client, attachments, media_dir))
 
-        # Convert to markdown
-        markdown = convert_page(
-            page,
-            base_url=self.base_url,
-            space_key=space_key,
-            path=path,
-            attachments=attachments,
-            user_resolver=self._resolve_user,
-        )
-
-        # Handle draw.io diagrams
+        # Render draw.io diagrams BEFORE conversion so the converter can emit a
+        # real <img> inline. (Previously the converter wrote a [drawio:NAME] text
+        # sentinel that a post-pass string-replaced; markdownify escaped `_` in
+        # that sentinel so the replace silently failed (#9), and a failed render
+        # left the raw sentinel in the output (#8). Rendering first removes both.)
+        rendered: dict[str, Path] = {}
         if self.render_drawio:
             drawio_atts = find_drawio_attachments(attachments)
             if drawio_atts:
-                rendered = {}
-                media_dir = ensure_media_dir(page_dir)
+                media_dir = media_dir or ensure_media_dir(page_dir)
                 for att in drawio_atts:
                     drawio_file = media_dir / att.title
                     if drawio_file.exists():
@@ -340,8 +334,18 @@ class Exporter:
                         if png_path:
                             rendered[att.title] = png_path
                             written.append(png_path)
-                if rendered:
-                    markdown = replace_drawio_placeholders(markdown, rendered)
+
+        # Convert to markdown (drawio macros become real images via `rendered`,
+        # or a graceful "not rendered" note when a diagram has no PNG).
+        markdown = convert_page(
+            page,
+            base_url=self.base_url,
+            space_key=space_key,
+            path=path,
+            attachments=attachments,
+            user_resolver=self._resolve_user,
+            rendered=rendered,
+        )
 
         # Write markdown file. Same allocated segment as the page directory
         # (via the shared plan), so the dir name and file stem stay in sync.

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -93,11 +93,14 @@ def test_preprocess_code_block():
     assert "print('hello')" in result
 
 
-def test_preprocess_drawio_placeholder():
+def test_preprocess_drawio_not_rendered_falls_back():
+    # No rendered PNG and no attachment: graceful "not rendered" note, never a
+    # raw [drawio:NAME] sentinel that could leak to the output (#8).
     html = (
         '<ac:structured-macro ac:name="drawio">'
         '<ac:parameter ac:name="diagramName">architecture</ac:parameter>'
         "</ac:structured-macro>"
     )
     result = _preprocess_html(html, [])
-    assert "[drawio:architecture]" in result
+    assert "Draw.io diagram not rendered: architecture.drawio" in result
+    assert "[drawio:" not in result

--- a/tests/test_converter_extra.py
+++ b/tests/test_converter_extra.py
@@ -1,5 +1,7 @@
 """Converter tests: Confluence HTML in, verify transformed output."""
 
+from pathlib import Path
+
 import pytest
 
 from confluence_export.converter import _preprocess_html, convert_page
@@ -81,7 +83,7 @@ PREPROCESS_CASES = [
     ("view-file via ri:attachment", '<ac:structured-macro ac:name="view-file"><ri:attachment ri:filename="report.pdf"/></ac:structured-macro>', [".media/report.pdf"], []),
     ("view-file via name param", '<ac:structured-macro ac:name="view-file"><ac:parameter ac:name="name">doc.pdf</ac:parameter></ac:structured-macro>', [".media/doc.pdf"], []),
     ("view-file empty", '<ac:structured-macro ac:name="view-file"></ac:structured-macro>', [], ["ac:structured-macro"]),
-    ("drawio placeholder", '<ac:structured-macro ac:name="drawio"><ac:parameter ac:name="diagramName">arch</ac:parameter></ac:structured-macro>', ["[drawio:arch]"], []),
+    ("drawio not rendered falls back", '<ac:structured-macro ac:name="drawio"><ac:parameter ac:name="diagramName">arch</ac:parameter></ac:structured-macro>', ["Draw.io diagram not rendered: arch.drawio"], ["[drawio:"]),
 
     # Structural macros
     ("toc placeholder", '<ac:structured-macro ac:name="toc"></ac:structured-macro>', ["[Confluence dynamic content: toc]"], ["ac:structured-macro"]),
@@ -233,3 +235,53 @@ def test_full_conversion_pipeline():
     assert "ac:structured-macro" not in md
     assert "ac:image" not in md
     assert "ri:attachment" not in md
+
+
+# -- draw.io: render-before-convert, real <img> not a [drawio:NAME] sentinel (#9, #8) --
+
+_DRAWIO_MACRO = (
+    '<ac:structured-macro ac:name="drawio">'
+    '<ac:parameter ac:name="diagramName">{name}</ac:parameter>'
+    "</ac:structured-macro>"
+)
+
+
+def test_drawio_rendered_emits_real_image():
+    html = _DRAWIO_MACRO.format(name="arch")
+    atts = [Attachment(id="a", title="arch.drawio", media_type="application/x-drawio")]
+    result = _preprocess_html(html, atts, rendered={"arch.drawio": Path(".media/arch.drawio.png")})
+    assert 'src=".media/arch.drawio.png"' in result  # a real <img>, not a sentinel
+    assert 'href=".media/arch.drawio"' in result      # source link
+    assert "[drawio:" not in result
+    assert "not rendered" not in result
+
+
+def test_drawio_underscore_name_survives_markdownify():
+    # #9: a diagramName containing '_' used to be markdownify-escaped ('foo\\_bar')
+    # inside the [drawio:...] sentinel, so the post-pass string replace failed and
+    # the literal token leaked. Emitting a real <img> before markdownify keeps the
+    # rendered PNG link intact through the full pipeline.
+    page = Page(
+        id="1", title="Diagram Page", space_id="1",
+        version=Version(created_at="2025-01-01T00:00:00Z", number=1),
+        body_storage=_DRAWIO_MACRO.format(name="foo_bar"),
+        webui="/x",
+    )
+    atts = [Attachment(id="a", title="foo_bar.drawio", media_type="application/x-drawio")]
+    md = convert_page(
+        page, base_url="https://x", space_key="T", path="/Diagram Page",
+        attachments=atts, rendered={"foo_bar.drawio": Path(".media/foo_bar.drawio.png")},
+    )
+    assert ".media/foo_bar.drawio.png" in md  # rendered PNG link survives (not escaped)
+    assert "[drawio:" not in md               # no leaked sentinel
+
+
+def test_drawio_render_failure_keeps_source_link_no_sentinel():
+    # #8: render failed (empty `rendered`) but the .drawio attachment exists → a
+    # graceful "not rendered" note + source link, never a leaked [drawio:...] token.
+    html = _DRAWIO_MACRO.format(name="arch")
+    atts = [Attachment(id="a", title="arch.drawio", media_type="application/x-drawio")]
+    result = _preprocess_html(html, atts, rendered={})
+    assert "Draw.io diagram not rendered: arch.drawio" in result
+    assert 'href=".media/arch.drawio"' in result  # source link still offered
+    assert "[drawio:" not in result

--- a/tests/test_converter_extra.py
+++ b/tests/test_converter_extra.py
@@ -285,3 +285,40 @@ def test_drawio_render_failure_keeps_source_link_no_sentinel():
     assert "Draw.io diagram not rendered: arch.drawio" in result
     assert 'href=".media/arch.drawio"' in result  # source link still offered
     assert "[drawio:" not in result
+
+
+def test_drawio_name_with_spaces_produces_valid_encoded_url():
+    # A diagram/attachment name with spaces must yield a percent-encoded URL so
+    # the image actually renders after markdownify (a raw space truncates the URL).
+    page = Page(
+        id="1", title="P", space_id="1",
+        version=Version(created_at="2025-01-01T00:00:00Z", number=1),
+        body_storage=_DRAWIO_MACRO.format(name="Foo Bar"), webui="/x",
+    )
+    atts = [Attachment(id="a", title="Foo Bar.drawio", media_type="application/x-drawio")]
+    md_out = convert_page(
+        page, base_url="https://x", space_key="T", path="/P",
+        attachments=atts, rendered={"Foo Bar.drawio": Path(".media/Foo Bar.drawio.png")},
+    )
+    assert ".media/Foo%20Bar.drawio.png" in md_out      # space encoded -> valid URL
+    assert "(.media/Foo Bar.drawio.png)" not in md_out  # no raw space in the URL
+
+
+def test_drawio_name_with_injection_chars_is_neutralized():
+    # A diagramName with markdown-structural chars must not break the image/link
+    # syntax or inject a clickable javascript link (#9 review).
+    page = Page(
+        id="1", title="P", space_id="1",
+        version=Version(created_at="2025-01-01T00:00:00Z", number=1),
+        body_storage=_DRAWIO_MACRO.format(name="x](javascript:alert(1))"), webui="/x",
+    )
+    title = "x](javascript:alert(1)).drawio"
+    atts = [Attachment(id="a", title=title, media_type="application/x-drawio")]
+    md_out = convert_page(
+        page, base_url="https://x", space_key="T", path="/P",
+        attachments=atts, rendered={title: Path(".media/safe.drawio.png")},
+    )
+    assert ".media/safe.drawio.png" in md_out          # image still renders
+    assert "javascript%3A" in md_out                   # source href percent-encoded (neutralized)
+    body = md_out.split("# P", 1)[1]                   # exclude the YAML frontmatter
+    assert "](javascript:" not in body                 # no injected clickable link in the body

--- a/tests/test_drawio.py
+++ b/tests/test_drawio.py
@@ -1,11 +1,8 @@
 """Tests for draw.io diagram detection and processing."""
 
-from pathlib import Path
-
 from confluence_export.drawio import (
     detect_drawio_macros,
     find_drawio_attachments,
-    replace_drawio_placeholders,
 )
 from confluence_export.types import Attachment
 
@@ -46,36 +43,3 @@ def test_detect_drawio_macros():
 def test_detect_drawio_macros_none():
     html = "<p>No drawio here</p>"
     assert detect_drawio_macros(html) == []
-
-
-def test_replace_drawio_placeholders(tmp_path):
-    markdown = (
-        "# Page\n\n"
-        "Some text\n\n"
-        "[drawio:architecture]\n\n"
-        "More text\n"
-    )
-    png = tmp_path / "architecture.drawio.png"
-    png.touch()
-
-    result = replace_drawio_placeholders(
-        markdown,
-        {"architecture": png},
-    )
-    assert "![architecture](.media/architecture.drawio.png)" in result
-    assert "Draw.io source:" in result
-    assert "architecture.drawio" in result
-    assert "[drawio:" not in result
-
-
-def test_replace_drawio_placeholders_with_extension(tmp_path):
-    markdown = "Some [drawio:arch.drawio] diagram\n"
-    png = tmp_path / "arch.drawio.png"
-    png.touch()
-
-    result = replace_drawio_placeholders(
-        markdown,
-        {"arch.drawio": png},
-    )
-    assert "arch.drawio.png" in result
-    assert "[drawio:" not in result

--- a/tests/test_drawio_extra.py
+++ b/tests/test_drawio_extra.py
@@ -10,7 +10,6 @@ from confluence_export.drawio import (
     find_drawio_attachments,
     find_drawio_cli,
     render_drawio_to_png,
-    replace_drawio_placeholders,
 )
 from confluence_export.types import Attachment
 
@@ -211,24 +210,3 @@ class TestRenderDrawioToPng:
              patch("confluence_export.drawio.time.sleep"):
             result = render_drawio_to_png(drawio)
             assert result == expected_png
-
-
-class TestReplaceDrawioPlaceholders:
-    def test_replace_with_extension(self):
-        md = "# Diagram\n\n[drawio:arch.drawio]\n\nMore text"
-        rendered = {"arch.drawio": Path(".media/arch.drawio.png")}
-        result = replace_drawio_placeholders(md, rendered)
-        assert "![arch](.media/arch.drawio.png)" in result
-        assert "arch.drawio" in result  # source link
-
-    def test_replace_without_extension(self):
-        md = "# Diagram\n\n[drawio:arch]\n\nMore text"
-        rendered = {"arch.drawio": Path(".media/arch.drawio.png")}
-        result = replace_drawio_placeholders(md, rendered)
-        assert "![arch](.media/arch.drawio.png)" in result
-
-    def test_no_matching_placeholder(self):
-        md = "# No diagrams here"
-        rendered = {"other.drawio": Path(".media/other.drawio.png")}
-        result = replace_drawio_placeholders(md, rendered)
-        assert result == md


### PR DESCRIPTION
Closes #9. Closes #8.

## Problem
The drawio macro used a two-stage pipeline: the converter wrote a literal `[drawio:NAME]` **text sentinel**, and a post-markdownify pass (`replace_drawio_placeholders`) string-replaced it with an `<img>` once the PNG rendered. Two failure modes fell out of that:

- **#9** — markdownify escapes `_` → `\_` in the sentinel text, so the literal lookup silently failed and the raw `[drawio:foo\_bar.drawio]` token leaked (observed: 129 files with unresolved placeholders despite the PNGs rendering fine).
- **#8** — when a render failed (CLI missing, attachment absent, …), nothing rewrote the sentinel, so it survived verbatim into the output.

## Fix (render-before-convert — the architectural swap proposed in #9)
Render `.drawio` → PNG **before** markdown conversion and hand the rendered map into the converter. The drawio macro handler now emits a **real `<img>` + source link inline**, or a graceful `*[Draw.io diagram not rendered: NAME]*` note (plus the source link when the attachment exists) on failure. Because the converter emits real HTML, no escapable sentinel ever round-trips through markdownify — both bug classes disappear by construction.

- `converter.py`: `convert_page`/`_preprocess_html` take a `rendered` map; `_convert_drawio_placeholder` emits `<img>`/`<a>` or the fallback.
- `drawio.py`: **`replace_drawio_placeholders` removed** (and its now-unused `MEDIA_DIR_NAME` import).
- `exporter.py`: render drawio before `convert_page`, pass `rendered`; the post-pass call is gone.

## Tests
- `test_drawio_underscore_name_survives_markdownify` — full pipeline, `diagramName=foo_bar`: the `.media/foo_bar.drawio.png` link survives (the #9 regression).
- `test_drawio_render_failure_keeps_source_link_no_sentinel` — empty render map → graceful note + source link, no `[drawio:` leak (#8).
- `test_drawio_rendered_emits_real_image`, updated converter cases, removed the dead `replace_drawio_placeholders` tests.
- Full suite: 416 passing. `drawio.py`/`exporter.py` at 100%; the new converter handler is fully covered (remaining converter gaps are pre-existing and unrelated).

## Notes
- `--no-media` / render-disabled / render-failure all degrade to the visible "not rendered" note (no silent leak).
- Related #6 (drawio-sketch) should build on this post-refactor architecture — its issue has been updated to say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
