### PR TITLE
Address open issues: #41 flaky test, #40 decision lists, #39 refresh perf, #6 drawio-sketch

### DIFF
--- a/src/confluence_export/cache.py
+++ b/src/confluence_export/cache.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sys
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
@@ -43,12 +44,27 @@ class CacheStore:
             p.unlink()
 
     def refresh(
-        self, client: ConfluenceClient, space: Space, include_archived: bool = False
+        self,
+        client: ConfluenceClient,
+        space: Space,
+        include_archived: bool = False,
+        *,
+        fetch_attachments: bool = True,
     ) -> CachedSpace:
-        """Fetch all pages + attachments from the API and cache them."""
+        """Fetch pages (and, unless ``fetch_attachments`` is False, per-page
+        attachment metadata) from the API and cache them.
+
+        ``fetch_attachments=False`` is a PAGE-ONLY refresh for commands that only
+        need the page tree/versions (tree, find, diff): it skips the one-request-
+        per-page attachment listing, which dominates refresh cost on large spaces.
+        The resulting cache has ``attachments_complete=False`` so export never
+        treats it as authoritative for attachments (#39)."""
+        verbose = getattr(client, "verbose", False) is True
+        t0 = time.monotonic()
         print(f"Fetching pages for space {space.key}...", file=sys.stderr)
         pages = client.get_pages_in_space(space.id, include_archived=include_archived)
         print(f"Found {len(pages)} pages.", file=sys.stderr)
+        t_pages = time.monotonic()
 
         # A 0-page response over a populated cache is ambiguous: the space may be
         # genuinely empty, or the API may be hiccupping. Warn loudly but proceed,
@@ -82,29 +98,48 @@ class CacheStore:
         # Resolve folders: pages may reference parent IDs that are folders,
         # not pages. Fetch these as synthetic Page entries so the tree is complete.
         pages = self._resolve_folders(client, pages)
+        t_folders = time.monotonic()
 
         attachments: dict[str, list] = {}
         real_pages = [p for p in pages if p.status != "folder"]
-        total = len(real_pages)
-        counter = [0]
-        lock = threading.Lock()
+        if fetch_attachments:
+            total = len(real_pages)
+            counter = [0]
+            lock = threading.Lock()
 
-        def fetch_one(page: Page) -> tuple[str, list]:
-            atts = client.get_attachments(page.id)
-            with lock:
-                counter[0] += 1
-                print(
-                    f"\rFetching attachments ({counter[0]}/{total})...",
-                    end="",
-                    file=sys.stderr,
+            def fetch_one(page: Page) -> tuple[str, list]:
+                atts = client.get_attachments(page.id)
+                with lock:
+                    counter[0] += 1
+                    print(
+                        f"\rFetching attachments ({counter[0]}/{total})...",
+                        end="",
+                        file=sys.stderr,
+                    )
+                return page.id, atts
+
+            with ThreadPoolExecutor(max_workers=8) as pool:
+                for page_id, atts in pool.map(fetch_one, real_pages):
+                    if atts:
+                        attachments[page_id] = atts
+            print(file=sys.stderr)
+        t_atts = time.monotonic()
+
+        if verbose:
+            stats = getattr(client, "stats", {}) or {}
+            att_calls = len(real_pages) if fetch_attachments else 0
+            msg = (
+                f"Refresh timing: {len(pages)} pages in {t_pages - t0:.1f}s, "
+                f"folders in {t_folders - t_pages:.1f}s, "
+                f"{att_calls} attachment-list call(s) in {t_atts - t_folders:.1f}s"
+            )
+            if stats:
+                msg += (
+                    f"; {stats.get('requests', 0)} requests, "
+                    f"{stats.get('retries', 0)} retr(y/ies), "
+                    f"{stats.get('rate_limit_sleep_s', 0.0):.1f}s slept on rate limits"
                 )
-            return page.id, atts
-
-        with ThreadPoolExecutor(max_workers=8) as pool:
-            for page_id, atts in pool.map(fetch_one, real_pages):
-                if atts:
-                    attachments[page_id] = atts
-        print(file=sys.stderr)
+            print(msg, file=sys.stderr)
 
         # v2 always returns current+archived regardless of the requested flag, so
         # the cache is archive-capable even when the caller asked for current-only.
@@ -116,6 +151,7 @@ class CacheStore:
             attachments=attachments,
             updated_at=datetime.now(timezone.utc).isoformat(),
             include_archived=cache_includes_archived,
+            attachments_complete=fetch_attachments,
         )
         self.save(cs)
         return cs
@@ -159,12 +195,31 @@ class CacheStore:
         return pages
 
     def ensure_loaded(
-        self, client: ConfluenceClient, space: Space, include_archived: bool = False
+        self,
+        client: ConfluenceClient,
+        space: Space,
+        include_archived: bool = False,
+        *,
+        need_attachments: bool = True,
     ) -> CachedSpace:
-        """Load from cache, or refresh if not cached."""
+        """Load from cache, or refresh if the cache cannot satisfy the request.
+
+        ``need_attachments=False`` lets page-only commands (tree, find) accept — or
+        create — a page-only cache. A cache satisfies the request only if it covers
+        archived pages when asked AND has complete attachment metadata when needed;
+        otherwise it is refreshed (page-only when attachments are not needed). Older
+        cache files have no provenance bits: include_archived falls into the refresh
+        branch, and attachments_complete defaults True (they were always full)."""
         cs = self.load(space.key)
-        # A current-only cache cannot satisfy an archived export. Older cache
-        # files have no provenance bit and intentionally fall into this branch.
-        if cs is not None and (cs.include_archived or not include_archived):
+        if (
+            cs is not None
+            and (cs.include_archived or not include_archived)
+            and (cs.attachments_complete or not need_attachments)
+        ):
             return cs
-        return self.refresh(client, space, include_archived=include_archived)
+        return self.refresh(
+            client,
+            space,
+            include_archived=include_archived,
+            fetch_attachments=need_attachments,
+        )

--- a/src/confluence_export/cli.py
+++ b/src/confluence_export/cli.py
@@ -188,41 +188,50 @@ def main() -> None:
 
     client = ConfluenceClient(profile, verbose=args.verbose)
 
-    match args.command:
-        case "spaces":
-            _exit_on_auth_error(lambda: _cmd_spaces(client))
-        case "tree":
-            _cmd_tree(client, CacheStore(), profile, args.space_key)
-        case "find":
-            _cmd_find(client, CacheStore(), profile, args.space_key, args.query)
-        case "export":
-            _cmd_export(
-                client,
-                profile,
-                space_key=args.space_key,
-                path_filter=args.path,
-                output_dir=args.output,
-                no_children=args.no_children,
-                no_media=args.no_media,
-                no_drawio_render=args.no_drawio_render,
-                force_refresh=not args.cached,
-                debug=args.include_html,
-                include_archived=args.include_archived,
-                no_git=args.no_git,
-                no_author_lookup=args.no_author_lookup,
-            )
-        case "diff":
-            _cmd_diff(
-                client,
-                CacheStore(),
-                profile,
-                space_key=args.space_key,
-                export_dir=args.export_dir,
-                path_filter=args.path,
-                include_archived=args.include_archived,
-            )
-        case "refresh":
-            _cmd_refresh(client, CacheStore(), profile, args.space_key)
+    try:
+        match args.command:
+            case "spaces":
+                _exit_on_auth_error(lambda: _cmd_spaces(client))
+            case "tree":
+                _cmd_tree(client, CacheStore(), profile, args.space_key)
+            case "find":
+                _cmd_find(client, CacheStore(), profile, args.space_key, args.query)
+            case "export":
+                _cmd_export(
+                    client,
+                    profile,
+                    space_key=args.space_key,
+                    path_filter=args.path,
+                    output_dir=args.output,
+                    no_children=args.no_children,
+                    no_media=args.no_media,
+                    no_drawio_render=args.no_drawio_render,
+                    force_refresh=not args.cached,
+                    debug=args.include_html,
+                    include_archived=args.include_archived,
+                    no_git=args.no_git,
+                    no_author_lookup=args.no_author_lookup,
+                )
+            case "diff":
+                _cmd_diff(
+                    client,
+                    CacheStore(),
+                    profile,
+                    space_key=args.space_key,
+                    export_dir=args.export_dir,
+                    path_filter=args.path,
+                    include_archived=args.include_archived,
+                )
+            case "refresh":
+                _cmd_refresh(client, CacheStore(), profile, args.space_key)
+    except requests.exceptions.RequestException as exc:
+        # A network request that exhausted the client's retries (e.g. a persistent
+        # read timeout or connection drop) should fail with a clear message, not an
+        # uncaught traceback (issue #39 follow-up). Transient blips are retried in
+        # the client; this is the genuine-outage path.
+        print(f"Error: a network request to Confluence failed: {exc}", file=sys.stderr)
+        print("Likely transient (read timeout / connection drop) — re-run to retry.", file=sys.stderr)
+        sys.exit(1)
 
 
 # -- command implementations -------------------------------------------------

--- a/src/confluence_export/cli.py
+++ b/src/confluence_export/cli.py
@@ -12,6 +12,7 @@ import requests
 
 from confluence_export.cache import CacheStore
 from confluence_export.client import AuthenticationError, ConfluenceClient
+from confluence_export.diagnostics import format_warning_summary
 from confluence_export.config import (
     ApiDialect,
     AuthConfig,
@@ -669,6 +670,9 @@ def _cmd_export(
         )
 
     print(f"\nExported {result.count} page(s) to {out.resolve()}")
+    summary = format_warning_summary(result.warnings)
+    if summary:
+        print(summary, file=sys.stderr)
 
 
 def _cmd_diff(

--- a/src/confluence_export/cli.py
+++ b/src/confluence_export/cli.py
@@ -404,7 +404,7 @@ def _cmd_tree(
 ) -> None:
     """Show page hierarchy."""
     space = _exit_on_auth_error(lambda: _resolve_space(client, space_key))
-    cs = cache.ensure_loaded(client, space)
+    cs = cache.ensure_loaded(client, space, need_attachments=False)
 
     roots = build_tree(cs.pages)
     tree_str = format_tree(roots)
@@ -421,7 +421,7 @@ def _cmd_find(
 ) -> None:
     """Search pages by title."""
     space = _exit_on_auth_error(lambda: _resolve_space(client, space_key))
-    cs = cache.ensure_loaded(client, space)
+    cs = cache.ensure_loaded(client, space, need_attachments=False)
 
     results = find_pages(cs.pages, query)
     if not results:
@@ -682,14 +682,18 @@ def _cmd_diff(
     exported = scan_export_dir(export_path, space_key)
     print(f"Scanned {len(exported)} page(s) from export directory.", file=sys.stderr)
 
-    # Always refresh — diff against stale cache is useless
+    # Always refresh — diff against stale cache is useless. Page-only: diff compares
+    # page ids/versions/paths (compute_diff takes pages, not attachments), so skip
+    # the per-page attachment listing (#39).
     cs = cache.load(space_key)
     if cs is not None:
         space = cs.space
     else:
         space = _exit_on_auth_error(lambda: _resolve_space(client, space_key))
     cs = _exit_on_auth_error(
-        lambda: cache.refresh(client, space, include_archived=include_archived)
+        lambda: cache.refresh(
+            client, space, include_archived=include_archived, fetch_attachments=False
+        )
     )
 
     # Filter API pages

--- a/src/confluence_export/client.py
+++ b/src/confluence_export/client.py
@@ -259,6 +259,7 @@ class ConfluenceClient:
         url = self.base_url + path
         for attempt in range(max_retries):
             self._await_rate_limit()
+            resp = None
             try:
                 self._log(f"GET (raw) {url}")
                 with self._rate_lock:
@@ -271,6 +272,15 @@ class ConfluenceClient:
                 requests.exceptions.ConnectionError,
                 requests.exceptions.Timeout,
             ) as exc:
+                # raise_for_status() leaves a streamed body unread, so a failed
+                # response holds its pooled connection until GC. Close it before we
+                # retry or raise so the connection is released, not leaked across the
+                # retry loop (#39) or a sustained outage.
+                if resp is not None:
+                    try:
+                        resp.close()
+                    except Exception:  # pragma: no cover - best-effort cleanup
+                        pass
                 self._on_request_error(exc, attempt, max_retries, url)
         raise RuntimeError(f"Max retries exceeded for {url}")
 

--- a/src/confluence_export/client.py
+++ b/src/confluence_export/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import random
 import sys
 import threading
 import time
@@ -171,10 +172,15 @@ class ConfluenceClient:
 
     def _await_rate_limit(self) -> None:
         """Block until a rate-limit window set by a 429 (possibly on another worker
-        thread) has passed. Never holds the lock while sleeping."""
+        thread) has passed, so one 429 backs off the whole pool. Adds small jitter so
+        the pooled workers don't all wake on the same instant and re-trip the limiter
+        (Atlassian's rate-limit guidance). Best-effort single-shot: a window extended
+        by a peer mid-sleep is honored on this thread's next request, not mid-sleep.
+        Never holds the lock while sleeping."""
         with self._rate_lock:
             wait = self._rate_limit_until - time.monotonic()
         if wait > 0:
+            wait += random.uniform(0, 0.5)
             time.sleep(wait)
             with self._rate_lock:
                 self.stats["rate_limit_sleep_s"] += wait
@@ -203,7 +209,14 @@ class ConfluenceClient:
             if status in (401, 403):
                 raise AuthenticationError(status, url) from exc
             if status == 429:
-                retry_after = int(exc.response.headers.get("Retry-After", 60))
+                # Retry-After is normally delta-seconds, but a proxy/gateway can send
+                # an HTTP-date (or junk). Don't let int() raise a ValueError that would
+                # escape the (HTTPError, ConnectionError)-only except and crash a
+                # retryable 429; fall back to 60s.
+                try:
+                    retry_after = float(exc.response.headers.get("Retry-After", 60))
+                except (TypeError, ValueError):
+                    retry_after = 60.0
                 self._log(f"Rate limited, waiting {retry_after}s")
                 self._note_rate_limit(retry_after)
                 return

--- a/src/confluence_export/client.py
+++ b/src/confluence_export/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import threading
 import time
 from urllib.parse import parse_qs, quote, urlparse
 
@@ -63,6 +64,17 @@ class ConfluenceClient:
         self.session.timeout = 30
         self.api_dialect = profile.api_dialect
         self._space_key_by_id: dict[str, str] = {}
+
+        # Shared rate-limit coordination (#39): a 429 on any thread sets a window
+        # all threads honor before their next request, so one rate-limit response
+        # backs off the whole worker pool instead of every worker re-hammering.
+        self._rate_lock = threading.Lock()
+        self._rate_limit_until = 0.0  # monotonic time; requests wait until it passes
+        self.stats: dict[str, float] = {
+            "requests": 0,
+            "retries": 0,
+            "rate_limit_sleep_s": 0.0,
+        }
 
         auth = profile.auth
         if profile.auth_mode is AuthMode.COOKIE and auth.cookie_header:
@@ -157,46 +169,93 @@ class ConfluenceClient:
         else:
             self._get(f"/wiki/api/v2/pages/{quote(page_id, safe='')}/attachments", {"limit": "1"})
 
+    def _await_rate_limit(self) -> None:
+        """Block until a rate-limit window set by a 429 (possibly on another worker
+        thread) has passed. Never holds the lock while sleeping."""
+        with self._rate_lock:
+            wait = self._rate_limit_until - time.monotonic()
+        if wait > 0:
+            time.sleep(wait)
+            with self._rate_lock:
+                self.stats["rate_limit_sleep_s"] += wait
+
+    def _note_rate_limit(self, retry_after: float) -> None:
+        """Record a 429: extend the shared backoff window and count the retry."""
+        with self._rate_lock:
+            self._rate_limit_until = max(
+                self._rate_limit_until, time.monotonic() + retry_after
+            )
+            self.stats["retries"] += 1
+
+    def _backoff(self, attempt: int) -> None:
+        """Exponential backoff for a transient 5xx / connection error."""
+        wait = 2 ** attempt
+        self._log(f"Transient error, retrying in {wait}s")
+        time.sleep(wait)
+        with self._rate_lock:
+            self.stats["retries"] += 1
+
+    def _on_request_error(self, exc, attempt: int, max_retries: int, url: str) -> None:
+        """Shared retry decision for _get and _get_raw: coordinate/back off and
+        return so the caller retries, or (re-)raise if not retryable / exhausted."""
+        if isinstance(exc, requests.exceptions.HTTPError):
+            status = exc.response.status_code
+            if status in (401, 403):
+                raise AuthenticationError(status, url) from exc
+            if status == 429:
+                retry_after = int(exc.response.headers.get("Retry-After", 60))
+                self._log(f"Rate limited, waiting {retry_after}s")
+                self._note_rate_limit(retry_after)
+                return
+            if status >= 500 and attempt < max_retries - 1:
+                self._backoff(attempt)
+                return
+            raise exc
+        # ConnectionError
+        if attempt < max_retries - 1:
+            self._backoff(attempt)
+            return
+        raise exc
+
     def _get(self, path: str, params: dict | None = None, max_retries: int = 3) -> dict:
-        """GET with retry + rate-limit handling."""
+        """GET with retry + shared rate-limit handling."""
         url = self.base_url + path
         for attempt in range(max_retries):
+            self._await_rate_limit()
             try:
                 self._log(f"GET {url} params={params}")
+                with self._rate_lock:
+                    self.stats["requests"] += 1
                 resp = self.session.get(url, params=params, timeout=30)
                 resp.raise_for_status()
                 return resp.json()
-            except requests.exceptions.HTTPError as exc:
-                status = exc.response.status_code
-                if status in (401, 403):
-                    raise AuthenticationError(status, url) from exc
-                if status == 429:
-                    retry_after = int(exc.response.headers.get("Retry-After", 60))
-                    self._log(f"Rate limited, waiting {retry_after}s")
-                    time.sleep(retry_after)
-                    continue
-                if status >= 500 and attempt < max_retries - 1:
-                    wait = 2 ** attempt
-                    self._log(f"Server error {status}, retrying in {wait}s")
-                    time.sleep(wait)
-                    continue
-                raise
-            except requests.exceptions.ConnectionError:
-                if attempt < max_retries - 1:
-                    wait = 2 ** attempt
-                    self._log(f"Connection error, retrying in {wait}s")
-                    time.sleep(wait)
-                    continue
-                raise
+            except (
+                requests.exceptions.HTTPError,
+                requests.exceptions.ConnectionError,
+            ) as exc:
+                self._on_request_error(exc, attempt, max_retries, url)
         raise RuntimeError(f"Max retries exceeded for {url}")
 
-    def _get_raw(self, path: str) -> requests.Response:
-        """GET returning raw response (for file downloads)."""
+    def _get_raw(self, path: str, max_retries: int = 3) -> requests.Response:
+        """GET returning a raw streaming response (file downloads), with the SAME
+        retry + shared rate-limit coordination as _get so attachment downloads honor
+        429/5xx/transient errors and the shared backoff window (#39)."""
         url = self.base_url + path
-        self._log(f"GET (raw) {url}")
-        resp = self.session.get(url, stream=True, timeout=60)
-        resp.raise_for_status()
-        return resp
+        for attempt in range(max_retries):
+            self._await_rate_limit()
+            try:
+                self._log(f"GET (raw) {url}")
+                with self._rate_lock:
+                    self.stats["requests"] += 1
+                resp = self.session.get(url, stream=True, timeout=60)
+                resp.raise_for_status()
+                return resp
+            except (
+                requests.exceptions.HTTPError,
+                requests.exceptions.ConnectionError,
+            ) as exc:
+                self._on_request_error(exc, attempt, max_retries, url)
+        raise RuntimeError(f"Max retries exceeded for {url}")
 
     def _paginate(self, path: str, params: dict | None = None) -> list[dict]:
         """Fetch all pages of results using cursor-based pagination."""

--- a/src/confluence_export/client.py
+++ b/src/confluence_export/client.py
@@ -224,7 +224,9 @@ class ConfluenceClient:
                 self._backoff(attempt)
                 return
             raise exc
-        # ConnectionError
+        # ConnectionError / Timeout (ReadTimeout, ConnectTimeout): transient, retry.
+        # A read timeout on a single per-page attachment-list call must not abort the
+        # whole space refresh/export with an uncaught traceback (issue #39 follow-up).
         if attempt < max_retries - 1:
             self._backoff(attempt)
             return
@@ -245,6 +247,7 @@ class ConfluenceClient:
             except (
                 requests.exceptions.HTTPError,
                 requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout,
             ) as exc:
                 self._on_request_error(exc, attempt, max_retries, url)
         raise RuntimeError(f"Max retries exceeded for {url}")
@@ -266,6 +269,7 @@ class ConfluenceClient:
             except (
                 requests.exceptions.HTTPError,
                 requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout,
             ) as exc:
                 self._on_request_error(exc, attempt, max_retries, url)
         raise RuntimeError(f"Max retries exceeded for {url}")

--- a/src/confluence_export/converter.py
+++ b/src/confluence_export/converter.py
@@ -211,6 +211,31 @@ def _preprocess_html(
     for tag_name in ("ac:adf-fallback", "ac:adf-attribute", "ac:adf-mark"):
         for tag in list(soup.find_all(tag_name)):
             tag.decompose()
+    # Decision lists (ADF) must be rendered BEFORE the generic adf-node unwrap
+    # below, which would otherwise flatten them to plain text and drop both the
+    # list structure and the decided/undecided state (issue #40). A decisionItem's
+    # state lives in a ``state`` node attribute ("DECIDED"); its text is in child
+    # nodes. Render each list as a bullet list; mark decided items with a ✓.
+    for dlist in list(soup.find_all(
+        lambda t: t.name == "ac:adf-node"
+        and t.get("type") in ("decisionList", "decision-list")
+    )):
+        ul = soup.new_tag("ul")
+        for item in dlist.find_all(
+            lambda t: t.name == "ac:adf-node"
+            and t.get("type") in ("decisionItem", "decision-item")
+        ):
+            text = item.get_text().strip()
+            if not text:
+                continue
+            decided = (item.get("state", "") or "").strip().upper() == "DECIDED"
+            li = soup.new_tag("li")
+            li.string = ("✓ " if decided else "") + text
+            ul.append(li)
+        if ul.find("li"):
+            dlist.replace_with(ul)
+        else:
+            dlist.decompose()
     # Unwrap adf-content, adf-extension, adf-node so their inner HTML is preserved
     for tag_name in ("ac:adf-content", "ac:adf-extension", "ac:adf-node"):
         for tag in list(soup.find_all(tag_name)):
@@ -257,11 +282,7 @@ def _preprocess_html(
             ul.append(li)
         task_list.replace_with(ul)
 
-    # NOTE: decision lists (ac:adf-node type="decisionList"/"decisionItem") are not
-    # specially handled — the generic ac:adf-node unwrap above already strips every
-    # adf-node, so their text content survives as plain markdown. A dedicated
-    # decision-list handler used to live here but was dead (shadowed by that unwrap);
-    # removed. If richer decision rendering is wanted, it must run BEFORE the unwrap.
+    # (Decision lists are handled above, before the adf-node unwrap.)
 
     # --- User mentions (ri:user inside ac:link or standalone) ---
     for user_tag in list(soup.find_all("ri:user")):

--- a/src/confluence_export/converter.py
+++ b/src/confluence_export/converter.py
@@ -359,11 +359,14 @@ def _preprocess_html(
             _convert_profile(soup, macro, user_resolver)
         elif macro_name == "profile-picture":
             # A profile-picture with a user was already resolved to an inline
-            # mention in the user-mention pre-pass. If it still holds that
-            # resolved content (e.g. a nested profile-picture whose inner mention
-            # we kept — F4), unwrap to preserve it; an empty one (no user) is
-            # dropped rather than emitting a dynamic-content placeholder.
-            if macro.get_text(strip=True):
+            # mention <span> in the user-mention pre-pass (converter.py:312-314) —
+            # including the nested case (F4), where the inner macro is replaced by a
+            # span that ends up inside this outer one. Unwrap ONLY when that resolved
+            # span is present; a macro whose only text is a raw ac:parameter value
+            # (a bare account-id with no nested ri:user) carries no span and is
+            # dropped, so the raw id is never leaked as body text. An empty one (no
+            # user) is likewise dropped rather than emitting a placeholder.
+            if macro.find("span"):
                 macro.unwrap()
             else:
                 macro.decompose()

--- a/src/confluence_export/converter.py
+++ b/src/confluence_export/converter.py
@@ -350,6 +350,11 @@ def _preprocess_html(
                 soup, macro, rendered, attach_map, name_plan,
                 media_downloaded=media_downloaded, available_media=available_media,
             )
+        elif macro_name == "drawio-sketch":
+            _convert_drawio_sketch(
+                soup, macro, rendered, attach_map, name_plan,
+                media_downloaded=media_downloaded, available_media=available_media,
+            )
         elif macro_name == "profile":
             _convert_profile(soup, macro, user_resolver)
         elif macro_name == "profile-picture":
@@ -722,36 +727,52 @@ def _convert_drawio_placeholder(
     ``rendered``."""
     name_param = macro.find("ac:parameter", attrs={"ac:name": "diagramName"})
     diagram_name = name_param.get_text().strip() if name_param else "diagram"
-    bare = diagram_name.removesuffix(".drawio")
-
     # F6/F7: resolve the diagramName to the real on-disk attachment, tolerant of
     # the .drawio extension and case/whitespace, rather than reconstructing a name.
     matched = _match_drawio_attachment(diagram_name, attach_map)
-    source_name = matched.title if matched is not None else f"{bare}.drawio"
+    _emit_drawio(
+        soup, macro, diagram_name, matched, rendered, name_plan,
+        media_downloaded=media_downloaded, available_media=available_media,
+    )
+
+
+def _emit_drawio(
+    soup: BeautifulSoup,
+    macro: Tag,
+    source_name: str,
+    matched: Attachment | None,
+    rendered: dict[str, Path],
+    name_plan: AttachmentNamePlan,
+    *,
+    media_downloaded: bool,
+    available_media: set[str] | None,
+) -> None:
+    """Emit the rendered-PNG ``<img>`` (+ a source link when the .drawio is on disk)
+    for a drawio / drawio-sketch macro resolved to ``matched``, or a graceful
+    "not rendered" note when no PNG is available."""
+    bare = source_name.removesuffix(".drawio")
+    source_title = matched.title if matched is not None else f"{bare}.drawio"
     source_local_name = (
         name_plan.for_attachment(matched)
         if matched is not None
-        else safe_attachment_name(source_name)
+        else safe_attachment_name(source_title)
     )
 
     # Rendered-PNG lookup: the exporter keys rendered[att.title]; try the matched
     # title first, then the reconstructed names (F7).
     png_path = None
     for key in ([matched.title] if matched is not None else []) + [
-        diagram_name, f"{bare}.drawio", bare,
+        source_name, f"{bare}.drawio", bare,
     ]:
         if key in rendered:
             png_path = rendered[key]
             break
 
     # F5: a source link only when the source is actually on disk.
-    source_tracked = (
-        matched is not None
-        and (
-            source_local_name in available_media
-            if available_media is not None
-            else media_downloaded
-        )
+    source_tracked = matched is not None and (
+        source_local_name in available_media
+        if available_media is not None
+        else media_downloaded
     )
 
     p = soup.new_tag("p")
@@ -763,16 +784,50 @@ def _convert_drawio_placeholder(
         ))
     else:
         em = soup.new_tag("em")
-        em.string = f"[Draw.io diagram not rendered: {_markdown_label(source_name)}]"
+        em.string = f"[Draw.io diagram not rendered: {_markdown_label(source_title)}]"
         p.append(em)
     if source_tracked:
         p.append(soup.new_tag("br"))
         src_em = soup.new_tag("em")
         src_em.append("Draw.io source: ")
         link = soup.new_tag("a", href=_markdown_media_url(source_local_name))
-        link.string = _markdown_label(source_name)
+        link.string = _markdown_label(source_title)
         src_em.append(link)
         p.append(src_em)
+    macro.replace_with(p)
+
+
+def _convert_drawio_sketch(
+    soup: BeautifulSoup,
+    macro: Tag,
+    rendered: dict[str, Path],
+    attach_map: dict[str, Attachment],
+    name_plan: AttachmentNamePlan,
+    *,
+    media_downloaded: bool = True,
+    available_media: set[str] | None = None,
+) -> None:
+    """drawio-sketch macro (#6). Render it like a drawio diagram when it is
+    attachment-backed (carries an ``ri:attachment``); otherwise emit a graceful
+    ``[Draw.io sketch]`` note instead of the generic dynamic-content placeholder.
+
+    The inline-payload render path (writing an embedded sketch to a temp ``.drawio``
+    and rendering it) is intentionally deferred until a real drawio-sketch storage
+    sample confirms the shape — until then an inline sketch degrades to a clean note
+    rather than a confusing ``[Confluence dynamic content: drawio-sketch]``."""
+    ri = macro.find("ri:attachment")
+    filename = ri.get("ri:filename", "").strip() if ri is not None else ""
+    if filename:
+        matched = _match_drawio_attachment(filename, attach_map)
+        _emit_drawio(
+            soup, macro, filename, matched, rendered, name_plan,
+            media_downloaded=media_downloaded, available_media=available_media,
+        )
+        return
+    p = soup.new_tag("p")
+    em = soup.new_tag("em")
+    em.string = "[Draw.io sketch]"
+    p.append(em)
     macro.replace_with(p)
 
 

--- a/src/confluence_export/diagnostics.py
+++ b/src/confluence_export/diagnostics.py
@@ -1,0 +1,46 @@
+"""End-of-run export diagnostics.
+
+Best-effort export warnings (an attachment whose binary is gone, a draw.io render
+that produced nothing, a page that failed to convert) are printed inline to stderr
+as they happen, which is hard to skim after a bulk run. ``WarningCollector`` records
+them by category so the export command can print one grouped summary at the end —
+no log scraping to answer "did anything degrade, and how much?". Thread-safe because
+attachment downloads record from a worker pool.
+"""
+
+from __future__ import annotations
+
+import threading
+
+
+class WarningCollector:
+    """Thread-safe tally of best-effort warnings, keyed by a short category string."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._counts: dict[str, int] = {}
+
+    def record(self, category: str) -> None:
+        with self._lock:
+            self._counts[category] = self._counts.get(category, 0) + 1
+
+    def counts(self) -> dict[str, int]:
+        with self._lock:
+            return dict(self._counts)
+
+    @property
+    def total(self) -> int:
+        with self._lock:
+            return sum(self._counts.values())
+
+
+def format_warning_summary(counts: dict[str, int]) -> str:
+    """One-line grouped summary, most-frequent first, e.g.
+    ``14 warning(s): attachment unavailable (HTTP 404) ×12, empty draw.io diagram ×2``.
+    Empty when there were no warnings."""
+    if not counts:
+        return ""
+    total = sum(counts.values())
+    items = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+    body = ", ".join(f"{cat} ×{n}" for cat, n in items)
+    return f"{total} warning(s): {body}"

--- a/src/confluence_export/drawio.py
+++ b/src/confluence_export/drawio.py
@@ -11,6 +11,7 @@ import tempfile
 import time
 from pathlib import Path
 
+from confluence_export.diagnostics import WarningCollector
 from confluence_export.filemode import default_file_mode, replacement_mode
 from confluence_export.types import Attachment
 
@@ -73,11 +74,26 @@ def _usable_png(path: Path) -> bool:
         return False
 
 
+def _is_empty_drawio(drawio_path: Path) -> bool:
+    """Whether a .drawio source has no renderable diagram content (so draw.io legitimately
+    produces no PNG). An empty mxGraphModel is tiny and has no shape geometry; a real
+    diagram (even compressed) is larger and has ``mxGeometry``/encoded ``<diagram>`` body.
+    Heuristic, used only to word the warning — never changes behavior."""
+    try:
+        if drawio_path.stat().st_size > 600:
+            return False
+        text = drawio_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    return "mxGeometry" not in text and text.count("<mxCell") <= 2
+
+
 def render_drawio_to_png(
     drawio_path: Path,
     output_path: Path | None = None,
     *,
     force: bool = False,
+    warnings: "WarningCollector | None" = None,
 ) -> Path | None:
     """Render a .drawio file to PNG using the draw.io CLI.
 
@@ -214,5 +230,14 @@ def render_drawio_to_png(
     except OSError:  # pragma: no cover
         pass
 
-    print(f"  Warning: draw.io produced no output for {drawio_path.name}", file=sys.stderr)
+    if _is_empty_drawio(drawio_path):
+        # Low-severity content warning: the source has no renderable diagram, so
+        # draw.io legitimately wrote no PNG — not a render failure.
+        print(f"  Warning: empty draw.io diagram skipped: {drawio_path.name}", file=sys.stderr)
+        if warnings is not None:
+            warnings.record("empty draw.io diagram skipped")
+    else:
+        print(f"  Warning: draw.io produced no output for {drawio_path.name}", file=sys.stderr)
+        if warnings is not None:
+            warnings.record("draw.io produced no output")
     return None

--- a/src/confluence_export/exporter.py
+++ b/src/confluence_export/exporter.py
@@ -30,6 +30,7 @@ from confluence_export.provenance import (
     recursive_archived_dirs,
 )
 from confluence_export.protection import ProtectionSet, move_window_dirs
+from confluence_export.diagnostics import WarningCollector
 from confluence_export.media import (
     MEDIA_DIR_NAME,
     WORKSPACE_DIR_NAME,
@@ -77,6 +78,10 @@ class ExportResult:
     # though no current media file was written, so stale tracked media can be
     # pruned during --no-media exports.
     prune_media_dirs: list[Path] = field(default_factory=list)
+    # Best-effort warnings this run, grouped by category (e.g. "attachment
+    # unavailable (HTTP 404)" -> count). Printed as one end-of-run summary by the
+    # cli so a clean exit (0) doesn't hide soft losses.
+    warnings: dict[str, int] = field(default_factory=dict)
 
     def protection(self, output_dir: Path) -> ProtectionSet:
         """Compile this run's protected-path accumulators into the typed bundle the
@@ -172,6 +177,8 @@ class Exporter:
         self._skipped_paths: list[Path] = []
         self._preserved_page_paths: list[Path] = []
         self._preserved_paths: list[Path] = []
+        # Best-effort warnings collected across this run (reset in export_space).
+        self._warnings = WarningCollector()
         self._prune_media_dirs: list[Path] = []
         # page_id -> on-disk dirs as they existed BEFORE reconcile ran this run.
         # Used to protect a moved-then-skipped page's old path from the prune (M2).
@@ -234,6 +241,7 @@ class Exporter:
                     page.webui = full_page.webui
             except Exception as exc:
                 print(f"  Warning: could not fetch body for {page.title}: {exc}", file=sys.stderr)
+                self._warnings.record("page body fetch failed")
             with lock:
                 counter[0] += 1
                 print(
@@ -260,6 +268,7 @@ class Exporter:
         self._preserved_page_paths = []
         self._preserved_paths = []
         self._prune_media_dirs = []
+        self._warnings = WarningCollector()
         self._pre_reconcile_dirs = {}
         self._scan_grouped = {}
         # Ensure cache
@@ -421,6 +430,7 @@ class Exporter:
                 node_result.preserved_page_paths = list(self._preserved_page_paths)
                 node_result.preserved_paths = list(self._preserved_paths)
                 node_result.prune_media_dirs = list(self._prune_media_dirs)
+                node_result.warnings = self._warnings.counts()
                 return node_result
         else:
             if no_children:
@@ -435,6 +445,7 @@ class Exporter:
                 result.preserved_page_paths = list(self._preserved_page_paths)
                 result.preserved_paths = list(self._preserved_paths)
                 result.prune_media_dirs = list(self._prune_media_dirs)
+                result.warnings = self._warnings.counts()
                 return result
 
         # Export flat list (no_children case)
@@ -447,6 +458,7 @@ class Exporter:
         result.preserved_page_paths = list(self._preserved_page_paths)
         result.preserved_paths = list(self._preserved_paths)
         result.prune_media_dirs = list(self._prune_media_dirs)
+        result.warnings = self._warnings.counts()
         return result
 
     def _mark_skipped_subtree(self, node: PageNode, page_dir: Path) -> None:
@@ -525,6 +537,7 @@ class Exporter:
                     page.webui = full_page.webui
             except Exception as exc:
                 print(f"  Warning: could not fetch body for {page.title}: {exc}", file=sys.stderr)
+                self._warnings.record("page body fetch failed")
                 # M2: also protect the page's pre-reconcile (old) path so a moved
                 # page that fails to refetch keeps its last-good committed export.
                 self._skipped_paths.extend(
@@ -629,7 +642,11 @@ class Exporter:
                 snapshot_file(media_dir / _VERSIONS_FILE)
                 for name in current_attachment_names:
                     snapshot_file(resolve_within(media_dir, name))
-                written.extend(download_attachments(self.client, attachments, media_dir))
+                written.extend(
+                    download_attachments(
+                        self.client, attachments, media_dir, warnings=self._warnings
+                    )
+                )
             elif not self.download_media and attachments:
                 existing_media_dir = page_dir / MEDIA_DIR_NAME
                 if existing_media_dir.is_dir():
@@ -684,6 +701,7 @@ class Exporter:
                                 drawio_file,
                                 output_path=output_path,
                                 force=force_render,
+                                warnings=self._warnings,
                             )
                             if png_path:
                                 rendered[att.title] = png_path
@@ -720,6 +738,7 @@ class Exporter:
             )
         except Exception as exc:
             print(f"  Warning: could not convert {page.title}: {exc}", file=sys.stderr)
+            self._warnings.record("page conversion failed")
             # M2: also protect the page's pre-reconcile (old) path (see above).
             self._skipped_paths.extend(
                 move_window_dirs(page_dir, page.id, self._pre_reconcile_dirs)
@@ -735,6 +754,7 @@ class Exporter:
             _write_text_atomic(md_path, markdown, encoding="utf-8")
         except Exception as exc:
             print(f"  Warning: could not write {page.title}: {exc}", file=sys.stderr)
+            self._warnings.record("page write failed")
             self._skipped_paths.extend(
                 move_window_dirs(page_dir, page.id, self._pre_reconcile_dirs)
             )

--- a/src/confluence_export/git.py
+++ b/src/confluence_export/git.py
@@ -384,6 +384,11 @@ def _restore_protected_deletions(
     if not page_dirs and not sub_dirs:
         return
     result = _run_git(output_dir, "ls-files", "--deleted", "-z", check=False)
+    if result is None:  # pragma: no cover - transient git failure under load
+        # Retry once: a transient git failure here would silently skip the heal,
+        # leaving a protected file's deletion (or a symlinked ancestor) until the
+        # next run (issue #41 flake).
+        result = _run_git(output_dir, "ls-files", "--deleted", "-z", check=False)
     if result is None or not result.stdout.strip("\0"):
         return
     to_restore = []
@@ -414,7 +419,13 @@ def _restore_protected_deletions(
     if blocked:
         to_restore = [path for path in to_restore if path not in blocked]
     for batch in _chunked_paths(to_restore):
-        _run_git(output_dir, "checkout", "HEAD", "--", *batch, check=False)
+        if _run_git(output_dir, "checkout", "HEAD", "--", *batch, check=False) is None:
+            # Retry once: a transient git failure under load would otherwise leave a
+            # protected file unrestored and a just-unlinked symlinked ancestor not
+            # re-materialized as a real dir (issue #41 flake). The symlink ancestor
+            # was already unlinked above, so `checkout HEAD` is idempotent and can
+            # never write through the symlink to its outside target.
+            _run_git(output_dir, "checkout", "HEAD", "--", *batch, check=False)  # pragma: no cover - transient
 
 
 def _symlink_ancestor(output_dir: Path, rel_path: str) -> Path | None:

--- a/src/confluence_export/media.py
+++ b/src/confluence_export/media.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import requests
 
-from confluence_export.client import ConfluenceClient
+from confluence_export.client import AuthenticationError, ConfluenceClient
 from confluence_export.diagnostics import WarningCollector
 from confluence_export.filemode import default_file_mode, replacement_mode
 from confluence_export.paths import (
@@ -394,13 +394,26 @@ def _record_download_warning(
 ) -> None:
     """Print a clear best-effort download warning and tally it by category. A 404 on
     the binary (the metadata listed the file, but its bytes are gone) is *unavailable
-    content*, not an exporter endpoint bug — word it so the user doesn't misread it."""
+    content*, not an exporter endpoint bug — word it so the user doesn't misread it.
+    A 401/403 is distinct: the metadata listed fine but the binary fetch was rejected,
+    which is most often a token-type problem (granular/scoped API tokens are widely
+    reported to fail attachment downloads even with the attachment scope granted), so
+    point the user at the one fix rather than burying it as a generic failure."""
     status = getattr(getattr(exc, "response", None), "status_code", None)
     if isinstance(exc, requests.exceptions.HTTPError) and status == 404:
         category = "attachment unavailable (HTTP 404)"
         print(
             f"  Warning: attachment '{att.title}': metadata exists but its binary is "
             "unavailable (HTTP 404)",
+            file=sys.stderr,
+        )
+    elif isinstance(exc, AuthenticationError):
+        category = "attachment download forbidden (HTTP 401/403)"
+        print(
+            f"  Warning: HTTP {exc.status_code} downloading '{att.title}': its metadata "
+            "is listed but the binary fetch was rejected. Granular/scoped API tokens are "
+            "known to fail attachment downloads even with the attachment scope; if these "
+            "persist across runs, use a classic (unscoped) API token.",
             file=sys.stderr,
         )
     elif isinstance(exc, requests.exceptions.Timeout):

--- a/src/confluence_export/media.py
+++ b/src/confluence_export/media.py
@@ -10,7 +10,10 @@ import tempfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
+import requests
+
 from confluence_export.client import ConfluenceClient
+from confluence_export.diagnostics import WarningCollector
 from confluence_export.filemode import default_file_mode, replacement_mode
 from confluence_export.paths import (
     attachment_identity,
@@ -386,11 +389,36 @@ def available_attachment_names(attachments: list[Attachment], media_dir: Path) -
     return available
 
 
+def _record_download_warning(
+    att: Attachment, exc: Exception, warnings: WarningCollector | None
+) -> None:
+    """Print a clear best-effort download warning and tally it by category. A 404 on
+    the binary (the metadata listed the file, but its bytes are gone) is *unavailable
+    content*, not an exporter endpoint bug — word it so the user doesn't misread it."""
+    status = getattr(getattr(exc, "response", None), "status_code", None)
+    if isinstance(exc, requests.exceptions.HTTPError) and status == 404:
+        category = "attachment unavailable (HTTP 404)"
+        print(
+            f"  Warning: attachment '{att.title}': metadata exists but its binary is "
+            "unavailable (HTTP 404)",
+            file=sys.stderr,
+        )
+    elif isinstance(exc, requests.exceptions.Timeout):
+        category = "attachment download timeout"
+        print(f"  Warning: timed out downloading {att.title}: {exc}", file=sys.stderr)
+    else:
+        category = "attachment download failed"
+        print(f"  Warning: failed to download {att.title}: {exc}", file=sys.stderr)
+    if warnings is not None:
+        warnings.record(category)
+
+
 def download_attachments(
     client: ConfluenceClient,
     attachments: list[Attachment],
     media_dir: Path,
     skip_existing: bool = True,
+    warnings: WarningCollector | None = None,
 ) -> list[Path]:
     """Download attachments to media_dir. Returns list of downloaded file paths.
 
@@ -545,7 +573,7 @@ def download_attachments(
                     versions[name] = _manifest_entry(att)
                 except Exception as exc:
                     keep_existing(name, att, dest, allow_legacy=True)
-                    print(f"  Warning: failed to download {att.title}: {exc}", file=sys.stderr)
+                    _record_download_warning(att, exc, warnings)
 
         _save_versions(media_dir, versions)
         downloaded.append(media_dir / _VERSIONS_FILE)

--- a/src/confluence_export/types.py
+++ b/src/confluence_export/types.py
@@ -198,6 +198,11 @@ class CachedSpace:
     attachments: dict[str, list[Attachment]]  # page_id -> attachments
     updated_at: str = ""
     include_archived: bool = False
+    # Whether per-page attachment metadata was fetched this refresh. A page-only
+    # refresh (tree/find/diff) sets this False; export must NOT treat such a cache
+    # as authoritative for attachments/media-prune. Old caches (no flag) predate
+    # page-only mode and were always full, so they default to True.
+    attachments_complete: bool = True
 
     def to_dict(self) -> dict:
         return {
@@ -217,6 +222,7 @@ class CachedSpace:
             },
             "updated_at": self.updated_at,
             "include_archived": self.include_archived,
+            "attachments_complete": self.attachments_complete,
         }
 
     @classmethod
@@ -230,4 +236,5 @@ class CachedSpace:
             },
             updated_at=data.get("updated_at", ""),
             include_archived=bool(data.get("include_archived", False)),
+            attachments_complete=bool(data.get("attachments_complete", True)),
         )

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -258,3 +258,91 @@ def test_resolve_folders_skips_unresolvable_parent():
     result = CacheStore._resolve_folders(client, pages)
 
     assert [p.id for p in result] == ["c"]
+
+
+class TestPageOnlyRefresh:
+    """#39: page-only refresh skips the per-page attachment listing."""
+
+    def _client(self, pages, returns_archived=True):
+        client = MagicMock()
+        client.returns_archived_pages = returns_archived
+        client.verbose = False
+        client.get_pages_in_space.return_value = pages
+        client.get_attachments.return_value = []
+        return client
+
+    def _pages(self):
+        return [Page(id="p1", title="Page", space_id="1", version=Version(number=1))]
+
+    def test_page_only_refresh_skips_attachment_listing(self, tmp_path):
+        with patch("confluence_export.cache.cache_dir", return_value=tmp_path):
+            store = CacheStore()
+            client = self._client(self._pages())
+            cs = store.refresh(client, _make_space(), fetch_attachments=False)
+            client.get_attachments.assert_not_called()
+            assert cs.attachments == {}
+            assert cs.attachments_complete is False
+
+    def test_full_refresh_fetches_attachments_and_marks_complete(self, tmp_path):
+        with patch("confluence_export.cache.cache_dir", return_value=tmp_path):
+            store = CacheStore()
+            client = self._client(self._pages())
+            cs = store.refresh(client, _make_space())  # default: full
+            client.get_attachments.assert_called_once_with("p1")
+            assert cs.attachments_complete is True
+
+    def test_attachments_complete_roundtrips(self, tmp_path):
+        with patch("confluence_export.cache.cache_dir", return_value=tmp_path):
+            store = CacheStore()
+            cs = _make_cached_space()
+            cs.attachments_complete = False
+            store.save(cs)
+            assert store.load("TEST").attachments_complete is False
+
+    def test_legacy_cache_without_flag_defaults_complete(self):
+        data = _make_cached_space().to_dict()
+        del data["attachments_complete"]
+        assert CachedSpace.from_dict(data).attachments_complete is True
+
+    def test_ensure_loaded_page_only_cache_satisfies_page_only_request(self, tmp_path):
+        with patch("confluence_export.cache.cache_dir", return_value=tmp_path):
+            store = CacheStore()
+            cs = _make_cached_space()
+            cs.attachments_complete = False
+            store.save(cs)
+            client = MagicMock()
+            result = store.ensure_loaded(client, _make_space(), need_attachments=False)
+            client.get_pages_in_space.assert_not_called()  # served from cache, no refresh
+            assert result.attachments_complete is False
+
+    def test_ensure_loaded_page_only_cache_insufficient_for_export(self, tmp_path):
+        with patch("confluence_export.cache.cache_dir", return_value=tmp_path):
+            store = CacheStore()
+            cs = _make_cached_space()
+            cs.attachments_complete = False
+            store.save(cs)
+            client = self._client(self._pages())
+            result = store.ensure_loaded(client, _make_space(), need_attachments=True)
+            client.get_pages_in_space.assert_called_once()  # refreshed (full)
+            client.get_attachments.assert_called_once()
+            assert result.attachments_complete is True
+
+    def test_ensure_loaded_full_cache_satisfies_page_only_request(self, tmp_path):
+        with patch("confluence_export.cache.cache_dir", return_value=tmp_path):
+            store = CacheStore()
+            store.save(_make_cached_space())  # attachments_complete defaults True
+            client = MagicMock()
+            result = store.ensure_loaded(client, _make_space(), need_attachments=False)
+            client.get_pages_in_space.assert_not_called()  # full cache reused
+            assert result.attachments_complete is True
+
+    def test_verbose_refresh_prints_instrumentation(self, tmp_path, capsys):
+        with patch("confluence_export.cache.cache_dir", return_value=tmp_path):
+            store = CacheStore()
+            client = self._client(self._pages())
+            client.verbose = True
+            client.stats = {"requests": 3, "retries": 1, "rate_limit_sleep_s": 2.0}
+            store.refresh(client, _make_space())
+            err = capsys.readouterr().err
+            assert "Refresh timing:" in err
+            assert "attachment-list call" in err

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -191,6 +191,42 @@ class TestExportCommand:
         md_files = list(Path(out).rglob("*.md"))
         assert len(md_files) == 2
 
+    def test_prints_warning_summary_to_stderr_when_degraded(self, tmp_path, capsys):
+        client = _mock_client()
+        export_result = ExportResult(
+            count=3,
+            written_files=[tmp_path / "out" / "P" / "P.md"],
+            warnings={"attachment unavailable (HTTP 404)": 2, "draw.io produced no output": 1},
+        )
+        exporter = MagicMock()
+        exporter.export_space.return_value = export_result
+        out = str(tmp_path / "out")
+        with patch("sys.argv", ["confluence-export", "export", "TEST", "-o", out, "--no-git"]), \
+             patch("confluence_export.cli.load_connection_profile", return_value=_profile()), \
+             patch("confluence_export.cli.ConfluenceClient", return_value=client), \
+             patch("confluence_export.cli.Exporter", return_value=exporter):
+            main()
+
+        captured = capsys.readouterr()
+        assert "Exported 3 page(s)" in captured.out
+        # The grouped one-liner goes to stderr so it does not pollute piped stdout.
+        assert "3 warning(s):" in captured.err
+        assert "attachment unavailable (HTTP 404) ×2" in captured.err
+
+    def test_no_warning_summary_when_clean(self, tmp_path, capsys):
+        client = _mock_client()
+        export_result = ExportResult(count=1, written_files=[], warnings={})
+        exporter = MagicMock()
+        exporter.export_space.return_value = export_result
+        out = str(tmp_path / "out")
+        with patch("sys.argv", ["confluence-export", "export", "TEST", "-o", out, "--no-git"]), \
+             patch("confluence_export.cli.load_connection_profile", return_value=_profile()), \
+             patch("confluence_export.cli.ConfluenceClient", return_value=client), \
+             patch("confluence_export.cli.Exporter", return_value=exporter):
+            main()
+
+        assert "warning(s):" not in capsys.readouterr().err
+
 
     def test_export_migrates_legacy_media_dirs(self, tmp_path, capsys):
         client = _mock_client()

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -987,3 +987,45 @@ class TestConfigureExistingDefaults:
         assert data["auth"]["type"] == "scoped_api_token"
         assert data["cloud_id"] == "cloud-999"
         assert data["api_base_url"] == "https://api.atlassian.com/ex/confluence/cloud-999"
+
+
+class TestPageOnlyWiring:
+    """#39: tree/find/diff refresh page-only (skip the per-page attachment listing)."""
+
+    def _patches(self, argv, cache, client):
+        return [
+            patch("sys.argv", argv),
+            patch("confluence_export.cli.load_connection_profile", return_value=_profile()),
+            patch("confluence_export.cli.ConfluenceClient", return_value=client),
+            patch("confluence_export.cli.CacheStore", return_value=cache),
+        ]
+
+    def _run(self, argv, cache, client):
+        import contextlib
+        with contextlib.ExitStack() as stack:
+            for p in self._patches(argv, cache, client):
+                stack.enter_context(p)
+            main()
+
+    def test_tree_uses_page_only(self):
+        cache = MagicMock()
+        cache.ensure_loaded.return_value = _cached_space()
+        self._run(["confluence-export", "tree", "TEST"], cache, _mock_client())
+        assert cache.ensure_loaded.call_args.kwargs.get("need_attachments") is False
+
+    def test_find_uses_page_only(self):
+        cache = MagicMock()
+        cache.ensure_loaded.return_value = _cached_space()
+        self._run(["confluence-export", "find", "TEST", "Child"], cache, _mock_client())
+        assert cache.ensure_loaded.call_args.kwargs.get("need_attachments") is False
+
+    def test_diff_uses_page_only(self, tmp_path):
+        cache = MagicMock()
+        cache.load.return_value = None
+        cache.refresh.return_value = _cached_space()
+        export_dir = tmp_path / "export"
+        export_dir.mkdir()
+        self._run(
+            ["confluence-export", "diff", "TEST", str(export_dir)], cache, _mock_client()
+        )
+        assert cache.refresh.call_args.kwargs.get("fetch_attachments") is False

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1029,3 +1029,23 @@ class TestPageOnlyWiring:
             ["confluence-export", "diff", "TEST", str(export_dir)], cache, _mock_client()
         )
         assert cache.refresh.call_args.kwargs.get("fetch_attachments") is False
+
+
+class TestNetworkErrorHandling:
+    """#39 follow-up: a network failure that exhausts retries exits cleanly, not as
+    an uncaught traceback (a read timeout during refresh aborted a bulk export)."""
+
+    def test_persistent_read_timeout_exits_cleanly(self, capsys):
+        client = _mock_client()
+        cache = MagicMock()
+        cache.refresh.side_effect = requests.exceptions.ReadTimeout("read timed out")
+        with patch("sys.argv", ["confluence-export", "refresh", "TEST"]), \
+             patch("confluence_export.cli.load_connection_profile", return_value=_profile()), \
+             patch("confluence_export.cli.ConfluenceClient", return_value=client), \
+             patch("confluence_export.cli.CacheStore", return_value=cache):
+            with pytest.raises(SystemExit) as exc:
+                main()
+            assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "network request to Confluence failed" in err
+        assert "re-run to retry" in err.lower()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -92,6 +92,27 @@ class TestGet:
             with pytest.raises(requests.exceptions.ConnectionError):
                 client._get("/test", max_retries=2)
 
+    def test_read_timeout_retries_then_succeeds(self):
+        # #39 follow-up: a per-page attachment-list ReadTimeout (a Timeout, NOT a
+        # ConnectionError) must be retried, not escape uncaught and abort the export.
+        client = _make_client()
+        with patch.object(client.session, "get") as mock_get, \
+             patch("confluence_export.client.time.sleep"):
+            ok = MagicMock()
+            ok.status_code = 200
+            ok.raise_for_status.return_value = None
+            ok.json.return_value = {"ok": True}
+            mock_get.side_effect = [requests.exceptions.ReadTimeout(), ok]
+            assert client._get("/test") == {"ok": True}
+
+    def test_read_timeout_exhausted_raises(self):
+        client = _make_client()
+        with patch.object(client.session, "get") as mock_get, \
+             patch("confluence_export.client.time.sleep"):
+            mock_get.side_effect = requests.exceptions.ReadTimeout()
+            with pytest.raises(requests.exceptions.ReadTimeout):
+                client._get("/test", max_retries=2)
+
 
 class TestPaginate:
     def test_single_page(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -772,6 +772,20 @@ class TestGetRawRetryAndRateLimit:
             mock_get.side_effect = [self._http_error(500), ok]
             assert client._get_raw("/d") is ok
 
+    def test_get_raw_closes_failed_streamed_response_before_retry(self):
+        # raise_for_status leaves a stream=True body unread; the failed response must
+        # be closed so its pooled connection is released rather than leaked until GC.
+        client = _make_client()
+        with patch.object(client.session, "get") as mock_get, \
+             patch("confluence_export.client.time.sleep"):
+            failed = self._http_error(500)
+            ok = self._ok()
+            mock_get.side_effect = [failed, ok]
+            assert client._get_raw("/d") is ok
+            failed.close.assert_called_once()
+            # The successful response must NOT be closed (the caller streams it).
+            ok.close.assert_not_called()
+
     def test_get_raw_retries_on_connection_error(self):
         client = _make_client()
         with patch.object(client.session, "get") as mock_get, \

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -650,3 +650,99 @@ class TestGetFolderByIdV1:
         client.set_cookies("session=abc")
         with patch.object(client, "_get", side_effect=Exception("boom")):
             assert client.get_folder_by_id("77") is None
+
+
+class TestGetRawRetryAndRateLimit:
+    """#39: attachment downloads (_get_raw) share _get's retry/rate-limit path, and a
+    429 sets a shared backoff window all requests honor."""
+
+    def _http_error(self, status, retry_after=None):
+        resp = MagicMock()
+        resp.status_code = status
+        resp.headers = {"Retry-After": str(retry_after)} if retry_after is not None else {}
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError(response=resp)
+        return resp
+
+    def _ok(self):
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        return resp
+
+    def test_get_raw_retries_on_429_then_succeeds(self):
+        client = _make_client()
+        with patch.object(client.session, "get") as mock_get, \
+             patch("confluence_export.client.time.sleep"):
+            ok = self._ok()
+            mock_get.side_effect = [self._http_error(429, retry_after=0), ok]
+            assert client._get_raw("/d") is ok
+            assert client.stats["retries"] >= 1
+            assert client.stats["requests"] >= 2
+
+    def test_get_raw_retries_on_500_then_succeeds(self):
+        client = _make_client()
+        with patch.object(client.session, "get") as mock_get, \
+             patch("confluence_export.client.time.sleep"):
+            ok = self._ok()
+            mock_get.side_effect = [self._http_error(500), ok]
+            assert client._get_raw("/d") is ok
+
+    def test_get_raw_retries_on_connection_error(self):
+        client = _make_client()
+        with patch.object(client.session, "get") as mock_get, \
+             patch("confluence_export.client.time.sleep"):
+            ok = self._ok()
+            mock_get.side_effect = [requests.exceptions.ConnectionError(), ok]
+            assert client._get_raw("/d") is ok
+
+    def test_get_raw_auth_error_not_retried(self):
+        client = _make_client()
+        with patch.object(client.session, "get") as mock_get:
+            mock_get.return_value = self._http_error(403)
+            with pytest.raises(AuthenticationError):
+                client._get_raw("/d")
+
+    def test_get_raw_500_exhausted_raises_httperror(self):
+        client = _make_client()
+        with patch.object(client.session, "get") as mock_get, \
+             patch("confluence_export.client.time.sleep"):
+            mock_get.return_value = self._http_error(500)
+            with pytest.raises(requests.exceptions.HTTPError):
+                client._get_raw("/d", max_retries=2)
+
+    def test_get_raw_429_exhausted_raises_runtime(self):
+        client = _make_client()
+        with patch.object(client.session, "get") as mock_get, \
+             patch("confluence_export.client.time.sleep"):
+            mock_get.return_value = self._http_error(429, retry_after=0)
+            with pytest.raises(RuntimeError, match="Max retries"):
+                client._get_raw("/d", max_retries=2)
+
+    def test_get_raw_connection_error_exhausted_raises(self):
+        client = _make_client()
+        with patch.object(client.session, "get") as mock_get, \
+             patch("confluence_export.client.time.sleep"):
+            mock_get.side_effect = requests.exceptions.ConnectionError()
+            with pytest.raises(requests.exceptions.ConnectionError):
+                client._get_raw("/d", max_retries=2)
+
+    def test_shared_window_makes_next_request_wait(self):
+        client = _make_client()
+        with patch.object(client.session, "get") as mock_get, \
+             patch("confluence_export.client.time.sleep") as sleep:
+            ok = self._ok()
+            ok.json.return_value = {}
+            mock_get.return_value = ok
+            client._note_rate_limit(5)  # a 429 elsewhere set a 5s window
+            client._get("/x")  # must wait the window before its request
+            assert sleep.called
+            assert client.stats["rate_limit_sleep_s"] > 0
+
+    def test_stats_count_successful_requests(self):
+        client = _make_client()
+        with patch.object(client.session, "get") as mock_get:
+            ok = self._ok()
+            ok.json.return_value = {"ok": True}
+            mock_get.return_value = ok
+            client._get("/x")
+            assert client.stats["requests"] == 1
+            assert client.stats["retries"] == 0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 from unittest.mock import MagicMock, patch, PropertyMock
 
 import pytest
@@ -112,6 +113,70 @@ class TestGet:
             mock_get.side_effect = requests.exceptions.ReadTimeout()
             with pytest.raises(requests.exceptions.ReadTimeout):
                 client._get("/test", max_retries=2)
+
+
+class TestCrossHostRedirectAuth:
+    """A Confluence attachment download 302-redirects to the media CDN, whose signed
+    URL self-authenticates. `requests` must DROP our Atlassian Authorization header on
+    the host change — re-attaching it to the media host is the exact bug that turns
+    working downloads into 403s in other Confluence clients. This pins that behavior
+    for conex's session so a future auth/redirect change can't silently regress it."""
+
+    @staticmethod
+    def _resp(status, request, headers=None):
+        resp = requests.models.Response()
+        resp.status_code = status
+        resp.headers = requests.structures.CaseInsensitiveDict(headers or {})
+        resp.url = request.url
+        resp.request = request
+        resp.raw = io.BytesIO(b"")
+        resp._content = b""
+        resp._content_consumed = True
+        return resp
+
+    def _drive_redirect(self, client, first_url, media_url):
+        """Send a real request through the client's session, with the transport
+        adapter mocked to 302 cross-host then 200, capturing each hop's auth header."""
+        sent: list[tuple[str, str | None]] = []
+
+        def fake_send(_adapter, request, **_kwargs):
+            sent.append((request.url, request.headers.get("Authorization")))
+            if len(sent) == 1:
+                return self._resp(302, request, {"Location": media_url})
+            return self._resp(200, request)
+
+        with patch("requests.adapters.HTTPAdapter.send", new=fake_send):
+            resp = client.session.get(first_url, allow_redirects=True, stream=True)
+        return resp, sent
+
+    def test_basic_auth_header_stripped_on_media_redirect(self):
+        client = _make_client()  # email+token -> HTTPBasicAuth on the session
+        first_url = "https://x.atlassian.net/wiki/rest/api/content/1/child/attachment/2/download"
+        media_url = "https://api.media.atlassian.com/file/abc/binary?token=signed"
+
+        resp, sent = self._drive_redirect(client, first_url, media_url)
+
+        assert resp.status_code == 200
+        assert len(sent) == 2
+        (first_hop_url, first_auth), (media_hop_url, media_auth) = sent
+        # First hop to Atlassian carries our credentials...
+        assert "x.atlassian.net" in first_hop_url and first_auth is not None
+        # ...the cross-host hop to the media CDN must NOT.
+        assert "api.media.atlassian.com" in media_hop_url
+        assert media_auth is None
+
+    def test_bearer_pat_header_stripped_on_media_redirect(self):
+        client = _make_client()
+        # Simulate Bearer-PAT auth (header on the session rather than session.auth).
+        client.session.auth = None
+        client.session.headers["Authorization"] = "Bearer pat-secret"
+        first_url = "https://x.atlassian.net/wiki/rest/api/content/1/child/attachment/2/download"
+        media_url = "https://api.media.atlassian.com/file/abc/binary?token=signed"
+
+        _resp, sent = self._drive_redirect(client, first_url, media_url)
+
+        assert sent[0][1] == "Bearer pat-secret"
+        assert sent[1][1] is None  # stripped on the media host
 
 
 class TestPaginate:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -746,3 +746,17 @@ class TestGetRawRetryAndRateLimit:
             client._get("/x")
             assert client.stats["requests"] == 1
             assert client.stats["retries"] == 0
+
+    def test_non_numeric_retry_after_falls_back(self):
+        # A date-form or junk Retry-After must not crash the retryable 429.
+        client = _make_client()
+        with patch.object(client.session, "get") as mock_get, \
+             patch("confluence_export.client.time.sleep"):
+            bad = MagicMock()
+            bad.status_code = 429
+            bad.headers = {"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"}
+            bad.raise_for_status.side_effect = requests.exceptions.HTTPError(response=bad)
+            ok = self._ok()
+            ok.json.return_value = {"ok": True}
+            mock_get.side_effect = [bad, ok]
+            assert client._get("/x") == {"ok": True}  # retried, did not crash

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -35,6 +35,27 @@ def test_convert_page_basic():
     assert "**world**" in md
 
 
+def test_convert_page_decision_list_renders_as_markdown_list():
+    # #40: an ADF decision list renders as a real markdown bullet list, with decided
+    # items marked, instead of flattening to plain text.
+    page = Page(
+        id="124",
+        title="Decisions",
+        space_id="100",
+        version=Version(created_at="2025-01-01T00:00:00Z", number=1),
+        body_storage=(
+            '<ac:adf-node type="decisionList">'
+            '<ac:adf-node type="decisionItem" state="DECIDED"><p>Ship it</p></ac:adf-node>'
+            '<ac:adf-node type="decisionItem" state="UNDECIDED"><p>Maybe later</p></ac:adf-node>'
+            "</ac:adf-node>"
+        ),
+    )
+    md = convert_page(page, base_url="https://x.atlassian.net", space_key="TEST", path="/Decisions")
+    assert "* ✓ Ship it" in md  # decided item, marked, as a markdown list item
+    assert "* Maybe later" in md  # undecided item, no marker
+    assert "✓ Maybe later" not in md
+
+
 def test_convert_page_frontmatter_has_attachments():
     page = Page(
         id="123",

--- a/tests/test_converter_extra.py
+++ b/tests/test_converter_extra.py
@@ -84,6 +84,7 @@ PREPROCESS_CASES = [
     ("view-file via name param", '<ac:structured-macro ac:name="view-file"><ac:parameter ac:name="name">doc.pdf</ac:parameter></ac:structured-macro>', [".media/doc.pdf"], []),
     ("view-file empty", '<ac:structured-macro ac:name="view-file"></ac:structured-macro>', [], ["ac:structured-macro"]),
     ("drawio not rendered falls back", '<ac:structured-macro ac:name="drawio"><ac:parameter ac:name="diagramName">arch</ac:parameter></ac:structured-macro>', ["Draw.io diagram not rendered: arch.drawio"], ["[drawio:"]),
+    ("drawio-sketch inline -> graceful note not dynamic placeholder (#6)", '<ac:structured-macro ac:name="drawio-sketch"><ac:parameter ac:name="mVer">2</ac:parameter></ac:structured-macro>', ["[Draw.io sketch]"], ["Confluence dynamic content"]),
 
     # Structural macros
     ("toc placeholder", '<ac:structured-macro ac:name="toc"></ac:structured-macro>', ["[Confluence dynamic content: toc]"], ["ac:structured-macro"]),
@@ -358,6 +359,34 @@ def test_drawio_nested_in_panel_still_renders():
     result = _preprocess_html(html, atts, rendered={"arch.drawio": Path(".media/arch.drawio.png")})
     assert 'src=".media/arch.drawio.png"' in result
     assert "[drawio:" not in result
+
+
+def test_drawio_sketch_attachment_backed_renders_png():
+    # #6: an attachment-backed drawio-sketch renders its PNG like a full drawio macro.
+    html = (
+        '<ac:structured-macro ac:name="drawio-sketch">'
+        '<ac:parameter ac:name="mVer">2</ac:parameter>'
+        '<ri:attachment ri:filename="sketch.drawio"/>'
+        "</ac:structured-macro>"
+    )
+    atts = [Attachment(id="a", title="sketch.drawio", media_type="application/x-drawio")]
+    result = _preprocess_html(html, atts, rendered={"sketch.drawio": Path(".media/sketch.drawio.png")})
+    assert 'src=".media/sketch.drawio.png"' in result
+    assert "Confluence dynamic content" not in result
+
+
+def test_drawio_sketch_attachment_backed_not_rendered_falls_back():
+    # #6: attachment-backed sketch with no rendered PNG degrades to the same graceful
+    # "not rendered" note as a drawio diagram, not a dynamic-content placeholder.
+    html = (
+        '<ac:structured-macro ac:name="drawio-sketch">'
+        '<ri:attachment ri:filename="sketch.drawio"/>'
+        "</ac:structured-macro>"
+    )
+    atts = [Attachment(id="a", title="sketch.drawio", media_type="application/x-drawio")]
+    result = _preprocess_html(html, atts)
+    assert "Draw.io diagram not rendered: sketch.drawio" in result
+    assert "Confluence dynamic content" not in result
 
 
 def test_drawio_rendered_lookup_is_case_and_space_insensitive():

--- a/tests/test_converter_extra.py
+++ b/tests/test_converter_extra.py
@@ -117,6 +117,19 @@ PREPROCESS_CASES = [
     # Decision lists
     ("decision item with text", '<ac:adf-node type="decisionItem" state="DECIDED"><p>Decided X</p></ac:adf-node>', ["Decided X"], []),
     ("decision item empty removed", '<ac:adf-node type="decisionItem"></ac:adf-node>', [], []),
+    (
+        "decision list renders as bullet list, decided marked (#40)",
+        '<ac:adf-node type="decisionList">'
+        '<ac:adf-node type="decisionItem" state="DECIDED"><p>Ship it</p></ac:adf-node>'
+        '<ac:adf-node type="decisionItem" state="UNDECIDED"><p>Maybe later</p></ac:adf-node>'
+        "</ac:adf-node>",
+        ["<li>", "✓ Ship it", "Maybe later"], ["ac:adf-node", "✓ Maybe later"],
+    ),
+    (
+        "decision list with only empty items is dropped (#40)",
+        '<ac:adf-node type="decisionList"><ac:adf-node type="decisionItem"></ac:adf-node></ac:adf-node>',
+        [], ["<li>", "ac:adf-node"],
+    ),
 
     # Layout & cleanup
     ("layout tags unwrapped", "<ac:layout><ac:layout-section><ac:layout-cell><p>Inner</p></ac:layout-cell></ac:layout-section></ac:layout>", ["Inner"], ["ac:layout"]),

--- a/tests/test_converter_extra.py
+++ b/tests/test_converter_extra.py
@@ -209,6 +209,20 @@ def test_profile_picture_empty_account_id_dropped():
     assert "Confluence dynamic content" not in result
 
 
+def test_profile_picture_with_plain_text_param_does_not_leak_raw_id():
+    # A profile-picture whose only content is a raw ac:parameter value (no nested
+    # ri:user to resolve) must be dropped, not unwrapped — otherwise the raw
+    # account-id leaks as visible body text.
+    html = (
+        '<p>Author: <ac:structured-macro ac:name="profile-picture">'
+        '<ac:parameter ac:name="user">5f1a-accountid</ac:parameter>'
+        "</ac:structured-macro></p>"
+    )
+    result = _preprocess_html(html, [])
+    assert "5f1a-accountid" not in result
+    assert "Confluence dynamic content" not in result
+
+
 def test_profile_picture_inside_panel_keeps_mention():
     # Regression guard (#5 follow-up): a profile-picture nested in a panel must
     # keep its mention. _convert_panel re-parses the panel body into a fresh soup,

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,42 @@
+"""Tests for the end-of-run warning collector and summary formatting."""
+
+from __future__ import annotations
+
+from confluence_export.diagnostics import WarningCollector, format_warning_summary
+
+
+class TestWarningCollector:
+    def test_records_and_counts_by_category(self):
+        wc = WarningCollector()
+        wc.record("a")
+        wc.record("a")
+        wc.record("b")
+        assert wc.counts() == {"a": 2, "b": 1}
+
+    def test_counts_returns_a_copy(self):
+        wc = WarningCollector()
+        wc.record("a")
+        snapshot = wc.counts()
+        snapshot["a"] = 99
+        assert wc.counts() == {"a": 1}
+
+    def test_total_sums_all_categories(self):
+        wc = WarningCollector()
+        assert wc.total == 0
+        wc.record("a")
+        wc.record("b")
+        wc.record("b")
+        assert wc.total == 3
+
+
+class TestFormatWarningSummary:
+    def test_empty_counts_yields_empty_string(self):
+        assert format_warning_summary({}) == ""
+
+    def test_orders_by_count_descending_then_name(self):
+        summary = format_warning_summary({"rare": 1, "common": 5, "also-1": 1})
+        # Most frequent first; ties broken alphabetically.
+        assert summary == "7 warning(s): common ×5, also-1 ×1, rare ×1"
+
+    def test_single_category(self):
+        assert format_warning_summary({"x": 2}) == "2 warning(s): x ×2"

--- a/tests/test_drawio_extra.py
+++ b/tests/test_drawio_extra.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from confluence_export.diagnostics import WarningCollector
 from confluence_export.drawio import (
+    _is_empty_drawio,
     _usable_png,
     detect_drawio_macros,
     find_drawio_attachments,
@@ -13,6 +15,15 @@ from confluence_export.drawio import (
     render_drawio_to_png,
 )
 from confluence_export.types import Attachment
+
+# A non-empty diagram source (has mxGeometry) so render-failure tests exercise the
+# "produced no output" branch rather than the "empty diagram skipped" wording.
+REAL_DRAWIO = (
+    '<mxGraphModel><root><mxCell id="0"/><mxCell id="1" parent="0"/>'
+    '<mxCell id="2" vertex="1" parent="1">'
+    '<mxGeometry x="40" y="40" width="80" height="40" as="geometry"/>'
+    "</mxCell></root></mxGraphModel>"
+)
 
 
 class TestFindDrawioAttachments:
@@ -229,7 +240,7 @@ class TestRenderDrawioToPng:
 
     def test_failed_initial_render_removes_partial_png(self, tmp_path, capsys):
         drawio = tmp_path / "test.drawio"
-        drawio.write_text("<xml/>")
+        drawio.write_text(REAL_DRAWIO)
         png = tmp_path / "test.drawio.png"
         mock_proc = MagicMock()
         mock_proc.poll.return_value = 1
@@ -301,7 +312,7 @@ class TestRenderDrawioToPng:
 
     def test_render_failure(self, tmp_path, capsys):
         drawio = tmp_path / "test.drawio"
-        drawio.write_text("<xml/>")
+        drawio.write_text(REAL_DRAWIO)
 
         mock_proc = MagicMock()
         mock_proc.poll.return_value = 1  # process exited with error, no file
@@ -375,7 +386,7 @@ class TestRenderDrawioToPng:
     def test_render_timeout_kills_process(self, tmp_path, capsys):
         """drawio truly hangs without producing output — deadline triggers cleanup."""
         drawio = tmp_path / "test.drawio"
-        drawio.write_text("<xml/>")
+        drawio.write_text(REAL_DRAWIO)
 
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None  # never exits
@@ -515,3 +526,59 @@ class TestRenderEdgeCases:
 
         assert result == expected_png
         assert expected_png.read_bytes() == b"PNG data"
+
+
+class TestIsEmptyDrawio:
+    def test_empty_source_is_empty(self, tmp_path):
+        drawio = tmp_path / "test.drawio"
+        drawio.write_text("<xml/>")
+        assert _is_empty_drawio(drawio) is True
+
+    def test_diagram_with_geometry_is_not_empty(self, tmp_path):
+        drawio = tmp_path / "test.drawio"
+        drawio.write_text(REAL_DRAWIO)
+        assert _is_empty_drawio(drawio) is False
+
+    def test_large_source_is_not_empty(self, tmp_path):
+        # A real (even compressed) diagram is larger than the size gate, so the
+        # cheap size check short-circuits before reading the body.
+        drawio = tmp_path / "test.drawio"
+        drawio.write_text("<diagram>" + "x" * 700 + "</diagram>")
+        assert _is_empty_drawio(drawio) is False
+
+    def test_unreadable_source_is_not_empty(self, tmp_path):
+        # stat() raising (e.g. file vanished) must not crash the warning wording.
+        assert _is_empty_drawio(tmp_path / "does-not-exist.drawio") is False
+
+
+class TestRenderWarningCollection:
+    def _no_output_proc(self):
+        proc = MagicMock()
+        proc.poll.return_value = 1  # exited, wrote nothing
+        return proc
+
+    def test_empty_diagram_records_low_severity_category(self, tmp_path, capsys):
+        drawio = tmp_path / "test.drawio"
+        drawio.write_text("<xml/>")
+        warnings = WarningCollector()
+
+        with patch("confluence_export.drawio.find_drawio_cli", return_value="/usr/bin/drawio"), \
+             patch("subprocess.Popen", return_value=self._no_output_proc()):
+            result = render_drawio_to_png(drawio, warnings=warnings)
+
+        assert result is None
+        assert "empty draw.io diagram skipped" in capsys.readouterr().err
+        assert warnings.counts() == {"empty draw.io diagram skipped": 1}
+
+    def test_nonempty_no_output_records_render_warning(self, tmp_path, capsys):
+        drawio = tmp_path / "test.drawio"
+        drawio.write_text(REAL_DRAWIO)
+        warnings = WarningCollector()
+
+        with patch("confluence_export.drawio.find_drawio_cli", return_value="/usr/bin/drawio"), \
+             patch("subprocess.Popen", return_value=self._no_output_proc()):
+            result = render_drawio_to_png(drawio, warnings=warnings)
+
+        assert result is None
+        assert "produced no output" in capsys.readouterr().err
+        assert warnings.counts() == {"draw.io produced no output": 1}

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -171,7 +171,7 @@ class TestConvertFailureIsolated:
             attachments={"bad": [Attachment(id="x", title="img.png", media_type="image/png", file_size=3)]},
         )
 
-        def fake_download(client, attachments, media_dir):
+        def fake_download(client, attachments, media_dir, **_kwargs):
             p = media_dir / "img.png"
             p.write_bytes(b"png")
             return [p]
@@ -195,7 +195,7 @@ class TestConvertFailureIsolated:
         image.write_bytes(b"old-good")
         manifest.write_text('{"img.png": {"version": 1, "id": "x", "title": "img.png"}}')
 
-        def fake_download(client, attachments, media_dir):
+        def fake_download(client, attachments, media_dir, **_kwargs):
             p = media_dir / "img.png"
             p.write_bytes(b"new-partial")
             m = media_dir / _VERSIONS_FILE
@@ -292,7 +292,7 @@ class TestConvertFailureIsolated:
         outside.write_bytes(b"outside")
         (media_dir / "arch.drawio.png").symlink_to(outside)
 
-        def fake_download(_client, _attachments, _media_dir):
+        def fake_download(_client, _attachments, _media_dir, **_kwargs):
             source.write_text("new-source")
             manifest.write_text(json.dumps({
                 "arch.drawio": {"version": 2, "id": "a1", "title": "arch.drawio"}
@@ -329,7 +329,7 @@ class TestConvertFailureIsolated:
             "img.png": {"version": 1, "id": "a1", "title": "img.png"}
         }))
 
-        def fake_download(_client, _attachments, _media_dir):
+        def fake_download(_client, _attachments, _media_dir, **_kwargs):
             image.write_bytes(b"new-image")
             manifest.write_text(json.dumps({
                 "img.png": {"version": 2, "id": "a1", "title": "img.png"}
@@ -367,7 +367,7 @@ class TestConvertFailureIsolated:
         outside = tmp_path / "outside.png"
         outside.write_bytes(b"outside")
 
-        def fake_download(_client, _attachments, media_dir):
+        def fake_download(_client, _attachments, media_dir, **_kwargs):
             image = media_dir / "img.png"
             image.write_bytes(b"new-image")
             image.unlink()
@@ -402,7 +402,7 @@ class TestConvertFailureIsolated:
         outside = tmp_path / "outside.png"
         outside.write_bytes(b"outside")
 
-        def fake_download(_client, _attachments, _media_dir):
+        def fake_download(_client, _attachments, _media_dir, **_kwargs):
             image.unlink()
             image.symlink_to(outside)
             return [image]
@@ -438,7 +438,7 @@ class TestConvertFailureIsolated:
             "img.png": {"version": 1, "id": "a1", "title": "img.png"}
         }))
 
-        def mutate_then_raise(_client, _attachments, _media_dir):
+        def mutate_then_raise(_client, _attachments, _media_dir, **_kwargs):
             image.write_bytes(b"new-image")
             manifest.write_text(json.dumps({
                 "img.png": {"version": 2, "id": "a1", "title": "img.png"}

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -756,7 +756,12 @@ class TestCommitExport:
             protection=_prot(page_exact=[page]),
         )
 
+        # Security invariant (must ALWAYS hold): the protected symlinked .media dir
+        # is never followed to write/restore into its outside target.
         assert not (outside / "img.png").exists()
+        # Healing: the symlink ancestor is unlinked and the file restored as a real
+        # dir. The restore now retries a transient git failure once (#41), so this is
+        # deterministic rather than load-flaky.
         assert not media.is_symlink()
         assert (media / "img.png").read_bytes() == b"PNG"
         ls = subprocess.run(

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -8,9 +8,12 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
+from confluence_export.diagnostics import WarningCollector
 from confluence_export.media import (
     _VERSIONS_FILE,
+    _record_download_warning,
     _save_versions,
     available_attachment_names,
     download_attachments,
@@ -1495,3 +1498,40 @@ class TestPathTraversal:
         for title in ("report.pdf", "My Diagram (v2).png", "data.final.xlsx"):
             download_attachments(client, [_att(title=title, att_id=title)], media_dir)
             assert (media_dir / title).exists(), f"benign name changed: {title}"
+
+
+class TestRecordDownloadWarning:
+    def test_404_reads_as_unavailable_content_not_an_error(self, capsys):
+        wc = WarningCollector()
+        exc = requests.exceptions.HTTPError()
+        exc.response = MagicMock(status_code=404)
+
+        _record_download_warning(_att(title="gone.png"), exc, wc)
+
+        err = capsys.readouterr().err
+        assert "metadata exists but its binary is unavailable (HTTP 404)" in err
+        assert wc.counts() == {"attachment unavailable (HTTP 404)": 1}
+
+    def test_non_404_http_error_is_a_plain_failure(self, capsys):
+        wc = WarningCollector()
+        exc = requests.exceptions.HTTPError()
+        exc.response = MagicMock(status_code=500)
+
+        _record_download_warning(_att(title="boom.png"), exc, wc)
+
+        assert "failed to download" in capsys.readouterr().err
+        assert wc.counts() == {"attachment download failed": 1}
+
+    def test_timeout_is_its_own_category(self, capsys):
+        wc = WarningCollector()
+        _record_download_warning(
+            _att(title="slow.png"), requests.exceptions.ReadTimeout("slow"), wc
+        )
+
+        assert "timed out downloading slow.png" in capsys.readouterr().err
+        assert wc.counts() == {"attachment download timeout": 1}
+
+    def test_collector_is_optional(self, capsys):
+        # The helper still prints when no collector is supplied.
+        _record_download_warning(_att(title="x.png"), ValueError("nope"), None)
+        assert "failed to download x.png" in capsys.readouterr().err

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
+from confluence_export.client import AuthenticationError
 from confluence_export.diagnostics import WarningCollector
 from confluence_export.media import (
     _VERSIONS_FILE,
@@ -1530,6 +1531,24 @@ class TestRecordDownloadWarning:
 
         assert "timed out downloading slow.png" in capsys.readouterr().err
         assert wc.counts() == {"attachment download timeout": 1}
+
+    def test_401_points_at_token_type_not_generic_failure(self, capsys):
+        # A 401/403 lists fine but the binary is rejected — usually a scoped/granular
+        # token. It must NOT fall into the opaque generic bucket.
+        wc = WarningCollector()
+        _record_download_warning(_att(title="secret.png"), AuthenticationError(401, "/d"), wc)
+
+        err = capsys.readouterr().err
+        assert "HTTP 401 downloading 'secret.png'" in err
+        assert "classic (unscoped) API token" in err
+        assert wc.counts() == {"attachment download forbidden (HTTP 401/403)": 1}
+
+    def test_403_uses_the_same_forbidden_category(self, capsys):
+        wc = WarningCollector()
+        _record_download_warning(_att(title="x.png"), AuthenticationError(403, "/d"), wc)
+
+        assert "HTTP 403 downloading 'x.png'" in capsys.readouterr().err
+        assert wc.counts() == {"attachment download forbidden (HTTP 401/403)": 1}
 
     def test_collector_is_optional(self, capsys):
         # The helper still prints when no collector is supplied.


### PR DESCRIPTION
## What this is

Addresses the 4 open GitHub issues (#41, #40, #39, #6), stacked on `fix/harvest-robust-core` (PR #38). One commit per issue, **845 tests pass, 100% coverage** throughout.

## Issues addressed

### #41 — Flaky symlink-safety test (bug) · `1b11378`
`_restore_protected_deletions` silently no-ops if a git subprocess transiently fails under load, leaving a protected file's deletion unrestored and a just-unlinked symlinked ancestor not re-materialized — the rare flake. Retry `ls-files --deleted` / `checkout HEAD` once: `checkout HEAD` is idempotent and the symlink ancestor is already unlinked, so a retry can never write through the symlink to its outside target. The security invariant was always safe; only the heal-this-run was load-flaky. (Couldn't reproduce locally — 0/100 under load — so this is a targeted resilience fix for the most plausible cause.)

### #40 — Render decision lists (enhancement) · `77a2148`
ADF decision lists (`ac:adf-node type="decisionList"`) were flattened to plain text by the generic adf-node unwrap. They now render as a markdown bullet list, with `state="DECIDED"` items marked `✓`, handled **before** the unwrap.

### #39 — Speed up refreshes / reduce API pressure (feature) · `11c95c5`, `98c0c6c`, `f6e3d28`
- **Page-only refresh** for `tree`/`find`/`diff`: skips the per-page attachment listing that dominates refresh cost (a 2,000-page space drops from ~2,008 requests to ~8). A new `attachments_complete` provenance flag (defaults `True` for old caches) plus `ensure_loaded(need_attachments=...)` guarantee **export never treats a page-only cache as authoritative** for attachments. Verbose refresh prints per-phase timing + request/retry/sleep counts.
- **Shared backoff**: attachment downloads (`_get_raw`) now share `_get`'s 429/5xx retry; one 429 on any of the 8 workers sets a shared backoff window (with jitter) the whole pool honors. Retry-After parsing tolerates a date-form/junk header.
- The experimental ideas (global attachment listing, incremental refresh) are intentionally left out — the issue requires them opt-in/guarded and they need real-API validation.

### #6 — drawio-sketch macro (help wanted, **partial**) · `5e89576`
drawio-sketch macros fell through to the generic `[Confluence dynamic content: drawio-sketch]` placeholder. Now: attachment-backed sketches render via the shared `_emit_drawio` path; inline ones degrade to a clean `[Draw.io sketch]` note. The full **inline-payload render** is deferred pending a real drawio-sketch storage sample (the issue's hard blocker — the storage mechanism determines that approach).

## Review

A 4-lens adversarial review (concurrency / symlink-safety / cache-provenance / converter) returned **ship, zero must-fix**. Independently confirmed: no deadlock or data race in the cross-thread rate-limit gate; the #41 retry preserves the unlink-before-checkout ordering (no symlink write-through); export can never consume a page-only cache; decision lists render before the adf-node unwrap. The two real should-fixes it surfaced (Retry-After `ValueError`, missing jitter) are applied in `f6e3d28`.

## Notes for reviewers

- **Stacked on `fix/harvest-robust-core` (#38)** — base is that branch, not `main`; re-target `main` once #38 merges.
- **Still partially open:** #6's inline-render path and #39's experimental global/incremental refresh are deferred (documented in the issue/commits), not abandoned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
