### PR TITLE
Fix six review findings (cache crash, drawio-in-panel, NFC overwrite, +3)

### DIFF
--- a/src/confluence_export/cache.py
+++ b/src/confluence_export/cache.py
@@ -57,7 +57,12 @@ class CacheStore:
         # from the plan untouched, and an export with no written files prunes
         # nothing, so no data is lost either way.
         if not pages:
-            prior = self.load(space.key)
+            # A corrupt/unreadable prior cache must not abort the refresh — refresh
+            # exists precisely to overwrite it. Treat it as "no populated cache".
+            try:
+                prior = self.load(space.key)
+            except (json.JSONDecodeError, OSError):
+                prior = None
             if prior is not None and any(p.status != "folder" for p in prior.pages):
                 print(
                     f"Warning: the API returned 0 pages for space {space.key}, "

--- a/src/confluence_export/converter.py
+++ b/src/confluence_export/converter.py
@@ -273,17 +273,17 @@ def _preprocess_html(
         # (issue #5, nested-macro regression).
         parent_macro = user_tag.find_parent("ac:structured-macro")
         if parent_macro is not None and parent_macro.get("ac:name") == "profile-picture":
-            # Retarget an enclosing ac:link so the later ac:link pass doesn't
-            # unwrap-and-drop the resolved span (a link whose only child is a
-            # plain span falls through to decompose) — that would re-introduce the
-            # very silent mention-drop #5 set out to fix.
-            target = parent_macro.find_parent("ac:link") or parent_macro
+            # Replace only the macro itself with its inline mention (NOT any
+            # enclosing ac:link) so that multiple avatars sharing one link each
+            # resolve. A link left holding only resolved mention spans is unwrapped
+            # (not dropped) by the ac:link pass below, so the span still survives —
+            # which is the silent-drop class #5 set out to fix.
             if account_id:
                 span = soup.new_tag("span")
                 span.string = f"@{_resolve_user_name(account_id, user_resolver)}"
-                target.replace_with(span)
+                parent_macro.replace_with(span)
             else:
-                target.decompose()
+                parent_macro.decompose()
             continue
         name = _resolve_user_name(account_id, user_resolver)
         parent_link = user_tag.find_parent("ac:link")
@@ -410,6 +410,14 @@ def _replace_ac_link(soup: BeautifulSoup, tag: Tag, attach_map: dict[str, Attach
         tag.unwrap()
         return
 
+    # A link whose profile-picture macro(s) were already resolved to inline
+    # mention span(s) in the user-mention pre-pass has no ri: child left. Unwrap
+    # to keep the mention(s) inline — supporting more than one avatar per link —
+    # instead of dropping the link's content.
+    if tag.find("span"):
+        tag.unwrap()
+        return
+
     tag.decompose()
 
 
@@ -419,7 +427,6 @@ def _convert_panel(soup: BeautifulSoup, macro: Tag, macro_name: str) -> None:
     title = title_param.get_text().strip() if title_param else macro_name.capitalize()
 
     body = macro.find("ac:rich-text-body")
-    body_html = "".join(str(child) for child in body.children) if body else ""
 
     blockquote = soup.new_tag("blockquote")
     strong = soup.new_tag("strong")
@@ -428,9 +435,14 @@ def _convert_panel(soup: BeautifulSoup, macro: Tag, macro_name: str) -> None:
     title_p.append(strong)
     blockquote.append(title_p)
 
-    if body_html:
-        body_soup = BeautifulSoup(body_html, "html.parser")
-        for element in list(body_soup.children):
+    # Move the LIVE body children into the blockquote instead of re-parsing their
+    # serialized HTML into a fresh soup. Re-parsing detached any macro nested in
+    # the body from the structured-macro dispatch snapshot, so e.g. a drawio
+    # diagram inside a panel was silently dropped (never converted). Moving the
+    # live nodes keeps them attached and still in the snapshot, so the dispatch
+    # converts them in place.
+    if body:
+        for element in list(body.children):
             blockquote.append(element)
 
     macro.replace_with(blockquote)
@@ -480,18 +492,19 @@ def _convert_expand(soup: BeautifulSoup, macro: Tag) -> None:
     title = title_param.get_text().strip() if title_param else "Details"
 
     body = macro.find("ac:rich-text-body")
-    body_html = "".join(str(child) for child in body.children) if body else ""
 
-    # Use <details><summary> which markdownify will preserve as HTML
-    # or just use a heading + content approach
+    # Heading + content. Move the LIVE body children (not a re-parsed copy) so a
+    # macro nested in the expand body — e.g. a drawio diagram — stays attached and
+    # in the structured-macro dispatch snapshot and is still converted (re-parsing
+    # detached it, silently dropping it). The container is a throwaway holder; only
+    # its children are spliced in where the macro was.
     container = BeautifulSoup("", "html.parser")
     h4 = soup.new_tag("h4")
     h4.string = title
     container.append(h4)
 
-    if body_html:
-        body_soup = BeautifulSoup(body_html, "html.parser")
-        for element in list(body_soup.children):
+    if body:
+        for element in list(body.children):
             container.append(element)
 
     macro.replace_with(*list(container.children))

--- a/src/confluence_export/exporter.py
+++ b/src/confluence_export/exporter.py
@@ -16,7 +16,12 @@ from confluence_export.drawio import (
     find_drawio_attachments,
     render_drawio_to_png,
 )
-from confluence_export.media import WORKSPACE_DIR_NAME, download_attachments, ensure_media_dir
+from confluence_export.media import (
+    MEDIA_DIR_NAME,
+    WORKSPACE_DIR_NAME,
+    download_attachments,
+    ensure_media_dir,
+)
 from confluence_export.tree import (
     build_tree,
     collect_subtree,
@@ -332,6 +337,13 @@ class Exporter:
         # Build page path
         path = page_path(cs.pages, page.id)
 
+        # Snapshot media present BEFORE this run so a convert failure can clean up
+        # only what IT newly created, never a previously-committed file's copy.
+        _media_dir = page_dir / MEDIA_DIR_NAME
+        pre_existing_media = (
+            {p.resolve() for p in _media_dir.rglob("*")} if _media_dir.is_dir() else set()
+        )
+
         # Download media
         written: list[Path] = []
         media_dir: Path | None = None
@@ -375,6 +387,15 @@ class Exporter:
         except Exception as exc:
             print(f"  Warning: could not convert {page.title}: {exc}", file=sys.stderr)
             self._skipped_paths.append(page_dir)
+            # Don't leave this run's freshly downloaded/rendered media orphaned for
+            # a page that produced no markdown — but only remove files THIS run
+            # created (a pre-existing path may be a previously-committed copy).
+            for p in written:
+                if p.resolve() not in pre_existing_media:
+                    try:
+                        p.unlink()
+                    except OSError:
+                        pass
             return []
 
         # Write markdown file. Same allocated segment as the page directory

--- a/src/confluence_export/layout.py
+++ b/src/confluence_export/layout.py
@@ -12,10 +12,21 @@ a case-insensitive filesystem still get distinct, stable paths.
 
 from __future__ import annotations
 
+import unicodedata
 from pathlib import PurePosixPath
 
 from confluence_export.converter import MAX_FILENAME_LEN, sanitize_filename
 from confluence_export.types import PageNode
+
+
+def _fold(segment: str) -> str:
+    """Collision key folding the two axes a normalizing filesystem merges but
+    distinct byte strings do not: Unicode form (NFC) and case (casefold). Two
+    siblings whose sanitized titles are NFC-equivalent (e.g. distinct precomposed
+    codepoints with the same canonical form) or case-equivalent then collide and
+    get a disambiguating suffix, instead of mapping to one path and silently
+    overwriting on a normalizing filesystem like APFS (the issue-#11 class)."""
+    return unicodedata.normalize("NFC", segment).casefold()
 
 
 def _truncate_with_suffix(segment: str, suffix: str) -> str:
@@ -37,21 +48,22 @@ def _truncate_with_suffix(segment: str, suffix: str) -> str:
 def _allocate_segment(title: str, page_id: str, taken: dict[str, str]) -> str:
     """Allocate a collision-free path segment within one parent's namespace.
 
-    ``taken`` maps ``casefold(segment) -> page_id`` of the claimant. The first
+    ``taken`` maps ``_fold(segment) -> page_id`` of the claimant. The first
     sibling (in allocation order) to want a name keeps the bare sanitized form;
-    any later sibling colliding under casefold gets a numeric ``-2``/``-3``/...
-    suffix, with length reserved so the suffixed name never exceeds the cap.
+    any later sibling colliding under the NFC+casefold fold gets a numeric
+    ``-2``/``-3``/... suffix, with length reserved so the suffixed name never
+    exceeds the cap.
     """
     base = sanitize_filename(title)
-    if base.casefold() not in taken:
-        taken[base.casefold()] = page_id
+    if _fold(base) not in taken:
+        taken[_fold(base)] = page_id
         return base
 
     n = 2
     while True:
         candidate = _truncate_with_suffix(base, f"-{n}")
-        if candidate.casefold() not in taken:
-            taken[candidate.casefold()] = page_id
+        if _fold(candidate) not in taken:
+            taken[_fold(candidate)] = page_id
             return candidate
         n += 1
 

--- a/src/confluence_export/reconcile.py
+++ b/src/confluence_export/reconcile.py
@@ -50,7 +50,7 @@ import shutil
 import sys
 from pathlib import Path, PurePosixPath
 
-from confluence_export.diff import ExportedPage, scan_export_dir_grouped
+from confluence_export.diff import _NON_PAGE_DIRS, ExportedPage, scan_export_dir_grouped
 from confluence_export.media import MEDIA_DIR_NAME, WORKSPACE_DIR_NAME
 
 
@@ -225,8 +225,12 @@ def _heal_folder_workspaces(output_dir: Path, move_sources: list[Path]) -> None:
         ws = d / WORKSPACE_DIR_NAME
         if not ws.is_dir():
             continue
+        # A real page is markdown that is NOT inside a sidecar/internal dir.
+        # Mirror the grouped scan's pruning (.workspace/.media/.conex/.git) so a
+        # stray .md under a sidecar dir can't make an empty folder workspace look
+        # occupied and wrongly spare it from cleanup.
         has_page = any(
-            WORKSPACE_DIR_NAME not in md.relative_to(d).parts for md in d.rglob("*.md")
+            not (_NON_PAGE_DIRS & set(md.relative_to(d).parts)) for md in d.rglob("*.md")
         )
         if has_page:
             continue

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -199,6 +199,23 @@ class TestEmptyResponse:
             assert store.load("TEST").pages == []  # empty snapshot saved
             assert "returned 0 pages" in capsys.readouterr().err
 
+    def test_zero_pages_over_corrupt_cache_proceeds(self, tmp_path):
+        # A 0-page response with a CORRUPT prior cache file must still proceed —
+        # refresh exists to overwrite a bad cache. The prior-cache probe must not
+        # let a json.JSONDecodeError abort the export.
+        with patch("confluence_export.cache.cache_dir", return_value=tmp_path):
+            store = CacheStore()
+            store._space_file("TEST").write_text("{ this is not valid json")
+            client = MagicMock()
+            client.returns_archived_pages = False
+            client.get_pages_in_space.return_value = []
+            client.get_attachments.return_value = []
+
+            result = store.refresh(client, _make_space())  # must not raise
+
+            assert result.pages == []
+            assert store.load("TEST").pages == []  # corrupt file overwritten with valid JSON
+
     def test_zero_pages_with_no_prior_cache_proceeds(self, tmp_path):
         with patch("confluence_export.cache.cache_dir", return_value=tmp_path):
             store = CacheStore()

--- a/tests/test_converter_extra.py
+++ b/tests/test_converter_extra.py
@@ -249,10 +249,9 @@ def test_profile_picture_empty_then_second_ri_user_does_not_crash():
 
 def test_profile_picture_inside_ac_link_keeps_mention():
     # Regression guard: a profile-picture wrapped in an ac:link must keep its
-    # mention. Resolving the macro to a bare <span> while it is still inside the
-    # link left the later ac:link pass with a link whose only child is a plain
-    # span -> it fell through to decompose and silently dropped the mention (the
-    # exact failure class #5 fixes). Retargeting the enclosing ac:link survives it.
+    # mention. Resolving the macro to a bare <span> leaves the link holding only
+    # that span; the ac:link pass unwraps such a link (keeping the mention inline)
+    # rather than decomposing it, which would silently drop the mention (#5).
     html = (
         "<p><ac:link><ac:structured-macro ac:name=\"profile-picture\">"
         '<ac:parameter ac:name="U"><ri:user ri:account-id="abc"/></ac:parameter>'
@@ -261,6 +260,53 @@ def test_profile_picture_inside_ac_link_keeps_mention():
     result = _preprocess_html(html, [], user_resolver=lambda aid: {"displayName": "Alice"})
     assert "@Alice" in result
     assert "Confluence dynamic content" not in result
+
+
+def test_two_profile_pictures_in_one_ac_link_keep_both_mentions():
+    # Two avatars sharing a single ac:link: each profile-picture must resolve.
+    # Replacing the whole link on the first macro detached the second; resolving
+    # each macro in place and unwrapping the link keeps both mentions.
+    html = (
+        "<p><ac:link>"
+        '<ac:structured-macro ac:name="profile-picture"><ac:parameter ac:name="U">'
+        '<ri:user ri:account-id="u1"/></ac:parameter></ac:structured-macro>'
+        '<ac:structured-macro ac:name="profile-picture"><ac:parameter ac:name="U">'
+        '<ri:user ri:account-id="u2"/></ac:parameter></ac:structured-macro>'
+        "</ac:link></p>"
+    )
+    result = _preprocess_html(html, [], user_resolver=lambda aid: {"displayName": f"N-{aid}"})
+    assert "@N-u1" in result
+    assert "@N-u2" in result
+
+
+def test_drawio_nested_in_panel_still_renders():
+    # A drawio diagram inside an info/panel body must still emit its real <img>.
+    # _convert_panel re-parsed the body into a fresh soup, detaching the inner
+    # macro from the dispatch snapshot so it was silently dropped; moving the live
+    # body children keeps it attached and converted.
+    html = (
+        '<ac:structured-macro ac:name="info"><ac:rich-text-body>'
+        '<ac:structured-macro ac:name="drawio">'
+        '<ac:parameter ac:name="diagramName">arch</ac:parameter>'
+        "</ac:structured-macro></ac:rich-text-body></ac:structured-macro>"
+    )
+    atts = [Attachment(id="a", title="arch.drawio", media_type="application/x-drawio")]
+    result = _preprocess_html(html, atts, rendered={"arch.drawio": Path(".media/arch.drawio.png")})
+    assert 'src=".media/arch.drawio.png"' in result
+    assert "[drawio:" not in result
+
+
+def test_view_file_nested_in_expand_still_renders():
+    # Same nested-macro class for view-file inside an expand body.
+    html = (
+        '<ac:structured-macro ac:name="expand"><ac:rich-text-body>'
+        '<ac:structured-macro ac:name="view-file">'
+        '<ri:attachment ri:filename="report.pdf"/>'
+        "</ac:structured-macro></ac:rich-text-body></ac:structured-macro>"
+    )
+    atts = [Attachment(id="b", title="report.pdf", media_type="application/pdf")]
+    result = _preprocess_html(html, atts)
+    assert ".media/report.pdf" in result
 
 
 # -- Full pipeline test: HTML → markdown with frontmatter --------------------

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -117,6 +117,27 @@ class TestConvertFailureIsolated:
         assert (tmp_path / "Bad-Page") in result.skipped_paths
         assert (tmp_path / "Good-Page") not in result.skipped_paths
 
+    def test_convert_failure_cleans_up_newly_downloaded_media(self, tmp_path):
+        # A convert failure must not leave THIS run's freshly downloaded media
+        # orphaned on disk (no untracked junk). download_media=True, one attachment
+        # written, then convert raises -> the media file is cleaned up.
+        exporter, _, cache = _make_exporter(download_media=True)
+        cache.ensure_loaded.return_value = _make_cached_space(
+            pages=[_make_page(id="bad", title="Bad Page")],
+            attachments={"bad": [Attachment(id="x", title="img.png", media_type="image/png", file_size=3)]},
+        )
+
+        def fake_download(client, attachments, media_dir):
+            p = media_dir / "img.png"
+            p.write_bytes(b"png")
+            return [p]
+
+        with patch("confluence_export.exporter.download_attachments", side_effect=fake_download), \
+             patch("confluence_export.exporter.convert_page", side_effect=ValueError("boom")):
+            exporter.export_space(_make_space(), tmp_path)
+
+        assert not (tmp_path / "Bad-Page" / ".media" / "img.png").exists()
+
 
 class TestTreeExport:
     def test_nested_pages_create_nested_directories(self, tmp_path):

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -50,6 +50,19 @@ class TestCollisionMatrix:
         plan = _plan([_page("1", "Dup"), _page("2", "dup"), _page("3", "DUP")])
         assert _segments(plan, "1", "2", "3") == ["Dup", "dup-2", "DUP-3"]
 
+    def test_nfc_equivalent_titles_collide(self):
+        # Byte-distinct but NFC-equivalent precomposed codepoints (Greek alpha with
+        # oxia U+1F71 vs tonos U+03AC) map to one path on a normalizing filesystem
+        # (APFS) and would silently overwrite. Folding the collision key on NFC
+        # disambiguates them, like a casefold collision.
+        oxia = "alpha-\u1f71"   # α with oxia
+        tonos = "alpha-\u03ac"  # α with tonos (NFC-equivalent to oxia)
+        assert oxia != tonos  # byte-distinct code points...
+        plan = _plan([_page("1", oxia), _page("2", tonos)])
+        seg1, seg2 = _segments(plan, "1", "2")
+        assert seg1 != seg2
+        assert seg2.endswith("-2")
+
     def test_long_title_prefix_collision(self):
         # Two distinct titles sharing the first 100 chars collide after truncation
         long_a = "a" * 150

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -211,6 +211,26 @@ class TestFolderRename:
         # ...but the empty legacy FOLDER .workspace is tidied away.
         assert not (tmp_path / "Docs" / ".workspace").exists()
 
+    def test_legacy_empty_folder_workspace_tidied_despite_stray_sidecar_md(self, tmp_path):
+        # A stray .md under a SIDECAR dir (.media/.conex/.git) must not count as a
+        # real page and so must not spare an empty folder-level .workspace from
+        # cleanup. The has-page scan mirrors the grouped scan's sidecar pruning.
+        (tmp_path / "Docs").mkdir()
+        (tmp_path / "Docs" / ".workspace").mkdir()
+        (tmp_path / "Docs" / ".media").mkdir()
+        (tmp_path / "Docs" / ".media" / "stray.md").write_text("# not a page")
+        _seed(tmp_path, "Docs/Guide", "guide", workspace="g")
+        plan = _plan([
+            _page("f", "Manuals", status="folder"),
+            _page("guide", "Guide", parent_id="f"),
+        ])
+
+        reconcile(plan, tmp_path, "TEST")
+
+        # The stray .md under .media does not make the folder look occupied, so the
+        # empty legacy FOLDER .workspace is still tidied.
+        assert not (tmp_path / "Docs" / ".workspace").exists()
+
     def test_legacy_nonempty_folder_workspace_preserved_and_warned(self, tmp_path, capsys):
         (tmp_path / "Docs").mkdir()
         ws = tmp_path / "Docs" / ".workspace"


### PR DESCRIPTION
Follow-up batch from the holistic review of the 2026-05-30/31 changes. All six are non-blocking on their own; bundled here with a regression test each.

| ID | Fix | File |
|----|-----|------|
| **C1** | `cache.refresh()` crashed the default export when a 0-page API response met a **corrupt cache file** (unguarded `load()`). Treat a corrupt/unreadable prior cache as "no populated cache". | `cache.py` |
| **CV1** | A **drawio/view-file macro nested in a panel/expand** was silently dropped — the body was re-parsed into a fresh soup, detaching the inner macro from the dispatch snapshot. Move the *live* body children so nested macros stay attached and get converted. | `converter.py` |
| **CV2** | **Two profile-pictures in one `ac:link`** lost all but the first mention. Replace only the macro (not the whole link) and unwrap a link left holding resolved mention spans — also retires the `ac:link` retarget hack from #33. | `converter.py` |
| **L1** | **NFC-equivalent sibling titles** got distinct segments a normalizing FS (APFS) merges → silent overwrite. Fold the per-parent collision key on NFC as well as casefold. | `layout.py` |
| **R1** | The folder-workspace cleanup's has-page check **descended sidecar dirs**, so a stray `.md` under `.media`/`.conex`/`.git` wrongly spared an empty legacy folder `.workspace`. Prune those dirs like the grouped scan. | `reconcile.py` |
| **E2** | A convert failure left this run's **freshly downloaded media orphaned** on disk. Clean up only files this run newly created (never a pre-existing/committed copy). | `exporter.py` |

CV1 and L1 were pre-existing latent issues surfaced by the review; the rest were introduced in the 05-30/31 window. (The high-severity E1 was already hotfixed in #35.)

Full suite: **433 passing** (7 new regression tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)