### PR TITLE
Isolate per-page convert failures so one bad page can't abort the export

### DIFF
--- a/src/confluence_export/exporter.py
+++ b/src/confluence_export/exporter.py
@@ -344,15 +344,22 @@ class Exporter:
 
         # Convert to markdown (drawio macros become real images via `rendered`,
         # or a graceful "not rendered" note when a diagram has no PNG).
-        markdown = convert_page(
-            page,
-            base_url=self.base_url,
-            space_key=space_key,
-            path=path,
-            attachments=attachments,
-            user_resolver=self._resolve_user,
-            rendered=rendered,
-        )
+        # Defense-in-depth: a malformed page body must not abort the whole space
+        # export. Mirror the body-fetch guard above — warn and skip just this page
+        # (the rest still export; this one heals on a later run once fixed).
+        try:
+            markdown = convert_page(
+                page,
+                base_url=self.base_url,
+                space_key=space_key,
+                path=path,
+                attachments=attachments,
+                user_resolver=self._resolve_user,
+                rendered=rendered,
+            )
+        except Exception as exc:
+            print(f"  Warning: could not convert {page.title}: {exc}", file=sys.stderr)
+            return []
 
         # Write markdown file. Same allocated segment as the page directory
         # (via the shared plan), so the dir name and file stem stay in sync.

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -91,6 +91,29 @@ class TestExportWritesCorrectMarkdown:
         assert "<strong>world</strong>" in html_path.read_text()
 
 
+class TestConvertFailureIsolated:
+    def test_one_bad_page_does_not_abort_export(self, tmp_path):
+        # Defense-in-depth: a convert_page exception on one page must not abort
+        # the whole space export. The bad page is skipped with a warning; every
+        # other page still exports.
+        exporter, _, cache = _make_exporter()
+        cache.ensure_loaded.return_value = _make_cached_space(pages=[
+            _make_page(id="good", title="Good Page"),
+            _make_page(id="bad", title="Bad Page"),
+        ])
+
+        def flaky(page, **kwargs):
+            if page.title == "Bad Page":
+                raise ValueError("boom")
+            return "---\ntitle: Good Page\n---\n\n# Good Page\n"
+
+        with patch("confluence_export.exporter.convert_page", side_effect=flaky):
+            exporter.export_space(_make_space(), tmp_path)  # must not raise
+
+        assert (tmp_path / "Good-Page" / "Good-Page.md").exists()
+        assert not (tmp_path / "Bad-Page" / "Bad-Page.md").exists()
+
+
 class TestTreeExport:
     def test_nested_pages_create_nested_directories(self, tmp_path):
         exporter, _, cache = _make_exporter()


### PR DESCRIPTION
Defense-in-depth follow-up to the #33 hardening (the converter root-cause fix that landed with #33 already resolves the two known crash shapes; this bounds the blast radius of any *future/unknown* converter exception).

## Problem
`convert_page` was the only unguarded step in `_export_single_page`. The body-fetch above it (exporter.py:310) and `reconcile()` in `export_space` already degrade to warn-and-continue, but a converter exception propagated out of the **entire space export**, losing every not-yet-written page.

## Fix
Wrap the `convert_page` call in the same best-effort pattern already used for the body fetch: warn to stderr and skip just that page (`return []`). The rest of the space still exports; the skipped page heals on a later run once the underlying cause is fixed.

## Test
`TestConvertFailureIsolated::test_one_bad_page_does_not_abort_export` — patches `convert_page` to raise on one of two pages and asserts the good page is still written and the export does not raise. Full suite: 425 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)