### PR TITLE
Fix #27: reconcile on any full export, not only --force-refresh

### DIFF
--- a/src/confluence_export/exporter.py
+++ b/src/confluence_export/exporter.py
@@ -161,14 +161,18 @@ class Exporter:
         # archived or unarchived instead of being stranded at its old path.
         self._plan = plan_layout(roots_full)
 
-        # Reconcile moved pages and heal orphans BEFORE writing — but only on a
-        # full, freshly-fetched export, the one mode with complete tree
-        # visibility. Filtered / single-subtree / no-children runs never
-        # reconcile, nor prune (commit_export is_full=False). A --cached full
-        # export also skips reconcile here (stale tree), though git pruning still
-        # runs on it via commit_export.
+        # Reconcile moved pages and heal orphans BEFORE writing — on ANY full
+        # export (the one mode with complete tree visibility), whether the tree
+        # was freshly fetched or loaded from cache. Reconcile is idempotent and
+        # derives its targets from the SAME plan the write walk uses, so a
+        # --cached export heals the on-disk layout to match the cached plan it is
+        # also writing — without reconcile, a moved page's old path would be left
+        # as an orphan while git pruned only its tracked files (issue #27). A
+        # later --force-refresh re-heals to the fresh positions. Filtered /
+        # single-subtree / no-children runs never reconcile, nor prune
+        # (commit_export is_full=False).
         is_full = is_full_export(path_filter, no_children)
-        if is_full and force_refresh:
+        if is_full:
             from confluence_export.reconcile import reconcile
 
             # Reconcile only over what this run actually writes. When archived
@@ -203,12 +207,6 @@ class Exporter:
                 # planned paths, and a transient failure heals on the next run
                 # (reconcile is idempotent). Surface the error and continue.
                 print(f"Warning: layout reconciliation skipped ({exc})", file=sys.stderr)
-        elif is_full:
-            print(
-                "Note: orphan/move healing runs on a fresh full export; "
-                "re-run with --force-refresh to heal a stale layout.",
-                file=sys.stderr,
-            )
         else:
             print(
                 "Note: orphan/move healing happens on a full export of the space.",

--- a/src/confluence_export/exporter.py
+++ b/src/confluence_export/exporter.py
@@ -171,6 +171,15 @@ class Exporter:
         # later --force-refresh re-heals to the fresh positions. Filtered /
         # single-subtree / no-children runs never reconcile, nor prune
         # (commit_export is_full=False).
+        #
+        # Window: reconcile drops a moved page's old markdown/.media BEFORE the
+        # write walk regenerates them. The disposable artifacts are recomputable
+        # from the API (a --cached export uses the cached bodies, which the cache
+        # carries — get_pages_in_space fetches body.storage inline), so a failed
+        # write self-heals on the next successful full export; only the user's
+        # .workspace is irreplaceable, and it is never dropped. Same recoverable
+        # window the --force-refresh path already had — #27 just widens it to
+        # --cached (verified during review).
         is_full = is_full_export(path_filter, no_children)
         if is_full:
             from confluence_export.reconcile import reconcile

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -401,6 +401,26 @@ class TestMoveHealingEndToEnd:
         assert (tmp_path / "A" / "P" / ".workspace" / "u.txt").read_text() == "mine"  # left
         assert "do not move automatically" in capsys.readouterr().err
 
+    def test_cached_full_export_also_reconciles(self, tmp_path):
+        # #27: reconcile must run on a full export even WITHOUT --force-refresh
+        # (force_refresh=False loads from cache). Otherwise a moved page's old
+        # path is left as an on-disk orphan while git prunes only its tracked
+        # files. The page should be rewritten at the new path and the old shell
+        # cleaned, healing to the cached plan the write walk is also using.
+        exporter, _, cache = _make_exporter()
+        _seed_export_page(tmp_path, "A", "a")
+        _seed_export_page(tmp_path, "A/P", "p")  # old path on disk
+        cache.ensure_loaded.return_value = _make_cached_space(pages=[
+            _make_page(id="a", title="A"),
+            _make_page(id="b", title="B"),
+            _make_page(id="p", title="P", parent_id="b", parent_type="page"),
+        ])
+
+        exporter.export_space(_make_space(), tmp_path)  # no force_refresh (cached)
+
+        assert (tmp_path / "B" / "P" / "P.md").exists()  # written at new path
+        assert not (tmp_path / "A" / "P").exists()        # old orphan cleaned (was left pre-#27)
+
 
 class TestSelfNestEndToEnd:
     def test_reparent_into_own_name_no_crash_leaves_workspace(self, tmp_path):


### PR DESCRIPTION
Closes #27.

## Problem
The move/orphan reconciler was gated on `is_full and force_refresh`, so a `--cached` full export (which reuses the cached tree) **skipped** it — but the git stale-file prune still ran (`is_full=True`). Net effect when the cached tree reflects a move: the page is rewritten at its new path and its *tracked* old files are `git rm`'d, but the reconciler's filesystem cleanup (drop old `.media/`, `rmdir` the emptied shell) never happened, leaving on-disk orphans until the next `--force-refresh`.

## Fix (option 2 from the issue)
Drop the `force_refresh` requirement: reconcile now runs on **any** full export. It's idempotent and derives its targets from the **same plan the write walk uses**, so on a `--cached` export it heals the on-disk layout to match the cached plan it's also writing — no orphan left behind. A later `--force-refresh` re-heals to the fresh positions (accepted, documented behavior: `--cached` heals to cached positions, consistent with what that export writes). The now-unreachable "re-run with --force-refresh to heal" note is removed. Partial / subtree / no-children exports still never reconcile (`is_full` false).

## Why no stale-cache hazard
reconcile only ever cleans up to match the plan the write walk is already writing from. It can't move content to a position the export isn't also writing — so it never makes the layout *less* consistent with the exported data than it already is.

## Tests
- `test_cached_full_export_also_reconciles`: a `force_refresh=False` full export of a moved-page cache rewrites at the new path AND cleans the old orphan. Verified it **fails** without the gate change (reproducing #27) and passes with it.
- Full suite: 419 passing; `exporter.py` at 100%.

> Note: touches `exporter.py` in a different section than #9/PR #31 (reconcile gate vs drawio render) — they shouldn't conflict; if they do at merge it's trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
