### PR TITLE
Fix profile-picture mention lost inside panel/expand (regression from #5)

### DIFF
--- a/src/confluence_export/converter.py
+++ b/src/confluence_export/converter.py
@@ -141,6 +141,19 @@ def _build_frontmatter(
     return f"---\n{yaml_str}---\n\n"
 
 
+def _is_detached(node: Tag, soup: BeautifulSoup) -> bool:
+    """True if ``node`` is no longer reachable from ``soup`` — i.e. an earlier
+    mutation extracted or decomposed it (or an ancestor). Walking up to the soup
+    root is robust to both replace_with (subtree detached, parents intact) and
+    decompose (parent set to None)."""
+    cur = node
+    while cur is not None:
+        if cur is soup:
+            return False
+        cur = cur.parent
+    return True
+
+
 def _resolve_user_name(account_id: str, user_resolver: UserResolver) -> str:
     """Resolve a Confluence account id to a display name, falling back to the id
     when there is no resolver or no resolved name. Shared by the standalone
@@ -231,6 +244,14 @@ def _preprocess_html(
 
     # --- User mentions (ri:user inside ac:link or standalone) ---
     for user_tag in list(soup.find_all("ri:user")):
+        # The snapshot can hold ri:user nodes an earlier iteration already
+        # detached — e.g. a second ri:user inside a profile-picture we already
+        # resolved (replace_with leaves the sibling in a detached subtree) or one
+        # whose ancestor macro we decomposed (.get would raise on the dead node).
+        # Operating on those would abort the whole export, so skip anything no
+        # longer reachable from the live tree.
+        if _is_detached(user_tag, soup):
+            continue
         account_id = user_tag.get("ri:account-id", "")
         # A profile-picture macro is resolved to its inline @mention HERE, by
         # replacing the WHOLE macro — not deferred to the structured-macro pass.
@@ -240,12 +261,17 @@ def _preprocess_html(
         # (issue #5, nested-macro regression).
         parent_macro = user_tag.find_parent("ac:structured-macro")
         if parent_macro is not None and parent_macro.get("ac:name") == "profile-picture":
+            # Retarget an enclosing ac:link so the later ac:link pass doesn't
+            # unwrap-and-drop the resolved span (a link whose only child is a
+            # plain span falls through to decompose) — that would re-introduce the
+            # very silent mention-drop #5 set out to fix.
+            target = parent_macro.find_parent("ac:link") or parent_macro
             if account_id:
                 span = soup.new_tag("span")
                 span.string = f"@{_resolve_user_name(account_id, user_resolver)}"
-                parent_macro.replace_with(span)
+                target.replace_with(span)
             else:
-                parent_macro.decompose()
+                target.decompose()
             continue
         name = _resolve_user_name(account_id, user_resolver)
         parent_link = user_tag.find_parent("ac:link")

--- a/src/confluence_export/converter.py
+++ b/src/confluence_export/converter.py
@@ -141,6 +141,17 @@ def _build_frontmatter(
     return f"---\n{yaml_str}---\n\n"
 
 
+def _resolve_user_name(account_id: str, user_resolver: UserResolver) -> str:
+    """Resolve a Confluence account id to a display name, falling back to the id
+    when there is no resolver or no resolved name. Shared by the standalone
+    user-mention pass and the profile-picture macro so they render identically."""
+    if account_id and user_resolver:
+        info = user_resolver(account_id)
+        if info and info.get("displayName"):
+            return info["displayName"]
+    return account_id
+
+
 def _preprocess_html(
     html: str,
     attachments: list[Attachment],
@@ -220,21 +231,24 @@ def _preprocess_html(
 
     # --- User mentions (ri:user inside ac:link or standalone) ---
     for user_tag in list(soup.find_all("ri:user")):
-        # The profile-picture macro renders its own inline mention in the
-        # structured-macro pass below; leave its ri:user intact so that handler
-        # can resolve it, instead of it being consumed here and the macro then
-        # falling through to a noisy dynamic-content placeholder (issue #5).
+        account_id = user_tag.get("ri:account-id", "")
+        # A profile-picture macro is resolved to its inline @mention HERE, by
+        # replacing the WHOLE macro — not deferred to the structured-macro pass.
+        # Deferring breaks when the macro sits inside a panel/expand whose body is
+        # re-parsed into a fresh soup before that pass runs: the macro would be
+        # detached from the dispatch snapshot and the mention silently dropped
+        # (issue #5, nested-macro regression).
         parent_macro = user_tag.find_parent("ac:structured-macro")
         if parent_macro is not None and parent_macro.get("ac:name") == "profile-picture":
+            if account_id:
+                span = soup.new_tag("span")
+                span.string = f"@{_resolve_user_name(account_id, user_resolver)}"
+                parent_macro.replace_with(span)
+            else:
+                parent_macro.decompose()
             continue
-        account_id = user_tag.get("ri:account-id", "")
+        name = _resolve_user_name(account_id, user_resolver)
         parent_link = user_tag.find_parent("ac:link")
-        display_name = None
-        if account_id and user_resolver:
-            info = user_resolver(account_id)
-            if info:
-                display_name = info.get("displayName")
-        name = display_name or account_id
         if parent_link:
             span = soup.new_tag("span")
             span.string = f"@{name}"
@@ -262,7 +276,10 @@ def _preprocess_html(
         elif macro_name == "profile":
             _convert_profile(soup, macro, user_resolver)
         elif macro_name == "profile-picture":
-            _convert_profile_picture(soup, macro, user_resolver)
+            # A profile-picture with a user was already resolved to an inline
+            # mention in the user-mention pre-pass; one reaching here has no user
+            # — drop it rather than emit a dynamic-content placeholder.
+            macro.decompose()
         elif macro_name == "status":
             _convert_status(soup, macro)
         elif macro_name == "expand":
@@ -401,29 +418,6 @@ def _convert_profile(soup: BeautifulSoup, macro: Tag, user_resolver: UserResolve
     else:
         li.string = f"user:{account_id}" if account_id else "Unknown user"
     macro.replace_with(li)
-
-
-def _convert_profile_picture(soup: BeautifulSoup, macro: Tag, user_resolver: UserResolver) -> None:
-    """Render the lightweight profile-picture macro as an inline @mention.
-
-    The macro embeds an ``<ri:user>`` (its ``ri:user`` is left intact for us by the
-    user-mention pre-pass). Resolve the account id to a display name and emit
-    ``@Name`` inline, matching how standalone user mentions render — instead of the
-    generic dynamic-content placeholder. If there is no user, drop it silently
-    rather than leaving noise (issue #5)."""
-    user_tag = macro.find("ri:user")
-    account_id = user_tag.get("ri:account-id", "") if user_tag else ""
-    if not account_id:
-        macro.decompose()
-        return
-    name = account_id
-    if user_resolver:
-        info = user_resolver(account_id)
-        if info and info.get("displayName"):
-            name = info["displayName"]
-    span = soup.new_tag("span")
-    span.string = f"@{name}"
-    macro.replace_with(span)
 
 
 def _convert_status(soup: BeautifulSoup, macro: Tag) -> None:

--- a/tests/test_converter_extra.py
+++ b/tests/test_converter_extra.py
@@ -180,6 +180,38 @@ def test_profile_picture_resolver_without_name_falls_back_to_id():
     assert "Confluence dynamic content" not in result
 
 
+def test_profile_picture_empty_account_id_dropped():
+    # A profile-picture whose ri:user carries no account-id → dropped cleanly,
+    # no mention text and no dynamic-content placeholder.
+    html = (
+        '<ac:structured-macro ac:name="profile-picture">'
+        '<ac:parameter ac:name="User"><ri:user/></ac:parameter>'
+        "</ac:structured-macro>"
+    )
+    result = _preprocess_html(html, [])
+    assert "@" not in result
+    assert "Confluence dynamic content" not in result
+
+
+def test_profile_picture_inside_panel_keeps_mention():
+    # Regression guard (#5 follow-up): a profile-picture nested in a panel must
+    # keep its mention. _convert_panel re-parses the panel body into a fresh soup,
+    # so a macro resolved only in the later structured-macro pass would be detached
+    # from that pass's snapshot and the mention silently dropped. Resolving the
+    # profile-picture in the user-mention pre-pass (before any panel re-parse)
+    # survives it.
+    html = (
+        '<ac:structured-macro ac:name="info"><ac:rich-text-body>'
+        '<p>Owner: <ac:structured-macro ac:name="profile-picture">'
+        '<ac:parameter ac:name="User"><ri:user ri:account-id="abc"/></ac:parameter>'
+        "</ac:structured-macro></p>"
+        "</ac:rich-text-body></ac:structured-macro>"
+    )
+    result = _preprocess_html(html, [], user_resolver=lambda aid: {"displayName": "Alice"})
+    assert "@Alice" in result
+    assert "Confluence dynamic content" not in result
+
+
 # -- Full pipeline test: HTML → markdown with frontmatter --------------------
 
 def test_full_conversion_pipeline():

--- a/tests/test_converter_extra.py
+++ b/tests/test_converter_extra.py
@@ -212,6 +212,55 @@ def test_profile_picture_inside_panel_keeps_mention():
     assert "Confluence dynamic content" not in result
 
 
+def test_profile_picture_two_ri_users_does_not_crash():
+    # Hardening: resolving a profile-picture in the pre-pass replaces the WHOLE
+    # macro, detaching any sibling ri:user still in the find_all snapshot. Without
+    # a detached-node guard the second iteration called replace_with on a node not
+    # in the tree -> ValueError, aborting the entire export. Malformed/atypical
+    # input (a well-formed macro has one ri:user) but the blast radius is the whole
+    # run, so it must degrade gracefully to the first resolved mention.
+    html = (
+        '<ac:structured-macro ac:name="profile-picture">'
+        '<ac:parameter ac:name="U1"><ri:user ri:account-id="abc"/></ac:parameter>'
+        '<ac:parameter ac:name="U2"><ri:user ri:account-id="def"/></ac:parameter>'
+        "</ac:structured-macro>"
+    )
+    result = _preprocess_html(html, [], user_resolver=lambda aid: {"displayName": "Alice"})
+    assert "@Alice" in result
+
+
+def test_profile_picture_empty_then_second_ri_user_does_not_crash():
+    # Hardening: a first empty-account-id ri:user decomposes the macro, which
+    # destroys (attrs=None) a second snapshotted ri:user; without the guard the
+    # next iteration did user_tag.get(...) on the dead node -> AttributeError,
+    # aborting the export. Must degrade to a clean drop instead.
+    html = (
+        '<ac:structured-macro ac:name="profile-picture">'
+        '<ac:parameter ac:name="a"><ri:user ri:account-id=""/></ac:parameter>'
+        '<ac:parameter ac:name="b"><ri:user ri:account-id="def"/></ac:parameter>'
+        "</ac:structured-macro>"
+    )
+    result = _preprocess_html(html, [])
+    assert "@" not in result
+    assert "Confluence dynamic content" not in result
+
+
+def test_profile_picture_inside_ac_link_keeps_mention():
+    # Regression guard: a profile-picture wrapped in an ac:link must keep its
+    # mention. Resolving the macro to a bare <span> while it is still inside the
+    # link left the later ac:link pass with a link whose only child is a plain
+    # span -> it fell through to decompose and silently dropped the mention (the
+    # exact failure class #5 fixes). Retargeting the enclosing ac:link survives it.
+    html = (
+        "<p><ac:link><ac:structured-macro ac:name=\"profile-picture\">"
+        '<ac:parameter ac:name="U"><ri:user ri:account-id="abc"/></ac:parameter>'
+        "</ac:structured-macro></ac:link></p>"
+    )
+    result = _preprocess_html(html, [], user_resolver=lambda aid: {"displayName": "Alice"})
+    assert "@Alice" in result
+    assert "Confluence dynamic content" not in result
+
+
 # -- Full pipeline test: HTML → markdown with frontmatter --------------------
 
 def test_full_conversion_pipeline():


### PR DESCRIPTION
Follow-up to #5 — fixes a regression that #5 introduced.

## Regression
#5 changed the user-mention pre-pass to **skip** a `profile-picture`'s `<ri:user>` and resolve it later in the structured-macro dispatch. But `_convert_panel` / `_convert_expand` re-parse their body into a **fresh** `BeautifulSoup`, and the dispatch iterates a `list(soup.find_all(...))` snapshot taken **before** they run. So a `profile-picture` nested inside a panel/info/note/expand is detached from the snapshot — its handler mutates the orphan, the re-parsed copy keeps a raw `<ri:user>`, and the final `ac:`/`ri:` cleanup deletes it. **The mention vanishes** (pre-#5 it survived as the pre-pass's resolved text).

Found by the cross-model `/review` (Claude adversarial + Codex agreed); verified against the merged code.

## Fix
Resolve the `profile-picture` to its `@mention` **in the pre-pass**, replacing the whole macro before any panel body is re-parsed — so it's plain content by the time `_convert_panel` runs. Extracted `_resolve_user_name`, now shared with the standalone-mention path (identical rendering, addresses a review nit). The dispatch branch now only drops a user-less `profile-picture`.

## Tests
- `test_profile_picture_inside_panel_keeps_mention` — the regression guard; **fails on the pre-fix code**, passes now.
- `test_profile_picture_empty_account_id_dropped` — user-less ri:user path.
- Existing profile-picture/mention tests still green. Full suite: 419 passing; new code fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
