### PR TITLE
Fix all open issues: #44 case-fold prune data loss + #43/#45/#46/#47/#48

### DIFF
--- a/src/confluence_export/cache.py
+++ b/src/confluence_export/cache.py
@@ -177,13 +177,17 @@ class CacheStore:
             for data in results:
                 if not data:
                     continue
+                # `or` coalescing (#47 class): the v2 dialect returns the RAW
+                # folder dict (no builder), so an explicit null must coalesce
+                # HERE — a None title/position crashes the layout planner/tree
+                # sort outside every per-page guard, aborting the whole export.
                 folder_page = Page(
-                    id=str(data.get("id", "")),
-                    title=data.get("title", ""),
-                    space_id=str(data.get("spaceId", "")),
-                    parent_id=str(data.get("parentId", "") or ""),
-                    parent_type=data.get("parentType", ""),
-                    position=data.get("position", 0),
+                    id=str(data.get("id") or ""),
+                    title=data.get("title") or "",
+                    space_id=str(data.get("spaceId") or ""),
+                    parent_id=str(data.get("parentId") or ""),
+                    parent_type=data.get("parentType") or "",
+                    position=data.get("position") or 0,
                     status="folder",
                 )
                 pages.append(folder_page)

--- a/src/confluence_export/client.py
+++ b/src/confluence_export/client.py
@@ -26,6 +26,10 @@ from confluence_export.types import Attachment, Page, Space, Version
 # or buggy header that would otherwise stall a CLI export for hours.
 _RETRY_AFTER_CAP_S = 300.0
 
+# Wait used when the header is absent or junk (unparseable, non-finite,
+# negative). One constant for all three fallback sites so they cannot drift.
+_RETRY_AFTER_DEFAULT_S = 60.0
+
 
 class AuthenticationError(Exception):
     """Raised when the server returns 401 or 403."""
@@ -223,15 +227,17 @@ class ConfluenceClient:
                 # that would escape the (HTTPError, ConnectionError)-only except
                 # and crash a retryable 429; fall back to 60s.
                 try:
-                    retry_after = float(exc.response.headers.get("Retry-After", 60))
+                    retry_after = float(
+                        exc.response.headers.get("Retry-After", _RETRY_AFTER_DEFAULT_S)
+                    )
                 except (TypeError, ValueError):
-                    retry_after = 60.0
+                    retry_after = _RETRY_AFTER_DEFAULT_S
                 # Trust the header only within reason: float() accepts "inf"
                 # (time.sleep(inf) raises OverflowError OUTSIDE the requests-
                 # only except — a raw traceback), and a huge finite value
                 # would stall every worker via the shared window for days.
                 if not math.isfinite(retry_after) or retry_after < 0:
-                    retry_after = 60.0
+                    retry_after = _RETRY_AFTER_DEFAULT_S
                 retry_after = min(retry_after, _RETRY_AFTER_CAP_S)
                 # Extend the shared cross-thread backoff window on EVERY 429,
                 # including the exhausted last attempt: concurrent download/
@@ -317,9 +323,13 @@ class ConfluenceClient:
 
         while True:
             data = self._get(current_path, current_params)
-            all_results.extend(data.get("results", []))
+            # `or` coalescing (#47 class): an explicit-null envelope field
+            # would raise TypeError/AttributeError here — not a
+            # RequestException, so it would escape the CLI's network-error
+            # handler as a raw traceback.
+            all_results.extend(data.get("results") or [])
 
-            next_link = data.get("_links", {}).get("next")
+            next_link = (data.get("_links") or {}).get("next")
             if not next_link:
                 break
 
@@ -338,9 +348,13 @@ class ConfluenceClient:
 
         while True:
             data = self._get(current_path, current_params)
-            all_results.extend(data.get("results", []))
+            # `or` coalescing (#47 class): an explicit-null envelope field
+            # would raise TypeError/AttributeError here — not a
+            # RequestException, so it would escape the CLI's network-error
+            # handler as a raw traceback.
+            all_results.extend(data.get("results") or [])
 
-            next_link = data.get("_links", {}).get("next")
+            next_link = (data.get("_links") or {}).get("next")
             if not next_link:
                 break
 
@@ -430,7 +444,7 @@ class ConfluenceClient:
             author_id=self._account_id(history.get("createdBy")),
             created_at=history.get("createdDate") or "",
             version=self._version_from_v1(data.get("version")),
-            body_storage=storage.get("value", "") if storage else "",
+            body_storage=(storage.get("value") or "") if storage else "",
             webui=links.get("webui") or "",
             editui=links.get("editui") or "",
             tinyui=links.get("tinyui") or "",

--- a/src/confluence_export/client.py
+++ b/src/confluence_export/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import random
 import sys
 import threading
@@ -19,6 +20,11 @@ from confluence_export.config import (
     ConnectionProfile,
 )
 from confluence_export.types import Attachment, Page, Space, Version
+
+# Longest Retry-After a server/proxy can impose on the shared backoff window.
+# Real throttling waits are seconds to minutes; anything longer is a hostile
+# or buggy header that would otherwise stall a CLI export for hours.
+_RETRY_AFTER_CAP_S = 300.0
 
 
 class AuthenticationError(Exception):
@@ -186,7 +192,10 @@ class ConfluenceClient:
                 self.stats["rate_limit_sleep_s"] += wait
 
     def _note_rate_limit(self, retry_after: float) -> None:
-        """Record a 429: extend the shared backoff window and count the retry."""
+        """Record a 429: extend the shared backoff window and count the
+        rate-limited attempt in ``stats["retries"]``. Runs on EVERY 429 —
+        including an exhausted final attempt, where no retry follows but the
+        pool-wide pacing must survive the raise."""
         with self._rate_lock:
             self._rate_limit_until = max(
                 self._rate_limit_until, time.monotonic() + retry_after
@@ -209,23 +218,33 @@ class ConfluenceClient:
             if status in (401, 403):
                 raise AuthenticationError(status, url) from exc
             if status == 429:
+                # Retry-After is normally delta-seconds, but a proxy/gateway can
+                # send an HTTP-date (or junk). Don't let int() raise a ValueError
+                # that would escape the (HTTPError, ConnectionError)-only except
+                # and crash a retryable 429; fall back to 60s.
+                try:
+                    retry_after = float(exc.response.headers.get("Retry-After", 60))
+                except (TypeError, ValueError):
+                    retry_after = 60.0
+                # Trust the header only within reason: float() accepts "inf"
+                # (time.sleep(inf) raises OverflowError OUTSIDE the requests-
+                # only except — a raw traceback), and a huge finite value
+                # would stall every worker via the shared window for days.
+                if not math.isfinite(retry_after) or retry_after < 0:
+                    retry_after = 60.0
+                retry_after = min(retry_after, _RETRY_AFTER_CAP_S)
+                # Extend the shared cross-thread backoff window on EVERY 429,
+                # including the exhausted last attempt: concurrent download/
+                # prefetch workers must still honor the final Retry-After
+                # instead of firing straight into a throttling server.
+                self._note_rate_limit(retry_after)
                 if attempt < max_retries - 1:
-                    # Retry-After is normally delta-seconds, but a proxy/gateway can
-                    # send an HTTP-date (or junk). Don't let int() raise a ValueError
-                    # that would escape the (HTTPError, ConnectionError)-only except
-                    # and crash a retryable 429; fall back to 60s.
-                    try:
-                        retry_after = float(exc.response.headers.get("Retry-After", 60))
-                    except (TypeError, ValueError):
-                        retry_after = 60.0
                     self._log(f"Rate limited, waiting {retry_after}s")
-                    self._note_rate_limit(retry_after)
                     return
-                # Exhausted: surface the typed HTTPError (status 429 + Retry-After)
-                # like the 5xx branch below, so the CLI's RequestException handler
-                # reports it cleanly — the generic RuntimeError fallback isn't a
+                # Exhausted: fall through (429 < 500) to the typed-HTTPError
+                # raise below, so the CLI's RequestException handler reports it
+                # cleanly — the generic RuntimeError fallback isn't a
                 # RequestException and escaped that handler as a traceback (#46).
-                raise exc
             if status >= 500 and attempt < max_retries - 1:
                 self._backoff(attempt)
                 return
@@ -347,11 +366,12 @@ class ConfluenceClient:
     def _version_from_v1(cls, data: dict | None) -> Version:
         if not data:
             return Version()
+        # `or` coalescing (#47 class) — see types.Version.from_api.
         return Version(
-            created_at=data.get("createdAt", "") or data.get("when", ""),
-            message=data.get("message", ""),
-            number=data.get("number", 0),
-            minor_edit=data.get("minorEdit", False),
+            created_at=data.get("createdAt") or data.get("when") or "",
+            message=data.get("message") or "",
+            number=data.get("number") or 0,
+            minor_edit=data.get("minorEdit") or False,
             author_id=cls._account_id(data.get("by")),
         )
 
@@ -372,87 +392,94 @@ class ConfluenceClient:
         return space_id
 
     def _space_from_v1(self, data: dict) -> Space:
-        links = data.get("_links", {})
+        # `or` coalescing everywhere: a v1 record can carry explicit nulls just
+        # like v2 (#47 class) — see types.Space.from_api.
+        links = data.get("_links") or {}
         homepage = data.get("homepage") or {}
         return self._remember_space(
             Space(
-                id=str(data.get("id", "")),
-                key=data.get("key", ""),
-                name=data.get("name", ""),
-                type=data.get("type", ""),
-                status=data.get("status", ""),
-                homepage_id=str(data.get("homepageId", "") or homepage.get("id", "")),
-                webui=links.get("webui", ""),
-                base=links.get("base", ""),
+                id=str(data.get("id") or ""),
+                key=data.get("key") or "",
+                name=data.get("name") or "",
+                type=data.get("type") or "",
+                status=data.get("status") or "",
+                homepage_id=str(data.get("homepageId") or homepage.get("id") or ""),
+                webui=links.get("webui") or "",
+                base=links.get("base") or "",
             )
         )
 
     def _page_from_v1(self, data: dict) -> Page:
-        links = data.get("_links", {})
+        # `or` coalescing everywhere (#47 class) — see types.Page.from_api.
+        links = data.get("_links") or {}
         body = data.get("body", {})
         storage = body.get("storage", {}) if body else {}
         space = data.get("space") or {}
         history = data.get("history") or {}
         ancestors = data.get("ancestors") or []
-        parent = ancestors[-1] if ancestors else {}
+        parent = (ancestors[-1] if ancestors else {}) or {}
         extensions = data.get("extensions") or {}
         return Page(
-            id=str(data.get("id", "")),
-            title=data.get("title", ""),
-            space_id=str(space.get("id", "")),
-            parent_id=str(parent.get("id", "") or ""),
-            parent_type=parent.get("type", ""),
-            position=extensions.get("position", 0) or 0,
-            status=data.get("status", ""),
+            id=str(data.get("id") or ""),
+            title=data.get("title") or "",
+            space_id=str(space.get("id") or ""),
+            parent_id=str(parent.get("id") or ""),
+            parent_type=parent.get("type") or "",
+            position=extensions.get("position") or 0,
+            status=data.get("status") or "",
             author_id=self._account_id(history.get("createdBy")),
-            created_at=history.get("createdDate", ""),
+            created_at=history.get("createdDate") or "",
             version=self._version_from_v1(data.get("version")),
             body_storage=storage.get("value", "") if storage else "",
-            webui=links.get("webui", ""),
-            editui=links.get("editui", ""),
-            tinyui=links.get("tinyui", ""),
+            webui=links.get("webui") or "",
+            editui=links.get("editui") or "",
+            tinyui=links.get("tinyui") or "",
         )
 
     def _folder_from_v1(self, data: dict) -> dict:
         ancestors = data.get("ancestors") or []
-        parent = ancestors[-1] if ancestors else {}
+        parent = (ancestors[-1] if ancestors else {}) or {}
         space = data.get("space") or {}
         extensions = data.get("extensions") or {}
         return {
-            "id": str(data.get("id", "")),
-            "title": data.get("title", ""),
-            "spaceId": str(space.get("id", "")),
-            "parentId": str(parent.get("id", "") or ""),
-            "parentType": parent.get("type", ""),
-            "position": extensions.get("position", 0) or 0,
+            "id": str(data.get("id") or ""),
+            "title": data.get("title") or "",
+            "spaceId": str(space.get("id") or ""),
+            "parentId": str(parent.get("id") or ""),
+            "parentType": parent.get("type") or "",
+            "position": extensions.get("position") or 0,
             "status": "folder",
         }
 
     def _attachment_from_v1(self, data: dict, page_id: str) -> Attachment:
-        links = data.get("_links", {})
+        # `or` coalescing: a v1 record can carry explicit nulls just like v2;
+        # None here crashes .casefold()/.get() consumers (#47 class).
+        links = data.get("_links") or {}
         metadata = data.get("metadata") or {}
         extensions = data.get("extensions") or {}
         history = data.get("history") or {}
         version = self._version_from_v1(data.get("version"))
         return Attachment(
-            id=str(data.get("id", "")),
-            title=data.get("title", ""),
+            id=str(data.get("id") or ""),
+            title=data.get("title") or "",
             media_type=(
-                data.get("mediaType", "")
-                or metadata.get("mediaType", "")
-                or extensions.get("mediaType", "")
+                data.get("mediaType")
+                or metadata.get("mediaType")
+                or extensions.get("mediaType")
+                or ""
             ),
             media_type_description=(
-                data.get("mediaTypeDescription", "")
-                or metadata.get("mediaTypeDescription", "")
+                data.get("mediaTypeDescription")
+                or metadata.get("mediaTypeDescription")
+                or ""
             ),
-            file_size=data.get("fileSize", 0) or extensions.get("fileSize", 0) or 0,
+            file_size=data.get("fileSize") or extensions.get("fileSize") or 0,
             page_id=page_id,
-            comment=data.get("comment", ""),
-            created_at=history.get("createdDate", "") or version.created_at,
+            comment=data.get("comment") or "",
+            created_at=history.get("createdDate") or version.created_at,
             version=version,
-            download_link=links.get("download", "") or data.get("downloadLink", ""),
-            webui=links.get("webui", ""),
+            download_link=links.get("download") or data.get("downloadLink") or "",
+            webui=links.get("webui") or "",
         )
 
     # -- API methods ---------------------------------------------------------

--- a/src/confluence_export/client.py
+++ b/src/confluence_export/client.py
@@ -209,17 +209,23 @@ class ConfluenceClient:
             if status in (401, 403):
                 raise AuthenticationError(status, url) from exc
             if status == 429:
-                # Retry-After is normally delta-seconds, but a proxy/gateway can send
-                # an HTTP-date (or junk). Don't let int() raise a ValueError that would
-                # escape the (HTTPError, ConnectionError)-only except and crash a
-                # retryable 429; fall back to 60s.
-                try:
-                    retry_after = float(exc.response.headers.get("Retry-After", 60))
-                except (TypeError, ValueError):
-                    retry_after = 60.0
-                self._log(f"Rate limited, waiting {retry_after}s")
-                self._note_rate_limit(retry_after)
-                return
+                if attempt < max_retries - 1:
+                    # Retry-After is normally delta-seconds, but a proxy/gateway can
+                    # send an HTTP-date (or junk). Don't let int() raise a ValueError
+                    # that would escape the (HTTPError, ConnectionError)-only except
+                    # and crash a retryable 429; fall back to 60s.
+                    try:
+                        retry_after = float(exc.response.headers.get("Retry-After", 60))
+                    except (TypeError, ValueError):
+                        retry_after = 60.0
+                    self._log(f"Rate limited, waiting {retry_after}s")
+                    self._note_rate_limit(retry_after)
+                    return
+                # Exhausted: surface the typed HTTPError (status 429 + Retry-After)
+                # like the 5xx branch below, so the CLI's RequestException handler
+                # reports it cleanly — the generic RuntimeError fallback isn't a
+                # RequestException and escaped that handler as a traceback (#46).
+                raise exc
             if status >= 500 and attempt < max_retries - 1:
                 self._backoff(attempt)
                 return

--- a/src/confluence_export/converter.py
+++ b/src/confluence_export/converter.py
@@ -260,6 +260,18 @@ def _preprocess_html(
     def _is_nestable_list(t: Tag) -> bool:
         return t.name == "ac:task-list" or _is_decision_list(t)
 
+    def _top_level_uls(scope: Tag) -> list[Tag]:
+        """The rendered ``<ul>``s ``scope`` owns DIRECTLY. find_all is
+        recursive, so on a 3+-level list it also returns the grandchild
+        ``<ul>``s — extracting those too would yank them OUT of the mid-level
+        ``<ul>`` and re-attach them one level too high (items survive, the
+        hierarchy flattens). Keep only ``<ul>``s whose nearest enclosing
+        ``<ul>`` is not also inside ``scope``. Identity, not ``==``: bs4 Tag
+        equality is structural and two rendered sublists can be identical."""
+        found = scope.find_all("ul")
+        ids = {id(u) for u in found}
+        return [u for u in found if id(u.find_parent("ul")) not in ids]
+
     list_nodes = list(soup.find_all(_is_nestable_list))
     for node in sorted(list_nodes, key=lambda n: len(list(n.parents)), reverse=True):
         ul = soup.new_tag("ul")
@@ -273,7 +285,8 @@ def _preprocess_html(
                 # Rendered nested lists inside this item are <ul>s by now;
                 # lift them out so their text isn't flattened into this item's
                 # text, then re-attach them under the item's <li> as a sublist.
-                nested_uls = [u.extract() for u in item.find_all("ul")]
+                # Top-level only: deeper <ul>s ride along inside their parent.
+                nested_uls = [u.extract() for u in _top_level_uls(item)]
                 text = item.get_text().strip()
                 if text:
                     decided = (item.get("state", "") or "").strip().upper() == "DECIDED"
@@ -295,7 +308,7 @@ def _preprocess_html(
                     continue  # pragma: no cover - defensive
                 status = task.find("ac:task-status")
                 body = task.find("ac:task-body")
-                nested_uls = [u.extract() for u in task.find_all("ul")]
+                nested_uls = [u.extract() for u in _top_level_uls(task)]
                 is_done = status and status.get_text().strip() == "complete"
                 checkbox = "[x] " if is_done else "[ ] "
                 li = soup.new_tag("li")
@@ -305,8 +318,9 @@ def _preprocess_html(
                 ul.append(li)
         # A rendered nested list that was NOT inside any of this list's items
         # (e.g. a list as a direct child of a list) would be discarded by
-        # replace_with below; splice its items in instead.
-        for stray in list(node.find_all("ul")):
+        # replace_with below; splice its items in instead. Top-level only —
+        # a deeper <ul> already lives inside a spliced <li>.
+        for stray in _top_level_uls(node):
             stray.extract()
             for li_child in list(stray.children):
                 ul.append(li_child)

--- a/src/confluence_export/converter.py
+++ b/src/confluence_export/converter.py
@@ -510,10 +510,12 @@ def _replace_ac_link(
 
 def _convert_panel(soup: BeautifulSoup, macro: Tag, macro_name: str) -> None:
     """Convert info/tip/note/warning/panel to blockquotes."""
-    title_param = macro.find("ac:parameter", attrs={"ac:name": "title"})
+    # Direct children only (#45): a recursive lookup on an untitled panel reached
+    # into a nested macro and stole its title (wrong header + duplicated text).
+    title_param = macro.find("ac:parameter", attrs={"ac:name": "title"}, recursive=False)
     title = title_param.get_text().strip() if title_param else macro_name.capitalize()
 
-    body = macro.find("ac:rich-text-body")
+    body = macro.find("ac:rich-text-body", recursive=False)
 
     blockquote = soup.new_tag("blockquote")
     strong = soup.new_tag("strong")
@@ -573,10 +575,12 @@ def _convert_status(soup: BeautifulSoup, macro: Tag) -> None:
 
 def _convert_expand(soup: BeautifulSoup, macro: Tag) -> None:
     """Convert expand macro to a details/summary block (rendered as heading + content)."""
-    title_param = macro.find("ac:parameter", attrs={"ac:name": "title"})
+    # Direct children only (#45): see _convert_panel — an untitled expand must not
+    # steal a nested macro's title or body.
+    title_param = macro.find("ac:parameter", attrs={"ac:name": "title"}, recursive=False)
     title = title_param.get_text().strip() if title_param else "Details"
 
-    body = macro.find("ac:rich-text-body")
+    body = macro.find("ac:rich-text-body", recursive=False)
 
     # Heading + content. Move the LIVE body children (not a re-parsed copy) so a
     # macro nested in the expand body — e.g. a drawio diagram — stays attached and

--- a/src/confluence_export/converter.py
+++ b/src/confluence_export/converter.py
@@ -211,47 +211,10 @@ def _preprocess_html(
     for tag_name in ("ac:adf-fallback", "ac:adf-attribute", "ac:adf-mark"):
         for tag in list(soup.find_all(tag_name)):
             tag.decompose()
-    # Decision lists (ADF) must be rendered BEFORE the generic adf-node unwrap
-    # below, which would otherwise flatten them to plain text and drop both the
-    # list structure and the decided/undecided state (issue #40). A decisionItem's
-    # state lives in a ``state`` node attribute ("DECIDED"); its text is in child
-    # nodes. Render each list as a bullet list; mark decided items with a ✓.
-    def _is_decision_list(t: Tag) -> bool:
-        return t.name == "ac:adf-node" and t.get("type") in ("decisionList", "decision-list")
-
-    def _is_decision_item(t: Tag) -> bool:
-        return t.name == "ac:adf-node" and t.get("type") in ("decisionItem", "decision-item")
-
-    for dlist in list(soup.find_all(_is_decision_list)):
-        ul = soup.new_tag("ul")
-        for item in dlist.find_all(_is_decision_item):
-            # Items of a nested decisionList (not real ADF — item content is
-            # inline-only — but harden anyway, #43) belong to that inner list;
-            # emitting them here too would duplicate them.
-            if item.find_parent(_is_decision_list) is not dlist:
-                continue
-            text = item.get_text().strip()
-            if not text:
-                continue
-            decided = (item.get("state", "") or "").strip().upper() == "DECIDED"
-            li = soup.new_tag("li")
-            li.string = ("✓ " if decided else "") + text
-            ul.append(li)
-        if ul.find("li"):
-            dlist.replace_with(ul)
-        else:
-            dlist.decompose()
-    # Unwrap adf-content, adf-extension, adf-node so their inner HTML is preserved
-    for tag_name in ("ac:adf-content", "ac:adf-extension", "ac:adf-node"):
-        for tag in list(soup.find_all(tag_name)):
-            tag.unwrap()
-
-    # --- Layout tags ---
-    for tag_name in ("ac:layout", "ac:layout-section", "ac:layout-cell"):
-        for tag in list(soup.find_all(tag_name)):
-            tag.unwrap()
 
     # --- Emoticons ---
+    # BEFORE the list pass below: decision items and task bodies render via
+    # get_text(), so an unreplaced <ac:emoticon> inside one would vanish.
     for tag in list(soup.find_all("ac:emoticon")):
         name = tag.get("ac:name", "")
         # Prefer our Unicode map; the ac:emoji-fallback is usually a shortcode
@@ -266,7 +229,7 @@ def _preprocess_html(
         else:
             tag.decompose()
 
-    # --- Time/date tags ---
+    # --- Time/date tags --- (before the list pass, same reason as emoticons)
     for tag in list(soup.find_all("time")):
         dt = tag.get("datetime", "")
         if dt:
@@ -274,20 +237,97 @@ def _preprocess_html(
         else:
             tag.decompose()
 
-    # --- Task lists ---
-    for task_list in list(soup.find_all("ac:task-list")):
-        ul = soup.new_tag("ul")
-        for task in list(task_list.find_all("ac:task")):
-            status = task.find("ac:task-status")
-            body = task.find("ac:task-body")
-            is_done = status and status.get_text().strip() == "complete"
-            checkbox = "[x] " if is_done else "[ ] "
-            li = soup.new_tag("li")
-            li.string = checkbox + (body.get_text().strip() if body else "")
-            ul.append(li)
-        task_list.replace_with(ul)
+    # Decision lists (ADF) must be rendered BEFORE the generic adf-node unwrap
+    # below, which would otherwise flatten them to plain text and drop both the
+    # list structure and the decided/undecided state (issue #40). A decisionItem's
+    # state lives in a ``state`` node attribute ("DECIDED"); its text is in child
+    # nodes. Render each list as a bullet list; mark decided items with a ✓.
+    def _is_decision_list(t: Tag) -> bool:
+        return t.name == "ac:adf-node" and t.get("type") in ("decisionList", "decision-list")
 
-    # (Decision lists are handled above, before the adf-node unwrap.)
+    def _is_decision_item(t: Tag) -> bool:
+        return t.name == "ac:adf-node" and t.get("type") in ("decisionItem", "decision-item")
+
+    # Render decision lists AND task lists in ONE pass, INNERMOST-FIRST. The
+    # two node types nest into each other (a Tab-indented ac:task-list inside
+    # a decisionItem, a decisionList inside an ac:task-body), so separate
+    # passes flatten whichever type renders second — the status word fused
+    # into the outer item's prose ("OutercompleteInner") was the symptom.
+    # Innermost-first also fixes the single-type case (#43): a nested list is
+    # already a <ul> by the time its enclosing list is built, so its items
+    # can neither duplicate into the outer item's text nor be lost when the
+    # outer node is replaced while the inner one is still pending.
+    def _is_nestable_list(t: Tag) -> bool:
+        return t.name == "ac:task-list" or _is_decision_list(t)
+
+    list_nodes = list(soup.find_all(_is_nestable_list))
+    for node in sorted(list_nodes, key=lambda n: len(list(n.parents)), reverse=True):
+        ul = soup.new_tag("ul")
+        if _is_decision_list(node):
+            for item in node.find_all(_is_decision_item):
+                # Defensive: with innermost-first rendering no deeper list
+                # survives here, but an item routed to the wrong list must
+                # never be emitted twice (#43).
+                if item.find_parent(_is_decision_list) is not node:
+                    continue  # pragma: no cover - defensive
+                # Rendered nested lists inside this item are <ul>s by now;
+                # lift them out so their text isn't flattened into this item's
+                # text, then re-attach them under the item's <li> as a sublist.
+                nested_uls = [u.extract() for u in item.find_all("ul")]
+                text = item.get_text().strip()
+                if text:
+                    decided = (item.get("state", "") or "").strip().upper() == "DECIDED"
+                    li = soup.new_tag("li")
+                    li.string = ("✓ " if decided else "") + text
+                    for u in nested_uls:
+                        li.append(u)
+                    ul.append(li)
+                else:
+                    # No own text: keep any nested items rather than dropping them.
+                    for u in nested_uls:
+                        for li_child in list(u.children):
+                            ul.append(li_child)
+        else:  # ac:task-list
+            for task in list(node.find_all("ac:task")):
+                # Defensive: innermost-first rendering already consumed any
+                # deeper list's tasks.
+                if task.find_parent("ac:task-list") is not node:
+                    continue  # pragma: no cover - defensive
+                status = task.find("ac:task-status")
+                body = task.find("ac:task-body")
+                nested_uls = [u.extract() for u in task.find_all("ul")]
+                is_done = status and status.get_text().strip() == "complete"
+                checkbox = "[x] " if is_done else "[ ] "
+                li = soup.new_tag("li")
+                li.string = checkbox + (body.get_text().strip() if body else "")
+                for u in nested_uls:
+                    li.append(u)
+                ul.append(li)
+        # A rendered nested list that was NOT inside any of this list's items
+        # (e.g. a list as a direct child of a list) would be discarded by
+        # replace_with below; splice its items in instead.
+        for stray in list(node.find_all("ul")):
+            stray.extract()
+            for li_child in list(stray.children):
+                ul.append(li_child)
+        # Task lists always render (an all-unchecked empty list is meaningful);
+        # an empty decision list is dropped (#40).
+        if node.name == "ac:task-list" or ul.find("li"):
+            node.replace_with(ul)
+        else:
+            node.decompose()
+    # Unwrap adf-content, adf-extension, adf-node so their inner HTML is preserved
+    for tag_name in ("ac:adf-content", "ac:adf-extension", "ac:adf-node"):
+        for tag in list(soup.find_all(tag_name)):
+            tag.unwrap()
+
+    # --- Layout tags ---
+    for tag_name in ("ac:layout", "ac:layout-section", "ac:layout-cell"):
+        for tag in list(soup.find_all(tag_name)):
+            tag.unwrap()
+
+    # (Emoticons, time tags, decision lists, and task lists are handled
+    # together above, before the adf-node unwrap.)
 
     # --- User mentions (ri:user inside ac:link or standalone) ---
     for user_tag in list(soup.find_all("ri:user")):
@@ -384,9 +424,10 @@ def _preprocess_html(
         elif macro_name == "view-file":
             _convert_view_file(soup, macro, name_plan, available_media)
         elif macro_name in ("excerpt", "section", "column"):
-            # Pure layout/wrapper — keep body, drop wrapper, no placeholder
-            body = macro.find("ac:rich-text-body")
-            if body:
+            # Pure layout/wrapper — keep body, drop wrapper, no placeholder.
+            # Own bodies only (#45): a recursive find would unwrap a NESTED
+            # macro's body tag here, breaking that macro's own conversion.
+            for body in _macro_own_bodies(macro):
                 body.unwrap()
             macro.unwrap()
         else:
@@ -395,9 +436,18 @@ def _preprocess_html(
             # include, future Confluence additions) — emit a visible
             # placeholder so the reader knows something was there instead
             # of silently dropping it.
-            body = macro.find("ac:rich-text-body")
-            if body and body.get_text(strip=True):
-                macro.replace_with(*list(body.children))
+            bodies = _macro_own_bodies(macro)
+            if bodies and any(b.get_text(strip=True) for b in bodies):
+                macro.replace_with(*[el for b in bodies for el in list(b.children)])
+            elif macro.find("ac:structured-macro") is not None:
+                # No own body, but the macro WRAPS real macros (the #45 steal
+                # shape): keep the children live so the dispatch still
+                # converts them, instead of replacing the whole subtree with
+                # a placeholder. Drop own parameters so they can't leak as
+                # plain text.
+                for p in macro.find_all("ac:parameter", recursive=False):
+                    p.decompose()
+                macro.unwrap()
             else:
                 _convert_dynamic_macro_placeholder(soup, macro, macro_name)
 
@@ -513,14 +563,52 @@ def _replace_ac_link(
     tag.decompose()
 
 
+def _macro_own_bodies(macro: Tag) -> list[Tag]:
+    """ALL ``ac:rich-text-body`` nodes OWNED by this macro: direct children in
+    well-formed storage. On malformed storage (e.g. an unclosed
+    ``ac:parameter`` that swallowed the body) fall back to deeper descendants —
+    but only those whose nearest enclosing macro is THIS macro, so a nested
+    macro's body is never stolen (#45) while the mis-nested bodies' content is
+    still preserved instead of being silently discarded by replace_with."""
+    bodies = macro.find_all("ac:rich-text-body", recursive=False)
+    if bodies:
+        return bodies
+    return [
+        b
+        for b in macro.find_all("ac:rich-text-body")
+        if b.find_parent("ac:structured-macro") is macro
+    ]
+
+
+def _own_title_and_body_children(macro: Tag, default_title: str) -> tuple[str, list]:
+    """Resolve a bodied macro's own title and DETACH its body content as live
+    nodes, for _convert_panel/_convert_expand.
+
+    Title: a DIRECT-child ``ac:parameter`` only (#45 — an untitled macro must
+    never steal a nested macro's title). Body: every body ``_macro_own_bodies``
+    owns. A macro with NO own body at all treats its remaining non-parameter
+    children as the body, so a nested macro is moved LIVE — staying in the
+    structured-macro dispatch snapshot and converted in place — instead of
+    being destroyed by the caller's replace_with. Children are detached BEFORE
+    the title text is read so a body swallowed by an unclosed title parameter
+    cannot duplicate into the title."""
+    title_param = macro.find("ac:parameter", attrs={"ac:name": "title"}, recursive=False)
+    bodies = _macro_own_bodies(macro)
+    if bodies:
+        children = [el.extract() for b in bodies for el in list(b.children)]
+    else:
+        children = [
+            el.extract()
+            for el in list(macro.children)
+            if not (isinstance(el, Tag) and el.name == "ac:parameter")
+        ]
+    title = title_param.get_text().strip() if title_param else ""
+    return (title or default_title), children
+
+
 def _convert_panel(soup: BeautifulSoup, macro: Tag, macro_name: str) -> None:
     """Convert info/tip/note/warning/panel to blockquotes."""
-    # Direct children only (#45): a recursive lookup on an untitled panel reached
-    # into a nested macro and stole its title (wrong header + duplicated text).
-    title_param = macro.find("ac:parameter", attrs={"ac:name": "title"}, recursive=False)
-    title = title_param.get_text().strip() if title_param else macro_name.capitalize()
-
-    body = macro.find("ac:rich-text-body", recursive=False)
+    title, body_children = _own_title_and_body_children(macro, macro_name.capitalize())
 
     blockquote = soup.new_tag("blockquote")
     strong = soup.new_tag("strong")
@@ -535,9 +623,8 @@ def _convert_panel(soup: BeautifulSoup, macro: Tag, macro_name: str) -> None:
     # diagram inside a panel was silently dropped (never converted). Moving the
     # live nodes keeps them attached and still in the snapshot, so the dispatch
     # converts them in place.
-    if body:
-        for element in list(body.children):
-            blockquote.append(element)
+    for element in body_children:
+        blockquote.append(element)
 
     macro.replace_with(blockquote)
 
@@ -580,12 +667,7 @@ def _convert_status(soup: BeautifulSoup, macro: Tag) -> None:
 
 def _convert_expand(soup: BeautifulSoup, macro: Tag) -> None:
     """Convert expand macro to a details/summary block (rendered as heading + content)."""
-    # Direct children only (#45): see _convert_panel — an untitled expand must not
-    # steal a nested macro's title or body.
-    title_param = macro.find("ac:parameter", attrs={"ac:name": "title"}, recursive=False)
-    title = title_param.get_text().strip() if title_param else "Details"
-
-    body = macro.find("ac:rich-text-body", recursive=False)
+    title, body_children = _own_title_and_body_children(macro, "Details")
 
     # Heading + content. Move the LIVE body children (not a re-parsed copy) so a
     # macro nested in the expand body — e.g. a drawio diagram — stays attached and
@@ -597,9 +679,8 @@ def _convert_expand(soup: BeautifulSoup, macro: Tag) -> None:
     h4.string = title
     container.append(h4)
 
-    if body:
-        for element in list(body.children):
-            container.append(element)
+    for element in body_children:
+        container.append(element)
 
     macro.replace_with(*list(container.children))
 

--- a/src/confluence_export/converter.py
+++ b/src/confluence_export/converter.py
@@ -216,15 +216,20 @@ def _preprocess_html(
     # list structure and the decided/undecided state (issue #40). A decisionItem's
     # state lives in a ``state`` node attribute ("DECIDED"); its text is in child
     # nodes. Render each list as a bullet list; mark decided items with a ✓.
-    for dlist in list(soup.find_all(
-        lambda t: t.name == "ac:adf-node"
-        and t.get("type") in ("decisionList", "decision-list")
-    )):
+    def _is_decision_list(t: Tag) -> bool:
+        return t.name == "ac:adf-node" and t.get("type") in ("decisionList", "decision-list")
+
+    def _is_decision_item(t: Tag) -> bool:
+        return t.name == "ac:adf-node" and t.get("type") in ("decisionItem", "decision-item")
+
+    for dlist in list(soup.find_all(_is_decision_list)):
         ul = soup.new_tag("ul")
-        for item in dlist.find_all(
-            lambda t: t.name == "ac:adf-node"
-            and t.get("type") in ("decisionItem", "decision-item")
-        ):
+        for item in dlist.find_all(_is_decision_item):
+            # Items of a nested decisionList (not real ADF — item content is
+            # inline-only — but harden anyway, #43) belong to that inner list;
+            # emitting them here too would duplicate them.
+            if item.find_parent(_is_decision_list) is not dlist:
+                continue
             text = item.get_text().strip()
             if not text:
                 continue

--- a/src/confluence_export/drawio.py
+++ b/src/confluence_export/drawio.py
@@ -12,6 +12,7 @@ import time
 from pathlib import Path
 
 from confluence_export.diagnostics import WarningCollector
+from confluence_export.media import DRAWIO_TMP_PREFIX
 from confluence_export.filemode import default_file_mode, replacement_mode
 from confluence_export.types import Attachment
 
@@ -135,7 +136,7 @@ def render_drawio_to_png(
     )
     fd, tmp_name = tempfile.mkstemp(
         dir=output_path.parent,
-        prefix=".drawio-",
+        prefix=DRAWIO_TMP_PREFIX,
         suffix=".png",
     )
     os.close(fd)

--- a/src/confluence_export/exporter.py
+++ b/src/confluence_export/exporter.py
@@ -41,6 +41,7 @@ from confluence_export.media import (
     download_attachments,
     ensure_media_dir,
     materialize_existing_attachments,
+    sweep_stale_media_temps,
 )
 from confluence_export.tree import (
     build_tree,
@@ -639,6 +640,9 @@ class Exporter:
         try:
             if self.download_media and attachments:
                 media_dir = ensure_media_dir(page_dir)
+                # Sweep BEFORE the first snapshot_file: this run's own
+                # .rollback- snapshots live in media_dir too (#48).
+                sweep_stale_media_temps(media_dir)
                 snapshot_file(media_dir / _VERSIONS_FILE)
                 for name in current_attachment_names:
                     snapshot_file(resolve_within(media_dir, name))
@@ -655,6 +659,7 @@ class Exporter:
                             f"refusing to use symlinked media directory: {existing_media_dir}"
                         )
                     media_dir = existing_media_dir
+                    sweep_stale_media_temps(media_dir)
                     snapshot_file(media_dir / _VERSIONS_FILE)
                     snapshot_manifest_owned_files(media_dir)
                     for name in current_attachment_names:

--- a/src/confluence_export/exporter.py
+++ b/src/confluence_export/exporter.py
@@ -592,6 +592,13 @@ class Exporter:
                 except OSError:  # pragma: no cover
                     pass
                 raise
+            # copy2 stamps the SOURCE file's (arbitrarily old) mtime onto the
+            # snapshot, which the #48 sweep's age gate would misread as a
+            # crashed run's litter — a concurrent run could sweep this LIVE
+            # snapshot mid-transaction. Reset to now; nothing consumes the
+            # snapshot's own mtime (worst case a rollback-restored .drawio
+            # source triggers one spurious re-render).
+            os.utime(tmp)
             media_file_snapshots[tracked] = tmp
 
         def cleanup_media_snapshots() -> None:

--- a/src/confluence_export/exporter.py
+++ b/src/confluence_export/exporter.py
@@ -37,6 +37,7 @@ from confluence_export.media import (
     _VERSIONS_FILE,
     _load_versions,
     _resolve_manifest_entry,
+    ROLLBACK_TMP_PREFIX,
     available_attachment_names,
     download_attachments,
     ensure_media_dir,
@@ -578,7 +579,7 @@ class Exporter:
                 return
             fd, tmp_name = tempfile.mkstemp(
                 dir=path.parent,
-                prefix=".rollback-",
+                prefix=ROLLBACK_TMP_PREFIX,
                 suffix=".tmp",
             )
             os.close(fd)
@@ -637,12 +638,17 @@ class Exporter:
         available_media: set[str] = set()
         current_attachment_names = {name_plan.for_attachment(att) for att in attachments}
         reserved_media_names = set(current_attachment_names)
+        existing_media_dir = page_dir / MEDIA_DIR_NAME
         try:
+            # Sweep BEFORE the first snapshot_file (this run's own .rollback-
+            # snapshots live in media_dir too) and regardless of whether the
+            # page still HAS attachments — a hard-killed run's temps must not
+            # survive forever just because the attachments were since deleted
+            # upstream (#48). A fresh dir created below has nothing to sweep.
+            if existing_media_dir.is_dir() and not existing_media_dir.is_symlink():
+                sweep_stale_media_temps(existing_media_dir)
             if self.download_media and attachments:
                 media_dir = ensure_media_dir(page_dir)
-                # Sweep BEFORE the first snapshot_file: this run's own
-                # .rollback- snapshots live in media_dir too (#48).
-                sweep_stale_media_temps(media_dir)
                 snapshot_file(media_dir / _VERSIONS_FILE)
                 for name in current_attachment_names:
                     snapshot_file(resolve_within(media_dir, name))
@@ -652,21 +658,18 @@ class Exporter:
                     )
                 )
             elif not self.download_media and attachments:
-                existing_media_dir = page_dir / MEDIA_DIR_NAME
                 if existing_media_dir.is_dir():
                     if existing_media_dir.is_symlink():
                         raise ValueError(
                             f"refusing to use symlinked media directory: {existing_media_dir}"
                         )
                     media_dir = existing_media_dir
-                    sweep_stale_media_temps(media_dir)
                     snapshot_file(media_dir / _VERSIONS_FILE)
                     snapshot_manifest_owned_files(media_dir)
                     for name in current_attachment_names:
                         snapshot_file(resolve_within(media_dir, name))
                     written.extend(materialize_existing_attachments(attachments, media_dir))
             elif not self.download_media and not attachments:
-                existing_media_dir = page_dir / MEDIA_DIR_NAME
                 if existing_media_dir.is_dir():
                     if existing_media_dir.is_symlink():
                         raise ValueError(

--- a/src/confluence_export/git.py
+++ b/src/confluence_export/git.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import os
 import shutil
 import subprocess
@@ -193,7 +194,7 @@ def commit_export(
         # protection matchers AND the staleness key, so a protected dir whose
         # committed path differs only in case/Unicode form from this run's planned
         # name is matched rather than pruned (#44). Probe the FS once here.
-        fold = nfc_casefold if _fs_is_case_insensitive(output_dir) else nfc
+        fold = _fold_for(output_dir)
         page_dirs, sub_dirs = build_protected(output_dir, protection, fold)
         # DATA-SAFETY DECISION 1: prune ONLY when this run actually wrote live
         # pages. A full export that wrote nothing has no authority to reconcile
@@ -240,7 +241,10 @@ def _fs_is_case_insensitive(output_dir: Path) -> bool:
 
     The probe is a uniquely-named temp file created with O_EXCL (via mkstemp), so
     it can never clobber or be spoofed by a real user file: it tests whether an
-    upper-cased variant of *that unique name* resolves to the same file."""
+    upper-cased variant of *that unique name* resolves to the same file.
+
+    Use ``_fold_for`` rather than calling this directly when choosing the
+    case/Unicode fold — that keeps the fold POLICY in one place (#44)."""
     try:
         fd, probe_name = tempfile.mkstemp(dir=output_dir, prefix=".conex-case-")
     except OSError:
@@ -255,6 +259,20 @@ def _fs_is_case_insensitive(output_dir: Path) -> bool:
             probe.unlink()
         except OSError:
             pass
+
+
+def _fold_for(output_dir: Path) -> Callable[[str], str]:
+    """The ONE case/Unicode fold policy for ``output_dir``'s filesystem:
+    NFC+casefold when it folds case, plain NFC otherwise. commit_export probes
+    once and threads the result to build_protected, the prune, and the restore;
+    the prune/restore ``fold=None`` fallbacks (direct callers, tests) call this
+    too, so the policy cannot drift between sites (#44)."""
+    return nfc_casefold if _fs_is_case_insensitive(output_dir) else nfc
+
+
+def _fold_path(fold: Callable[[str], str], p: Path) -> Path:
+    """Fold a path into the shared (#44) comparison space."""
+    return Path(fold(str(p)))
 
 
 def _remove_stale_files(
@@ -297,14 +315,17 @@ def _remove_stale_files(
     # this staleness key agree under case/Unicode drift (#44); fall back to probing
     # the FS for direct callers (tests).
     if fold is None:
-        fold = nfc_casefold if _fs_is_case_insensitive(output_dir) else nfc
+        fold = _fold_for(output_dir)
+    _fp = functools.partial(_fold_path, fold)
 
-    def _fp(p: Path) -> Path:
-        """Fold a path into the shared comparison space (same fold as the matchers)."""
-        return Path(fold(str(p)))
+    result = _run_git(output_dir, "ls-files", "-z", ".", check=False)
+    if result is None or not result.stdout.strip("\0"):
+        return
 
     # The media-keep predicate compares owner dirs against these sets, so fold them
     # too — otherwise a re-cased owner dir misses its own written/preserved entry.
+    # All three are only consulted under preserve_media, so don't build them
+    # otherwise.
     written_page_dirs = (
         frozenset(_fp(p) for p in page_dirs_from_written_files(output_dir, written_files))
         if preserve_media else frozenset()
@@ -313,11 +334,10 @@ def _remove_stale_files(
         frozenset(_fp(p) for p in media_owner_dirs_from_written_files(output_dir, written_files))
         if preserve_media else frozenset()
     )
-    prune_media_owners = frozenset(_fp(p) for p in prune_media_owners)
-
-    result = _run_git(output_dir, "ls-files", "-z", ".", check=False)
-    if result is None or not result.stdout.strip("\0"):
-        return
+    prune_media_owners = (
+        frozenset(_fp(p) for p in prune_media_owners)
+        if preserve_media else frozenset()
+    )
 
     written_keys = {fold(str(f.resolve())) for f in written_files}
 
@@ -353,13 +373,14 @@ def _remove_stale_files(
         # the restore — see protection.ProtectedDir (pair-argument is load-bearing).
         # Fold each form into the matchers' (folded) comparison space, per form so
         # the symlink-safe resolved/lexical dual is preserved (#44).
-        full_f = _fp(full)
+        full_key = fold(str(full))
+        full_f = Path(full_key)
         full_lexical_f = _fp(full_lexical)
         if any(d.owns_exactly(full_f, full_lexical_f) for d in page_dirs):
             continue
         if any(d.contains_subtree(full_f, full_lexical_f) for d in sub_dirs):
             continue
-        if fold(str(full)) not in written_keys:
+        if full_key not in written_keys:
             stale.append(rel_path)
 
     if stale:
@@ -411,10 +432,8 @@ def _restore_protected_deletions(
     # drift under case/Unicode (#44 / RF-B). commit_export passes it; fall back to
     # probing for direct callers.
     if fold is None:
-        fold = nfc_casefold if _fs_is_case_insensitive(output_dir) else nfc
-
-    def _fp(p: Path) -> Path:
-        return Path(fold(str(p)))
+        fold = _fold_for(output_dir)
+    _fp = functools.partial(_fold_path, fold)
 
     result = _run_git(output_dir, "ls-files", "--deleted", "-z", check=False)
     if result is None:  # pragma: no cover - transient git failure under load

--- a/src/confluence_export/git.py
+++ b/src/confluence_export/git.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -189,7 +189,12 @@ def commit_export(
     if is_full:
         # Compile the typed protections ONCE into dual-form matchers shared by the
         # prune and the restore so they cannot drift (protection.build_protected).
-        page_dirs, sub_dirs = build_protected(output_dir, protection)
+        # One fold (case-insensitive FS → NFC+casefold, else NFC) is shared by the
+        # protection matchers AND the staleness key, so a protected dir whose
+        # committed path differs only in case/Unicode form from this run's planned
+        # name is matched rather than pruned (#44). Probe the FS once here.
+        fold = nfc_casefold if _fs_is_case_insensitive(output_dir) else nfc
+        page_dirs, sub_dirs = build_protected(output_dir, protection, fold)
         # DATA-SAFETY DECISION 1: prune ONLY when this run actually wrote live
         # pages. A full export that wrote nothing has no authority to reconcile
         # deletions — a transient/auth-failed empty response, or a v2 space that
@@ -203,6 +208,7 @@ def commit_export(
                 page_dirs=page_dirs, sub_dirs=sub_dirs,
                 prune_media_owners=protection.prune_media_owners,
                 preserve_media=preserve_media,
+                fold=fold,
             )
         # Restore any tracked file reconcile deleted from disk under a protected
         # dir, so the worktree matches the copy we kept in HEAD and the next run's
@@ -210,7 +216,7 @@ def commit_export(
         # it only re-adds protected files, never deletes — so it runs even on a
         # write-less run (e.g. all pages skipped this run).
         _restore_protected_deletions(
-            output_dir, page_dirs=page_dirs, sub_dirs=sub_dirs,
+            output_dir, page_dirs=page_dirs, sub_dirs=sub_dirs, fold=fold,
         )
 
     # Check if anything was staged
@@ -259,6 +265,7 @@ def _remove_stale_files(
     sub_dirs: list[ProtectedDir] | None = None,
     prune_media_owners: frozenset[Path] = frozenset(),
     preserve_media: bool = False,
+    fold: Callable[[str], str] | None = None,
 ) -> None:
     """Remove tracked files that are no longer part of the export.
 
@@ -274,19 +281,6 @@ def _remove_stale_files(
 
     page_dirs = page_dirs or []
     sub_dirs = sub_dirs or []
-    written_page_dirs = (
-        page_dirs_from_written_files(output_dir, written_files)
-        if preserve_media else frozenset()
-    )
-    written_media_dirs = (
-        media_owner_dirs_from_written_files(output_dir, written_files)
-        if preserve_media else frozenset()
-    )
-
-    result = _run_git(output_dir, "ls-files", "-z", ".", check=False)
-    if result is None or not result.stdout.strip("\0"):
-        return
-
     # Normalize the comparison key on two axes that git itself folds but
     # Path.resolve() does not:
     #   - Unicode form: a macOS attachment title can arrive NFD (decomposed); git
@@ -298,8 +292,33 @@ def _remove_stale_files(
     #     differ only in case (a re-cased title, or legacy content from another
     #     machine); git folds those to one path, so we must too, or the same file
     #     is both git-added (new case) and flagged stale (old case).
-    # One shared fold definition with layout's collision keys (Q6).
-    fold = nfc_casefold if _fs_is_case_insensitive(output_dir) else nfc
+    # One shared fold definition with layout's collision keys (Q6). commit_export
+    # passes the same fold it gave build_protected, so the protection matchers and
+    # this staleness key agree under case/Unicode drift (#44); fall back to probing
+    # the FS for direct callers (tests).
+    if fold is None:
+        fold = nfc_casefold if _fs_is_case_insensitive(output_dir) else nfc
+
+    def _fp(p: Path) -> Path:
+        """Fold a path into the shared comparison space (same fold as the matchers)."""
+        return Path(fold(str(p)))
+
+    # The media-keep predicate compares owner dirs against these sets, so fold them
+    # too — otherwise a re-cased owner dir misses its own written/preserved entry.
+    written_page_dirs = (
+        frozenset(_fp(p) for p in page_dirs_from_written_files(output_dir, written_files))
+        if preserve_media else frozenset()
+    )
+    written_media_dirs = (
+        frozenset(_fp(p) for p in media_owner_dirs_from_written_files(output_dir, written_files))
+        if preserve_media else frozenset()
+    )
+    prune_media_owners = frozenset(_fp(p) for p in prune_media_owners)
+
+    result = _run_git(output_dir, "ls-files", "-z", ".", check=False)
+    if result is None or not result.stdout.strip("\0"):
+        return
+
     written_keys = {fold(str(f.resolve())) for f in written_files}
 
     stale = []
@@ -318,7 +337,7 @@ def _remove_stale_files(
         if preserve_media and MEDIA_DIR_NAME in parts and (output_dir / rel_path).is_file():
             owner = _media_owner_dir(output_dir, rel_path)
             if owner is not None and media_file_is_preserved(
-                owner,
+                _fp(owner),
                 written_page_dirs=written_page_dirs,
                 written_media_dirs=written_media_dirs,
                 prune_media_owners=prune_media_owners,
@@ -332,9 +351,13 @@ def _remove_stale_files(
         full = full_lexical.resolve()
         # Dual-form (resolved OR lexical) match, one matcher object, shared with
         # the restore — see protection.ProtectedDir (pair-argument is load-bearing).
-        if any(d.owns_exactly(full, full_lexical) for d in page_dirs):
+        # Fold each form into the matchers' (folded) comparison space, per form so
+        # the symlink-safe resolved/lexical dual is preserved (#44).
+        full_f = _fp(full)
+        full_lexical_f = _fp(full_lexical)
+        if any(d.owns_exactly(full_f, full_lexical_f) for d in page_dirs):
             continue
-        if any(d.contains_subtree(full, full_lexical) for d in sub_dirs):
+        if any(d.contains_subtree(full_f, full_lexical_f) for d in sub_dirs):
             continue
         if fold(str(full)) not in written_keys:
             stale.append(rel_path)
@@ -366,6 +389,7 @@ def _restore_protected_deletions(
     *,
     page_dirs: list[ProtectedDir],
     sub_dirs: list[ProtectedDir],
+    fold: Callable[[str], str] | None = None,
 ) -> None:
     """Restore tracked-but-deleted files under a protected dir from HEAD.
 
@@ -383,6 +407,15 @@ def _restore_protected_deletions(
     drift — the original RF-B failure class."""
     if not page_dirs and not sub_dirs:
         return
+    # Must use the SAME fold the prune/build_protected used, or restore and prune
+    # drift under case/Unicode (#44 / RF-B). commit_export passes it; fall back to
+    # probing for direct callers.
+    if fold is None:
+        fold = nfc_casefold if _fs_is_case_insensitive(output_dir) else nfc
+
+    def _fp(p: Path) -> Path:
+        return Path(fold(str(p)))
+
     result = _run_git(output_dir, "ls-files", "--deleted", "-z", check=False)
     if result is None:  # pragma: no cover - transient git failure under load
         # Retry once: a transient git failure here would silently skip the heal,
@@ -400,9 +433,11 @@ def _restore_protected_deletions(
             continue
         full_lexical = (output_dir / rel_path).absolute()
         full = full_lexical.resolve()
+        full_f = _fp(full)
+        full_lexical_f = _fp(full_lexical)
         if (
-            any(d.owns_exactly(full, full_lexical) for d in page_dirs)
-            or any(d.contains_subtree(full, full_lexical) for d in sub_dirs)
+            any(d.owns_exactly(full_f, full_lexical_f) for d in page_dirs)
+            or any(d.contains_subtree(full_f, full_lexical_f) for d in sub_dirs)
         ):
             ancestor = _symlink_ancestor(output_dir, rel_path)
             if ancestor is not None:

--- a/src/confluence_export/media.py
+++ b/src/confluence_export/media.py
@@ -93,8 +93,11 @@ DRAWIO_TMP_PREFIX = ".drawio-"  # drawio.py render temps land in the media dir
 # behind; they are never staged or pruned (commit_export stages explicit paths,
 # the stale-prune walks tracked files only), so the worst case is untracked
 # litter the user notices. safe_attachment_name rejects leading-dot titles, so
-# no real attachment can ever carry one of these names — and the live
-# ".versions.json" matches none of the patterns.
+# no NEW attachment can be allocated one of these names — and the live
+# ".versions.json" matches none of the patterns. But LEGACY (pre-sanitizer)
+# exports wrote raw titles to disk and _resolve_manifest_entry deliberately
+# keeps honoring those names, so the sweep must spare anything the manifest
+# still resolves (see sweep_stale_media_temps).
 _TEMP_ARTIFACT_PATTERNS = (
     f"{DOWNLOAD_TMP_PREFIX}*.tmp",
     f"{COPY_TMP_PREFIX}*.tmp",
@@ -119,15 +122,34 @@ def sweep_stale_media_temps(media_dir: Path) -> None:
     ``media_dir`` (#48). MUST run before the current run creates its own temps
     and rollback snapshots there. Only entries older than
     ``_TEMP_ARTIFACT_MIN_AGE_S`` are removed — a younger match may belong to a
-    concurrently running export (see the constant's comment)."""
+    concurrently running export (see the constant's comment) — and never a
+    name the version manifest still resolves (a legacy-named REAL attachment,
+    see the patterns' comment)."""
     now = time.time()
+    manifest_names = {nfc_casefold(n) for n in _load_versions(media_dir)}
     for pattern in _TEMP_ARTIFACT_PATTERNS:
         for stale in media_dir.glob(pattern):
             try:
+                # Folded compare: a legacy manifest key's case/Unicode form
+                # can differ from the on-disk name. Sparing too much keeps
+                # litter; deleting too much destroys a committed attachment.
+                if nfc_casefold(stale.name) in manifest_names:
+                    continue
                 if now - stale.lstat().st_mtime < _TEMP_ARTIFACT_MIN_AGE_S:
                     continue
                 if stale.is_dir() and not stale.is_symlink():
                     shutil.rmtree(stale, ignore_errors=True)
+                elif (
+                    stale.name.startswith(PRESERVE_TMP_PREFIX)
+                    and not stale.is_symlink()
+                ):
+                    # .preserve-* snapshots are always DIRECTORIES
+                    # (TemporaryDirectory); a regular file matching the one
+                    # suffix-less pattern can only be a legacy-named real
+                    # attachment — never ours to delete. (A symlink is still
+                    # unlinked: conex never creates those here either, and
+                    # unlinking cannot destroy the target's content.)
+                    continue
                 else:
                     stale.unlink()
             except OSError:

--- a/src/confluence_export/media.py
+++ b/src/confluence_export/media.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import sys
 import tempfile
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
@@ -77,30 +78,54 @@ def migrate_media_dirs(root_dir: Path) -> list[tuple[Path, Path]]:
     return renamed
 
 
-# Dot-prefixed temp artifacts of the atomic-write/rollback machinery. A hard
-# kill (SIGKILL / power loss) between create and cleanup can leave them behind;
-# they are never staged or pruned (commit_export stages explicit paths, the
-# stale-prune walks tracked files only), so the worst case is untracked litter
-# the user notices. safe_attachment_name rejects leading-dot titles, so no real
-# attachment can ever carry one of these names — and the live ".versions.json"
-# matches none of the patterns.
+# Prefixes of the dot-prefixed temp artifacts of the atomic-write/rollback
+# machinery. The mkstemp/TemporaryDirectory creation sites and the sweep
+# patterns below derive from the SAME constants, so renaming a prefix (or
+# adding a new temp kind) cannot silently regress the sweep (#48).
+DOWNLOAD_TMP_PREFIX = ".download-"
+COPY_TMP_PREFIX = ".copy-"
+VERSIONS_TMP_PREFIX = ".versions-"
+ROLLBACK_TMP_PREFIX = ".rollback-"  # exporter.py snapshot_file
+PRESERVE_TMP_PREFIX = ".preserve-"
+DRAWIO_TMP_PREFIX = ".drawio-"  # drawio.py render temps land in the media dir
+
+# A hard kill (SIGKILL / power loss) between create and cleanup can leave these
+# behind; they are never staged or pruned (commit_export stages explicit paths,
+# the stale-prune walks tracked files only), so the worst case is untracked
+# litter the user notices. safe_attachment_name rejects leading-dot titles, so
+# no real attachment can ever carry one of these names — and the live
+# ".versions.json" matches none of the patterns.
 _TEMP_ARTIFACT_PATTERNS = (
-    ".download-*.tmp",
-    ".copy-*.tmp",
-    ".versions-*.tmp",
-    ".rollback-*.tmp",
-    ".preserve-*",
+    f"{DOWNLOAD_TMP_PREFIX}*.tmp",
+    f"{COPY_TMP_PREFIX}*.tmp",
+    f"{VERSIONS_TMP_PREFIX}*.tmp",
+    f"{ROLLBACK_TMP_PREFIX}*.tmp",
+    f"{PRESERVE_TMP_PREFIX}*",
+    f"{DRAWIO_TMP_PREFIX}*.png",
 )
+
+# A matching artifact YOUNGER than this is treated as another live run's
+# in-flight transaction file, not a crashed run's litter. Nothing enforces
+# single-process exclusivity on an output tree (no lockfile), so without the
+# age gate an overlapping export would sweep its peer's live .rollback-/
+# .download- temps — turning best-effort cleanup into a cross-process
+# data-loss race. Litter from a crash is still swept by any run starting at
+# least this much later.
+_TEMP_ARTIFACT_MIN_AGE_S = 3600.0
 
 
 def sweep_stale_media_temps(media_dir: Path) -> None:
     """Best-effort removal of temp artifacts a hard-killed earlier run left in
     ``media_dir`` (#48). MUST run before the current run creates its own temps
-    and rollback snapshots there — anything matching at that point is stale by
-    definition; afterwards it would delete the live transaction's files."""
+    and rollback snapshots there. Only entries older than
+    ``_TEMP_ARTIFACT_MIN_AGE_S`` are removed — a younger match may belong to a
+    concurrently running export (see the constant's comment)."""
+    now = time.time()
     for pattern in _TEMP_ARTIFACT_PATTERNS:
         for stale in media_dir.glob(pattern):
             try:
+                if now - stale.lstat().st_mtime < _TEMP_ARTIFACT_MIN_AGE_S:
+                    continue
                 if stale.is_dir() and not stale.is_symlink():
                     shutil.rmtree(stale, ignore_errors=True)
                 else:
@@ -126,7 +151,7 @@ def _save_versions(media_dir: Path, versions: dict) -> None:
     """Save the version manifest to a media directory."""
     target = media_dir / _VERSIONS_FILE
     mode = replacement_mode(target)
-    fd, tmp_name = tempfile.mkstemp(dir=media_dir, prefix=".versions-", suffix=".tmp")
+    fd, tmp_name = tempfile.mkstemp(dir=media_dir, prefix=VERSIONS_TMP_PREFIX, suffix=".tmp")
     tmp = Path(tmp_name)
     try:
         with os.fdopen(fd, "w") as f:
@@ -303,7 +328,7 @@ def _unmanifested_file_can_preserve(
 
 
 def _copy_media_file(src: Path, dest: Path) -> None:
-    fd, tmp_name = tempfile.mkstemp(dir=dest.parent, prefix=".copy-", suffix=".tmp")
+    fd, tmp_name = tempfile.mkstemp(dir=dest.parent, prefix=COPY_TMP_PREFIX, suffix=".tmp")
     os.close(fd)
     tmp = Path(tmp_name)
     try:
@@ -379,7 +404,7 @@ def _snapshot_previous_owned_files(
                 continue
             old_name, old_path, old_record = found
             if tmp_dir is None:
-                tmp_dir = tempfile.TemporaryDirectory(dir=media_dir, prefix=".preserve-")
+                tmp_dir = tempfile.TemporaryDirectory(dir=media_dir, prefix=PRESERVE_TMP_PREFIX)
             snapshot_path = Path(tmp_dir.name) / f"{index}"
             shutil.copy2(old_path, snapshot_path)
             snapshots[id(att)] = (old_name, snapshot_path, old_record, old_path)
@@ -598,7 +623,7 @@ def download_attachments(
             mode = replacement_mode(dest, default_mode=download_default_mode)
             fd, tmp_name = tempfile.mkstemp(
                 dir=dest.parent,
-                prefix=".download-",
+                prefix=DOWNLOAD_TMP_PREFIX,
                 suffix=".tmp",
             )
             os.close(fd)

--- a/src/confluence_export/media.py
+++ b/src/confluence_export/media.py
@@ -77,6 +77,38 @@ def migrate_media_dirs(root_dir: Path) -> list[tuple[Path, Path]]:
     return renamed
 
 
+# Dot-prefixed temp artifacts of the atomic-write/rollback machinery. A hard
+# kill (SIGKILL / power loss) between create and cleanup can leave them behind;
+# they are never staged or pruned (commit_export stages explicit paths, the
+# stale-prune walks tracked files only), so the worst case is untracked litter
+# the user notices. safe_attachment_name rejects leading-dot titles, so no real
+# attachment can ever carry one of these names — and the live ".versions.json"
+# matches none of the patterns.
+_TEMP_ARTIFACT_PATTERNS = (
+    ".download-*.tmp",
+    ".copy-*.tmp",
+    ".versions-*.tmp",
+    ".rollback-*.tmp",
+    ".preserve-*",
+)
+
+
+def sweep_stale_media_temps(media_dir: Path) -> None:
+    """Best-effort removal of temp artifacts a hard-killed earlier run left in
+    ``media_dir`` (#48). MUST run before the current run creates its own temps
+    and rollback snapshots there — anything matching at that point is stale by
+    definition; afterwards it would delete the live transaction's files."""
+    for pattern in _TEMP_ARTIFACT_PATTERNS:
+        for stale in media_dir.glob(pattern):
+            try:
+                if stale.is_dir() and not stale.is_symlink():
+                    shutil.rmtree(stale, ignore_errors=True)
+                else:
+                    stale.unlink()
+            except OSError:
+                continue
+
+
 def _load_versions(media_dir: Path) -> dict:
     """Load the version manifest from a media directory."""
     p = media_dir / _VERSIONS_FILE
@@ -339,17 +371,24 @@ def _snapshot_previous_owned_files(
 ) -> tuple[dict[int, tuple[str, Path, object, Path]], tempfile.TemporaryDirectory | None]:
     snapshots: dict[int, tuple[str, Path, object, Path]] = {}
     tmp_dir: tempfile.TemporaryDirectory | None = None
-    for index, att in enumerate(attachments):
-        name = name_plan.for_attachment(att)
-        found = _find_previous_owned_file(versions, media_dir, name, att, collision_bases)
-        if found is None:
-            continue
-        old_name, old_path, old_record = found
-        if tmp_dir is None:
-            tmp_dir = tempfile.TemporaryDirectory(dir=media_dir, prefix=".preserve-")
-        snapshot_path = Path(tmp_dir.name) / f"{index}"
-        shutil.copy2(old_path, snapshot_path)
-        snapshots[id(att)] = (old_name, snapshot_path, old_record, old_path)
+    try:
+        for index, att in enumerate(attachments):
+            name = name_plan.for_attachment(att)
+            found = _find_previous_owned_file(versions, media_dir, name, att, collision_bases)
+            if found is None:
+                continue
+            old_name, old_path, old_record = found
+            if tmp_dir is None:
+                tmp_dir = tempfile.TemporaryDirectory(dir=media_dir, prefix=".preserve-")
+            snapshot_path = Path(tmp_dir.name) / f"{index}"
+            shutil.copy2(old_path, snapshot_path)
+            snapshots[id(att)] = (old_name, snapshot_path, old_record, old_path)
+    except Exception:
+        # A raise here happens before the caller binds tmp_dir to its
+        # try/finally, which would leave the .preserve- dir behind until GC (#48).
+        if tmp_dir is not None:
+            tmp_dir.cleanup()
+        raise
     return snapshots, tmp_dir
 
 

--- a/src/confluence_export/protection.py
+++ b/src/confluence_export/protection.py
@@ -231,9 +231,11 @@ def media_file_is_preserved(
     not force-pruned; OR the owner is page-exact protected; OR the owner lives under
     a recursively-protected subtree.
 
-    RESOLVED-ONLY by construction: ``owner`` is already a resolved path and the old
-    inline check (``owner in protected`` / ``is_relative_to`` over the resolved
-    subtree set) had no lexical variant, so this queries ``d.resolved`` only — never
+    RESOLVED-ONLY by construction: ``owner`` is a resolved path FOLDED into the
+    shared comparison space (the caller applies the same fold the matchers and
+    written/preserved sets were built with, #44), and the old inline check
+    (``owner in protected`` / ``is_relative_to`` over the resolved subtree set)
+    had no lexical variant, so this queries ``d.resolved`` only — never
     ``d.lexical`` — preserving that asymmetry exactly."""
     keep_by_write = (
         owner in written_page_dirs

--- a/src/confluence_export/protection.py
+++ b/src/confluence_export/protection.py
@@ -27,6 +27,7 @@ This module welds each decision into exactly one shape:
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -164,18 +165,40 @@ class ProtectedDir:
 
 
 def build_protected(
-    output_dir: Path, protection: ProtectionSet
+    output_dir: Path,
+    protection: ProtectionSet,
+    fold: Callable[[str], str] | None = None,
 ) -> tuple[list[ProtectedDir], list[ProtectedDir]]:
     """Compile a ``ProtectionSet`` into ``(page_exact_dirs, subtree_dirs)`` of
     ``ProtectedDir``, each carrying both path forms with ``output_dir`` self-
     excluded per-form. Built ONCE and shared by ``_remove_stale_files`` and
-    ``_restore_protected_deletions`` so the two can never drift."""
-    out_resolved = output_dir.resolve()
-    out_absolute = output_dir.absolute()
+    ``_restore_protected_deletions`` so the two can never drift.
+
+    Each stored path form is run through ``fold`` — the SAME case/NFC fold the
+    prune applies to its staleness key — so a protected dir whose on-disk case or
+    Unicode form differs from this run's planned name still matches. Without it, a
+    case-only title change on a case-insensitive filesystem makes the protected
+    page compare unequal to its committed (other-case) path and the prune deletes
+    it (#44). ``fold`` is applied PER FORM, so the resolved/lexical dual remains two
+    independent symlink-safe values (never unioned).
+
+    CONTRACT: this is half of a "compiled once, shared, cannot drift" pair — the
+    matchers it returns are queried by ``_remove_stale_files`` /
+    ``_restore_protected_deletions``, which MUST fold the queried file forms with
+    the SAME function or matching silently drifts and a protected dir is pruned
+    (#44). Production (``commit_export``) probes the FS once and threads one fold to
+    all three, so they always agree. ``fold`` defaults to identity (a no-op) — NOT
+    the prune's fold (that is ``nfc`` on a case-sensitive FS, which still folds
+    NFD→NFC, and ``nfc_casefold`` on a case-insensitive one). The identity default
+    is for unit tests over fold-invariant/ASCII inputs only; any direct caller that
+    pairs this with a consumer MUST pass that consumer's exact fold."""
+    f = fold or (lambda s: s)
+    out_resolved = Path(f(str(output_dir.resolve())))
+    out_absolute = Path(f(str(output_dir.absolute())))
 
     def compile_dir(p: Path) -> ProtectedDir:
-        resolved = p.resolve()
-        lexical = p.absolute()
+        resolved = Path(f(str(p.resolve())))
+        lexical = Path(f(str(p.absolute())))
         return ProtectedDir(
             resolved=(resolved if resolved != out_resolved else None),
             lexical=(lexical if lexical != out_absolute else None),

--- a/src/confluence_export/types.py
+++ b/src/confluence_export/types.py
@@ -18,16 +18,20 @@ class Space:
 
     @classmethod
     def from_api(cls, data: dict) -> Space:
-        links = data.get("_links", {})
+        # `or` coalescing on EVERY field: the API/cache can carry an explicit
+        # null anywhere (a dict-key default only applies when the key is
+        # ABSENT); a None crashes string/path consumers and round-trips
+        # through to_dict into the cache (#47 class).
+        links = data.get("_links") or {}
         return cls(
-            id=str(data.get("id", "")),
-            key=data.get("key", ""),
-            name=data.get("name", ""),
-            type=data.get("type", ""),
-            status=data.get("status", ""),
-            homepage_id=str(data.get("homepageId", "")),
-            webui=links.get("webui", ""),
-            base=links.get("base", ""),
+            id=str(data.get("id") or ""),
+            key=data.get("key") or "",
+            name=data.get("name") or "",
+            type=data.get("type") or "",
+            status=data.get("status") or "",
+            homepage_id=str(data.get("homepageId") or ""),
+            webui=links.get("webui") or "",
+            base=links.get("base") or "",
         )
 
 
@@ -43,12 +47,14 @@ class Version:
     def from_api(cls, data: dict | None) -> Version:
         if not data:
             return cls()
+        # `or` coalescing: explicit nulls crash consumers (`number > 0` in the
+        # media phase) and round-trip through the cache (#47 class).
         return cls(
-            created_at=data.get("createdAt", ""),
-            message=data.get("message", ""),
-            number=data.get("number", 0),
-            minor_edit=data.get("minorEdit", False),
-            author_id=data.get("authorId", ""),
+            created_at=data.get("createdAt") or "",
+            message=data.get("message") or "",
+            number=data.get("number") or 0,
+            minor_edit=data.get("minorEdit") or False,
+            author_id=data.get("authorId") or "",
         )
 
 
@@ -71,24 +77,28 @@ class Page:
 
     @classmethod
     def from_api(cls, data: dict) -> Page:
-        links = data.get("_links", {})
+        # `or` coalescing on EVERY field (#47 class): an explicit null title
+        # aborts the whole space export in the layout planner (sanitize on
+        # None) and to_dict round-trips the None into the cache, so every
+        # --cached run crashes too until a refresh.
+        links = data.get("_links") or {}
         body = data.get("body", {})
         storage = body.get("storage", {}) if body else {}
         return cls(
-            id=str(data.get("id", "")),
-            title=data.get("title", ""),
-            space_id=str(data.get("spaceId", "")),
-            parent_id=str(data.get("parentId", "") or ""),
-            parent_type=data.get("parentType", ""),
-            position=data.get("position", 0),
-            status=data.get("status", ""),
-            author_id=data.get("authorId", ""),
-            created_at=data.get("createdAt", ""),
+            id=str(data.get("id") or ""),
+            title=data.get("title") or "",
+            space_id=str(data.get("spaceId") or ""),
+            parent_id=str(data.get("parentId") or ""),
+            parent_type=data.get("parentType") or "",
+            position=data.get("position") or 0,
+            status=data.get("status") or "",
+            author_id=data.get("authorId") or "",
+            created_at=data.get("createdAt") or "",
             version=Version.from_api(data.get("version")),
             body_storage=storage.get("value", "") if storage else "",
-            webui=links.get("webui", ""),
-            editui=links.get("editui", ""),
-            tinyui=links.get("tinyui", ""),
+            webui=links.get("webui") or "",
+            editui=links.get("editui") or "",
+            tinyui=links.get("tinyui") or "",
         )
 
     def to_dict(self) -> dict:
@@ -141,21 +151,24 @@ class Attachment:
 
     @classmethod
     def from_api(cls, data: dict) -> Attachment:
-        links = data.get("_links", {})
+        # `or` coalescing on EVERY field: the API/cache can carry an explicit
+        # null (the key default only applies when absent); None crashes
+        # .casefold() consumers (#47), and `str(None)` is the TRUTHY string
+        # "None" — a null pageId would defeat the `if att.page_id` guard and
+        # build a bogus /content/None/ download URL.
+        links = data.get("_links") or {}
         return cls(
-            id=str(data.get("id", "")),
-            # `or ""`: the API/cache can carry an explicit null (the key default
-            # only applies when absent); None crashes .casefold() consumers (#47).
+            id=str(data.get("id") or ""),
             title=data.get("title") or "",
             media_type=data.get("mediaType") or "",
             media_type_description=data.get("mediaTypeDescription") or "",
-            file_size=data.get("fileSize", 0),
-            page_id=str(data.get("pageId", "")),
-            comment=data.get("comment", ""),
-            created_at=data.get("createdAt", ""),
+            file_size=data.get("fileSize") or 0,
+            page_id=str(data.get("pageId") or ""),
+            comment=data.get("comment") or "",
+            created_at=data.get("createdAt") or "",
             version=Version.from_api(data.get("version")),
-            download_link=links.get("download", "") or data.get("downloadLink", ""),
-            webui=links.get("webui", ""),
+            download_link=links.get("download") or data.get("downloadLink") or "",
+            webui=links.get("webui") or "",
         )
 
     def to_dict(self) -> dict:

--- a/src/confluence_export/types.py
+++ b/src/confluence_export/types.py
@@ -144,9 +144,11 @@ class Attachment:
         links = data.get("_links", {})
         return cls(
             id=str(data.get("id", "")),
-            title=data.get("title", ""),
-            media_type=data.get("mediaType", ""),
-            media_type_description=data.get("mediaTypeDescription", ""),
+            # `or ""`: the API/cache can carry an explicit null (the key default
+            # only applies when absent); None crashes .casefold() consumers (#47).
+            title=data.get("title") or "",
+            media_type=data.get("mediaType") or "",
+            media_type_description=data.get("mediaTypeDescription") or "",
             file_size=data.get("fileSize", 0),
             page_id=str(data.get("pageId", "")),
             comment=data.get("comment", ""),

--- a/src/confluence_export/types.py
+++ b/src/confluence_export/types.py
@@ -95,7 +95,7 @@ class Page:
             author_id=data.get("authorId") or "",
             created_at=data.get("createdAt") or "",
             version=Version.from_api(data.get("version")),
-            body_storage=storage.get("value", "") if storage else "",
+            body_storage=(storage.get("value") or "") if storage else "",
             webui=links.get("webui") or "",
             editui=links.get("editui") or "",
             tinyui=links.get("tinyui") or "",

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1085,3 +1085,25 @@ class TestNetworkErrorHandling:
         err = capsys.readouterr().err
         assert "network request to Confluence failed" in err
         assert "re-run to retry" in err.lower()
+
+    def test_persistent_429_exits_cleanly(self, capsys):
+        # #46: an exhausted 429 now raises the typed HTTPError (a
+        # RequestException), so it lands in the same clean-exit handler instead
+        # of escaping as a RuntimeError traceback.
+        resp = MagicMock()
+        resp.status_code = 429
+        client = _mock_client()
+        cache = MagicMock()
+        cache.refresh.side_effect = requests.exceptions.HTTPError(
+            "429 Too Many Requests", response=resp
+        )
+        with patch("sys.argv", ["confluence-export", "refresh", "TEST"]), \
+             patch("confluence_export.cli.load_connection_profile", return_value=_profile()), \
+             patch("confluence_export.cli.ConfluenceClient", return_value=client), \
+             patch("confluence_export.cli.CacheStore", return_value=cache):
+            with pytest.raises(SystemExit) as exc:
+                main()
+            assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "network request to Confluence failed" in err
+        assert "429" in err

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -273,7 +273,10 @@ class TestApiMethods:
 
 
 class TestMaxRetriesExhausted:
-    def test_raises_runtime_error(self):
+    def test_429_exhausted_raises_typed_http_error(self):
+        # #46: a sustained 429 must surface the typed HTTPError (a
+        # RequestException the CLI handler catches), not a generic RuntimeError
+        # that escapes it as a raw traceback.
         client = _make_client()
         with patch.object(client.session, "get") as mock_get, \
              patch("confluence_export.client.time.sleep"):
@@ -283,8 +286,20 @@ class TestMaxRetriesExhausted:
             mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError(response=mock_resp)
             mock_get.return_value = mock_resp
 
-            with pytest.raises(RuntimeError, match="Max retries"):
+            with pytest.raises(requests.exceptions.HTTPError) as excinfo:
                 client._get("/test", max_retries=3)
+            assert excinfo.value.response.status_code == 429
+            # Two retries were attempted before the final raise.
+            assert mock_get.call_count == 3
+
+    def test_zero_retries_backstop_raises_runtime_error(self):
+        # max_retries=0 skips the request loop entirely; the defensive backstop
+        # raise is all that's left (every in-loop path now returns or raises).
+        client = _make_client()
+        with pytest.raises(RuntimeError, match="Max retries"):
+            client._get("/test", max_retries=0)
+        with pytest.raises(RuntimeError, match="Max retries"):
+            client._get_raw("/test", max_retries=0)
 
 
 class TestGetRaw:
@@ -809,13 +824,15 @@ class TestGetRawRetryAndRateLimit:
             with pytest.raises(requests.exceptions.HTTPError):
                 client._get_raw("/d", max_retries=2)
 
-    def test_get_raw_429_exhausted_raises_runtime(self):
+    def test_get_raw_429_exhausted_raises_typed_http_error(self):
+        # #46: mirror the 5xx branch — exhausted 429 raises the typed HTTPError.
         client = _make_client()
         with patch.object(client.session, "get") as mock_get, \
              patch("confluence_export.client.time.sleep"):
             mock_get.return_value = self._http_error(429, retry_after=0)
-            with pytest.raises(RuntimeError, match="Max retries"):
+            with pytest.raises(requests.exceptions.HTTPError) as excinfo:
                 client._get_raw("/d", max_retries=2)
+            assert excinfo.value.response.status_code == 429
 
     def test_get_raw_connection_error_exhausted_raises(self):
         client = _make_client()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -199,6 +199,16 @@ class TestPaginate:
             assert results[0]["id"] == "1"
             assert results[1]["id"] == "2"
 
+    def test_null_envelope_fields_coalesced(self):
+        # #47 class: an explicit-null envelope ("results"/"_links": null) must
+        # not raise a TypeError/AttributeError — neither is a
+        # RequestException, so it would escape the CLI's network-error
+        # handler as a raw traceback aborting the whole refresh.
+        client = _make_client()
+        with patch.object(client, "_get") as mock:
+            mock.return_value = {"results": None, "_links": None}
+            assert client._paginate("/test") == []
+
 
 class TestApiMethods:
     def test_get_spaces(self):
@@ -526,6 +536,67 @@ class TestCookieV1Mode:
         assert atts[0].webui == ""
 
 
+class TestV1BuilderNullShapes:
+    """#47 parity for the remaining v1 builders: like _attachment_from_v1 they
+    build their records directly (not via from_api), and `x.get(k) or ""` is a
+    single line — so line coverage alone cannot catch a regression back to the
+    dict-key-default idiom. These pin the null shape per builder."""
+
+    def test_page_from_v1_explicit_nulls_coalesced(self):
+        client = _make_client()
+        p = client._page_from_v1({
+            "id": None, "title": None, "status": None,
+            "space": {"id": None}, "history": None,
+            "ancestors": [None], "extensions": {"position": None},
+            "body": {"storage": {"value": None}},
+            "_links": None,
+        })
+        assert p.id == ""            # not the truthy string "None"
+        assert p.title == ""
+        assert p.space_id == ""
+        assert p.parent_id == ""
+        assert p.parent_type == ""
+        assert p.position == 0
+        assert p.body_storage == ""
+        assert p.webui == ""
+
+    def test_space_from_v1_explicit_nulls_coalesced(self):
+        client = _make_client()
+        s = client._space_from_v1({
+            "id": None, "key": None, "name": None, "type": None,
+            "status": None, "homepageId": None, "homepage": None,
+            "_links": None,
+        })
+        assert s.id == ""
+        assert s.key == ""
+        assert s.name == ""
+        assert s.homepage_id == ""
+        assert s.webui == ""
+
+    def test_version_from_v1_explicit_nulls_coalesced(self):
+        client = _make_client()
+        v = client._version_from_v1({
+            "createdAt": None, "when": None, "message": None,
+            "number": None, "minorEdit": None, "by": None,
+        })
+        assert v.created_at == ""
+        assert v.message == ""
+        assert v.number == 0
+        assert v.minor_edit is False
+
+    def test_folder_from_v1_explicit_nulls_coalesced(self):
+        client = _make_client()
+        f = client._folder_from_v1({
+            "id": None, "title": None, "space": {"id": None},
+            "ancestors": [None], "extensions": {"position": None},
+        })
+        assert f["id"] == ""
+        assert f["title"] == ""
+        assert f["spaceId"] == ""
+        assert f["parentId"] == ""
+        assert f["position"] == 0
+
+
 class TestVerboseLogging:
     def test_log_when_verbose(self, capsys):
         client = _make_client()
@@ -671,6 +742,13 @@ class TestPaginateOffset:
         second_path, second_params = mock.call_args_list[1].args
         assert second_path == "/wiki/rest/api/space"
         assert second_params == {"start": "25", "limit": "25"}
+
+    def test_null_envelope_fields_coalesced(self):
+        # #47 class: v1 twin of TestPaginate's null-envelope test.
+        client = _make_client()
+        with patch.object(client, "_get") as mock:
+            mock.return_value = {"results": None, "_links": None}
+            assert client._paginate_offset("/wiki/rest/api/space") == []
 
 
 class TestSpaceKeyForV1:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -499,6 +499,32 @@ class TestCookieV1Mode:
             {"expand": "version,metadata,extensions,history", "limit": "250"},
         )
 
+    def test_get_attachments_v1_null_fields_coalesced(self):
+        # #47 parity for the v1 dialect: _attachment_from_v1 builds Attachment
+        # directly (not via from_api), so explicit nulls must coalesce here too
+        # or the same .casefold() crash class comes back on the cookie path.
+        client = _make_client()
+        client.set_cookies("session=abc")
+
+        with patch.object(client, "_paginate_offset") as mock:
+            mock.return_value = [
+                {
+                    "id": "att1",
+                    "title": None,
+                    "mediaType": None,
+                    "mediaTypeDescription": None,
+                    "extensions": {"mediaType": None},
+                    "_links": None,
+                }
+            ]
+            atts = client.get_attachments("42")
+
+        assert atts[0].title == ""
+        assert atts[0].media_type == ""
+        assert atts[0].media_type_description == ""
+        assert atts[0].download_link == ""
+        assert atts[0].webui == ""
+
 
 class TestVerboseLogging:
     def test_log_when_verbose(self, capsys):
@@ -833,6 +859,42 @@ class TestGetRawRetryAndRateLimit:
             with pytest.raises(requests.exceptions.HTTPError) as excinfo:
                 client._get_raw("/d", max_retries=2)
             assert excinfo.value.response.status_code == 429
+
+    def test_429_exhausted_still_extends_shared_rate_limit_window(self):
+        # The FINAL 429's Retry-After must still extend the cross-thread
+        # backoff window before the typed HTTPError surfaces (#46): the pool
+        # swallows the per-item failure and moves on, so without the window
+        # the peer workers fire straight into the throttling server.
+        import time as _time
+
+        client = _make_client()
+        with patch.object(client.session, "get") as mock_get, \
+             patch("confluence_export.client.time.sleep"):
+            mock_get.return_value = self._http_error(429, retry_after=120)
+            before = _time.monotonic()
+            with pytest.raises(requests.exceptions.HTTPError):
+                client._get_raw("/d", max_retries=1)
+        assert client._rate_limit_until >= before + 119
+        assert client.stats["retries"] == 1
+
+    @pytest.mark.parametrize("header", ["inf", "nan", "-5", "864000"])
+    def test_retry_after_clamped_to_sane_window(self, header):
+        # float() accepts 'inf'/'nan' — an unclamped value reaches
+        # time.sleep via the shared window (OverflowError as a raw
+        # traceback); a huge finite value would stall every worker for
+        # days. The header is server/proxy-controlled: trust it only
+        # within the cap.
+        import time as _time
+
+        client = _make_client()
+        with patch.object(client.session, "get") as mock_get, \
+             patch("confluence_export.client.time.sleep"):
+            mock_get.return_value = self._http_error(429, retry_after=header)
+            before = _time.monotonic()
+            with pytest.raises(requests.exceptions.HTTPError):
+                client._get_raw("/d", max_retries=1)
+        window = client._rate_limit_until - before
+        assert 0 <= window <= 301  # finite, never past the cap
 
     def test_get_raw_connection_error_exhausted_raises(self):
         client = _make_client()

--- a/tests/test_converter_extra.py
+++ b/tests/test_converter_extra.py
@@ -834,3 +834,21 @@ def test_untitled_expand_does_not_steal_nested_panel_title():
     assert "<h4>Details</h4>" in result
     assert result.count("Inner") == 1
     assert "Body" in result
+
+
+def test_nested_decision_list_not_double_rendered():
+    # #43: a decisionList nested inside a decisionItem is not producible by real
+    # Confluence ADF (item content is inline-only) — hardening. The outer list's
+    # recursive item scan must not emit the inner list's items a second time.
+    html = (
+        '<ac:adf-node type="decisionList">'
+        '<ac:adf-node type="decisionItem" state="DECIDED"><p>Outer</p>'
+        '<ac:adf-node type="decisionList">'
+        '<ac:adf-node type="decisionItem"><p>Inner</p></ac:adf-node>'
+        "</ac:adf-node>"
+        "</ac:adf-node>"
+        "</ac:adf-node>"
+    )
+    result = _preprocess_html(html, [])
+    assert result.count("Inner") == 1
+    assert result.count("Outer") == 1

--- a/tests/test_converter_extra.py
+++ b/tests/test_converter_extra.py
@@ -1089,6 +1089,77 @@ def test_panel_keeps_all_mis_nested_bodies():
     assert "Second body" in result
 
 
+def test_three_level_task_list_preserves_middle_nesting():
+    # find_all("ul") is recursive: extracting both the mid and inner rendered
+    # lists pulled Inner OUT of Mid's just-extracted subtree and re-attached
+    # it one level too high — "Outer > Mid" + "Outer > Inner", losing
+    # "Mid > Inner". Three-level Tab-indented action items are producible in
+    # the real editor.
+    html = (
+        "<ac:task-list><ac:task>"
+        "<ac:task-status>incomplete</ac:task-status>"
+        "<ac:task-body>Outer"
+        "<ac:task-list><ac:task>"
+        "<ac:task-status>incomplete</ac:task-status>"
+        "<ac:task-body>Mid"
+        "<ac:task-list><ac:task>"
+        "<ac:task-status>complete</ac:task-status>"
+        "<ac:task-body>Inner</ac:task-body>"
+        "</ac:task></ac:task-list>"
+        "</ac:task-body>"
+        "</ac:task></ac:task-list>"
+        "</ac:task-body>"
+        "</ac:task></ac:task-list>"
+    )
+    result = _preprocess_html(html, [])
+    assert result.count("Inner") == 1
+    # Inner's sublist lives INSIDE Mid's <li>, not as its sibling.
+    assert "<li>[ ] Mid<ul><li>[x] Inner</li></ul></li>" in result
+
+
+def test_three_level_decision_list_preserves_middle_nesting():
+    # Decision twin of the three-level task case (same extraction sites).
+    html = (
+        '<ac:adf-node type="decisionList">'
+        '<ac:adf-node type="decisionItem"><p>Outer</p>'
+        '<ac:adf-node type="decisionList">'
+        '<ac:adf-node type="decisionItem"><p>Mid</p>'
+        '<ac:adf-node type="decisionList">'
+        '<ac:adf-node type="decisionItem" state="DECIDED"><p>Inner</p></ac:adf-node>'
+        "</ac:adf-node>"
+        "</ac:adf-node>"
+        "</ac:adf-node>"
+        "</ac:adf-node>"
+        "</ac:adf-node>"
+    )
+    result = _preprocess_html(html, [])
+    assert result.count("Inner") == 1
+    assert "<li>Mid<ul><li>✓ Inner</li></ul></li>" in result
+
+
+def test_stray_splice_keeps_deep_nesting():
+    # The stray-splice loop had the same recursive find_all("ul") shape: an
+    # outer list whose DIRECT CHILD is a list whose task carries its own
+    # sublist — the deep sublist was yanked back out of Mid's already-spliced
+    # <li> and its items appended flat beside it.
+    html = (
+        "<ac:task-list>"
+        "<ac:task-list><ac:task>"
+        "<ac:task-status>incomplete</ac:task-status>"
+        "<ac:task-body>Mid"
+        "<ac:task-list><ac:task>"
+        "<ac:task-status>complete</ac:task-status>"
+        "<ac:task-body>Inner</ac:task-body>"
+        "</ac:task></ac:task-list>"
+        "</ac:task-body>"
+        "</ac:task></ac:task-list>"
+        "</ac:task-list>"
+    )
+    result = _preprocess_html(html, [])
+    assert result.count("Inner") == 1
+    assert "<li>[ ] Mid<ul><li>[x] Inner</li></ul></li>" in result
+
+
 def test_unknown_bodyless_macro_wrapping_real_macro_keeps_it():
     # Default branch: an unknown macro with no own body WRAPPING a real macro
     # must unwrap (children stay live and convert), not stamp a placeholder

--- a/tests/test_converter_extra.py
+++ b/tests/test_converter_extra.py
@@ -863,3 +863,245 @@ def test_drawio_matcher_tolerates_null_media_type_attachment():
     target = Attachment.from_api({"id": "b", "title": "arch.drawio", "mediaType": None})
     attach_map = {noise.title: noise, target.title: target}
     assert _match_drawio_attachment("arch", attach_map) is target
+
+
+# -- nested decision/task lists must lose nothing and duplicate nothing -------
+
+def test_nested_decision_list_in_item_renders_as_sublist():
+    # The #43 guard alone processed lists outermost-first: the outer
+    # replace_with detached the not-yet-rendered inner list, losing its
+    # structured render (the ✓ marker) and gluing its text into the outer
+    # item. Innermost-first keeps it as a real sublist.
+    html = (
+        '<ac:adf-node type="decisionList">'
+        '<ac:adf-node type="decisionItem"><p>Outer</p>'
+        '<ac:adf-node type="decisionList">'
+        '<ac:adf-node type="decisionItem" state="DECIDED"><p>Inner</p></ac:adf-node>'
+        "</ac:adf-node>"
+        "</ac:adf-node>"
+        "</ac:adf-node>"
+    )
+    result = _preprocess_html(html, [])
+    assert result.count("Inner") == 1
+    assert "✓ Inner" in result
+    assert "OuterInner" not in result
+
+
+def test_nested_decision_list_sibling_of_items_content_kept():
+    # An inner decisionList that is a SIBLING of the outer list's items (not
+    # inside any item): its content must survive the outer replace_with.
+    html = (
+        '<ac:adf-node type="decisionList">'
+        '<ac:adf-node type="decisionItem"><p>Alpha</p></ac:adf-node>'
+        '<ac:adf-node type="decisionList">'
+        '<ac:adf-node type="decisionItem"><p>Beta</p></ac:adf-node>'
+        "</ac:adf-node>"
+        "</ac:adf-node>"
+    )
+    result = _preprocess_html(html, [])
+    assert result.count("Alpha") == 1
+    assert result.count("Beta") == 1
+
+
+def test_decision_list_directly_inside_decision_list_content_kept():
+    # A decisionList whose only child is another decisionList: the outer <ul>
+    # had no items of its own, and decompose() destroyed the not-yet-rendered
+    # inner list with it — the page rendered empty.
+    html = (
+        '<ac:adf-node type="decisionList">'
+        '<ac:adf-node type="decisionList">'
+        '<ac:adf-node type="decisionItem"><p>Inner</p></ac:adf-node>'
+        "</ac:adf-node>"
+        "</ac:adf-node>"
+    )
+    result = _preprocess_html(html, [])
+    assert "<li>Inner</li>" in result
+
+
+def test_nested_task_list_not_double_rendered():
+    # Tab-indented action items nest an ac:task-list inside an ac:task-body —
+    # producible in the real editor, unlike nested decisionLists. The
+    # outermost-first pass emitted the inner task twice AND leaked the raw
+    # status word into the outer item's text ("OutercompleteInner").
+    html = (
+        "<ac:task-list><ac:task>"
+        "<ac:task-status>incomplete</ac:task-status>"
+        "<ac:task-body>Outer"
+        "<ac:task-list><ac:task>"
+        "<ac:task-status>complete</ac:task-status>"
+        "<ac:task-body>Inner</ac:task-body>"
+        "</ac:task></ac:task-list>"
+        "</ac:task-body>"
+        "</ac:task></ac:task-list>"
+    )
+    result = _preprocess_html(html, [])
+    assert result.count("Inner") == 1
+    assert "[x] Inner" in result
+    assert "[ ] Outer" in result
+    assert "complete" not in result  # the status word must not leak as text
+
+
+def test_panel_body_recovered_from_malformed_storage():
+    # An unclosed ac:parameter makes html.parser nest the rich-text-body
+    # INSIDE the parameter. recursive=False alone (#45) then found no body and
+    # replace_with silently discarded it; the descendant fallback recovers it
+    # (it is still THIS macro's body) without re-opening the #45 steal, and
+    # the body text must not duplicate into the title.
+    html = (
+        '<ac:structured-macro ac:name="info">'
+        '<ac:parameter ac:name="title">MyTitle'
+        "<ac:rich-text-body><p>Important body</p></ac:rich-text-body>"
+        "</ac:structured-macro>"
+    )
+    result = _preprocess_html(html, [])
+    assert result.count("Important body") == 1
+    assert "<strong>MyTitle</strong>" in result
+
+
+def test_decision_item_with_only_a_nested_list_keeps_nested_items():
+    # An item with NO own text whose content is just a nested list: the empty
+    # item must not drop the nested items with it.
+    html = (
+        '<ac:adf-node type="decisionList">'
+        '<ac:adf-node type="decisionItem">'
+        '<ac:adf-node type="decisionList">'
+        '<ac:adf-node type="decisionItem"><p>Kept</p></ac:adf-node>'
+        "</ac:adf-node>"
+        "</ac:adf-node>"
+        "</ac:adf-node>"
+    )
+    result = _preprocess_html(html, [])
+    assert "<li>Kept</li>" in result
+
+
+def test_task_list_directly_inside_task_list_content_kept():
+    # A task-list as a DIRECT child of a task-list (no task-body between):
+    # the inner list's rendered items must survive the outer replace_with.
+    html = (
+        "<ac:task-list>"
+        "<ac:task-list><ac:task>"
+        "<ac:task-status>complete</ac:task-status>"
+        "<ac:task-body>Inner</ac:task-body>"
+        "</ac:task></ac:task-list>"
+        "</ac:task-list>"
+    )
+    result = _preprocess_html(html, [])
+    assert result.count("Inner") == 1
+    assert "[x] Inner" in result
+
+
+def test_task_list_inside_decision_item_renders_as_sublist():
+    # Cross-type nesting: decision lists and task lists render in ONE
+    # innermost-first pass — with separate passes the unrendered task list
+    # was get_text()-flattened into the decision item ('d-outercompletet-inner',
+    # status word fused into prose, checkbox lost).
+    html = (
+        '<ac:adf-node type="decisionList"><ac:adf-node type="decisionItem">'
+        "<p>d-outer</p>"
+        "<ac:task-list><ac:task>"
+        "<ac:task-status>complete</ac:task-status>"
+        "<ac:task-body>t-inner</ac:task-body>"
+        "</ac:task></ac:task-list>"
+        "</ac:adf-node></ac:adf-node>"
+    )
+    result = _preprocess_html(html, [])
+    assert result.count("t-inner") == 1
+    assert "[x] t-inner" in result
+    assert "complete" not in result
+    assert "d-outer" in result
+
+
+def test_decision_list_inside_task_body_renders_as_sublist():
+    # The reverse nesting direction must hold by design, not pass-order luck.
+    html = (
+        "<ac:task-list><ac:task>"
+        "<ac:task-status>incomplete</ac:task-status>"
+        "<ac:task-body>t-outer"
+        '<ac:adf-node type="decisionList">'
+        '<ac:adf-node type="decisionItem" state="DECIDED"><p>d-inner</p></ac:adf-node>'
+        "</ac:adf-node>"
+        "</ac:task-body>"
+        "</ac:task></ac:task-list>"
+    )
+    result = _preprocess_html(html, [])
+    assert result.count("d-inner") == 1
+    assert "✓ d-inner" in result
+    assert "[ ] t-outer" in result
+
+
+def test_emoticon_inside_task_body_survives():
+    # Emoticons are replaced BEFORE the list pass; a task body renders via
+    # get_text(), so an unreplaced <ac:emoticon> would silently vanish.
+    html = (
+        "<ac:task-list><ac:task>"
+        "<ac:task-status>incomplete</ac:task-status>"
+        '<ac:task-body>Ship it <ac:emoticon ac:name="thumbs-up"/></ac:task-body>'
+        "</ac:task></ac:task-list>"
+    )
+    result = _preprocess_html(html, [])
+    assert "Ship it" in result
+    assert "👍" in result
+
+
+def test_panel_without_own_body_keeps_nested_macro_content():
+    # A panel with NO own rich-text-body wrapping a real macro (malformed
+    # storage): the nested macro must be moved LIVE into the blockquote and
+    # still be converted — replace_with used to destroy it wholesale.
+    html = (
+        '<ac:structured-macro ac:name="info">'
+        '<ac:structured-macro ac:name="note">'
+        '<ac:parameter ac:name="title">NestedTitle</ac:parameter>'
+        "<ac:rich-text-body><p>NestedBody</p></ac:rich-text-body>"
+        "</ac:structured-macro></ac:structured-macro>"
+    )
+    result = _preprocess_html(html, [])
+    assert "NestedBody" in result
+    assert result.count("NestedTitle") == 1
+    assert "<strong>Info</strong>" in result  # outer keeps its default title (#45)
+
+
+def test_expand_body_recovered_from_malformed_storage():
+    # Expand twin of the panel test: an unclosed ac:parameter swallowing the
+    # body must not discard it, and the body text must not leak into the title.
+    html = (
+        '<ac:structured-macro ac:name="expand">'
+        '<ac:parameter ac:name="title">MyTitle'
+        "<ac:rich-text-body><p>Important body</p></ac:rich-text-body>"
+        "</ac:structured-macro>"
+    )
+    result = _preprocess_html(html, [])
+    assert result.count("Important body") == 1
+    assert "<h4>MyTitle</h4>" in result
+
+
+def test_panel_keeps_all_mis_nested_bodies():
+    # Multiple bodies swallowed by one unclosed parameter: ALL owned bodies'
+    # content survives, not just the first match.
+    html = (
+        '<ac:structured-macro ac:name="info">'
+        '<ac:parameter ac:name="title">T'
+        "<ac:rich-text-body><p>First body</p></ac:rich-text-body>"
+        "<ac:rich-text-body><p>Second body</p></ac:rich-text-body>"
+        "</ac:structured-macro>"
+    )
+    result = _preprocess_html(html, [])
+    assert "First body" in result
+    assert "Second body" in result
+
+
+def test_unknown_bodyless_macro_wrapping_real_macro_keeps_it():
+    # Default branch: an unknown macro with no own body WRAPPING a real macro
+    # must unwrap (children stay live and convert), not stamp a placeholder
+    # over the whole subtree or steal the nested macro's body (#45 shape).
+    html = (
+        '<ac:structured-macro ac:name="future-widget">'
+        '<ac:parameter ac:name="conf">x</ac:parameter>'
+        '<ac:structured-macro ac:name="info">'
+        "<ac:rich-text-body><p>Inner panel body</p></ac:rich-text-body>"
+        "</ac:structured-macro></ac:structured-macro>"
+    )
+    result = _preprocess_html(html, [])
+    assert "Inner panel body" in result
+    assert "<strong>Info</strong>" in result  # nested macro converted, not stolen
+    assert "future-widget" not in result.replace("[future-widget]", "")  # no param leak
+    assert ">x<" not in result  # the conf parameter must not leak as text

--- a/tests/test_converter_extra.py
+++ b/tests/test_converter_extra.py
@@ -798,3 +798,39 @@ def test_ac_image_resolves_id_specific_local_name_via_content_id():
     result = _preprocess_html(html, atts)
     assert ".media/shot-id2.png" in result
     assert 'src=".media/shot.png"' not in result
+
+
+# -- #45: untitled panel/expand must not steal a nested macro's title ---------
+
+def test_untitled_panel_does_not_steal_nested_macro_title():
+    # #45: the recursive title lookup reached INTO the nested status macro and
+    # stole its title param — the Info header became "DONE" and the status text
+    # was emitted twice (once as the header, once by the nested conversion).
+    html = (
+        '<ac:structured-macro ac:name="info"><ac:rich-text-body>'
+        '<ac:structured-macro ac:name="status">'
+        '<ac:parameter ac:name="title">DONE</ac:parameter>'
+        "</ac:structured-macro>Some text"
+        "</ac:rich-text-body></ac:structured-macro>"
+    )
+    result = _preprocess_html(html, [])
+    assert "<strong>Info</strong>" in result
+    assert result.count("DONE") == 1
+    assert "Some text" in result
+
+
+def test_untitled_expand_does_not_steal_nested_panel_title():
+    # #45: same steal in _convert_expand — an untitled expand around a titled
+    # inner panel must fall back to "Details", and the inner panel must keep its
+    # own header (one "Inner", not an expand header + a panel header).
+    html = (
+        '<ac:structured-macro ac:name="expand"><ac:rich-text-body>'
+        '<ac:structured-macro ac:name="info">'
+        '<ac:parameter ac:name="title">Inner</ac:parameter>'
+        "<ac:rich-text-body><p>Body</p></ac:rich-text-body>"
+        "</ac:structured-macro></ac:rich-text-body></ac:structured-macro>"
+    )
+    result = _preprocess_html(html, [])
+    assert "<h4>Details</h4>" in result
+    assert result.count("Inner") == 1
+    assert "Body" in result

--- a/tests/test_converter_extra.py
+++ b/tests/test_converter_extra.py
@@ -852,3 +852,14 @@ def test_nested_decision_list_not_double_rendered():
     result = _preprocess_html(html, [])
     assert result.count("Inner") == 1
     assert result.count("Outer") == 1
+
+
+def test_drawio_matcher_tolerates_null_media_type_attachment():
+    # #47: a sibling attachment with "title"/"mediaType": null must not crash
+    # _match_drawio_attachment's _is_drawio scan while matching another one.
+    from confluence_export.converter import _match_drawio_attachment
+
+    noise = Attachment.from_api({"id": "a", "title": None, "mediaType": None})
+    target = Attachment.from_api({"id": "b", "title": "arch.drawio", "mediaType": None})
+    attach_map = {noise.title: noise, target.title: target}
+    assert _match_drawio_attachment("arch", attach_map) is target

--- a/tests/test_drawio.py
+++ b/tests/test_drawio.py
@@ -98,3 +98,14 @@ def test_forced_render_uses_umask_mode_for_new_png(tmp_path):
     assert result == output
     assert output.read_bytes() == b"PNG"
     assert output.stat().st_mode & 0o777 == 0o640
+
+
+def test_find_drawio_attachments_tolerates_null_media_type():
+    # #47: an attachment record with "mediaType": null reaches consumers as a
+    # real None unless from_api coalesces it; the matcher must not crash and
+    # must still match by title.
+    atts = [
+        Attachment.from_api({"id": "a", "title": None, "mediaType": None}),
+        Attachment.from_api({"id": "b", "title": "d.drawio", "mediaType": None}),
+    ]
+    assert [a.id for a in find_drawio_attachments(atts)] == ["b"]

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -743,7 +743,9 @@ class TestMediaDownload:
         # possibly-concurrent run's live transaction files).
         import time
 
-        old = time.time() - 7200
+        from confluence_export.media import _TEMP_ARTIFACT_MIN_AGE_S
+
+        old = time.time() - 2 * _TEMP_ARTIFACT_MIN_AGE_S
         os.utime(p, (old, old), follow_symlinks=False)
 
     def test_sweeps_stale_temp_artifacts_before_download(self, tmp_path):
@@ -768,6 +770,39 @@ class TestMediaDownload:
 
         assert not (media_dir / ".download-stale.tmp").exists()
         assert not (media_dir / ".rollback-stale.tmp").exists()
+
+    def test_rollback_snapshot_mtime_is_fresh_not_inherited(self, tmp_path):
+        # copy2 stamps the SOURCE file's old mtime onto the snapshot; the #48
+        # sweep's age gate would misread that LIVE snapshot as crashed-run
+        # litter and a concurrent run could sweep it mid-transaction.
+        # snapshot_file resets the snapshot's mtime to now.
+        import time
+
+        exporter, _, _ = _make_exporter(download_media=True)
+        att = Attachment(id="a1", title="img.png", file_size=100,
+                         download_link="/wiki/download/a1", page_id="p1")
+        page = _make_page()
+        cs = _make_cached_space(attachments={"p1": [att]})
+        media_dir = tmp_path / ".media"
+        media_dir.mkdir()
+        (media_dir / _VERSIONS_FILE).write_text("{}")
+        self._backdate(media_dir / _VERSIONS_FILE)
+
+        ages = []
+
+        def capture(*args, **kwargs):
+            ages.extend(
+                time.time() - p.lstat().st_mtime
+                for p in media_dir.glob(".rollback-*.tmp")
+            )
+            return []
+
+        with patch("confluence_export.exporter.download_attachments",
+                   side_effect=capture):
+            exporter._export_single_page(page, tmp_path, cs, "TEST")
+
+        assert ages  # the .versions.json snapshot existed during the download
+        assert all(age < 600 for age in ages)  # fresh, not the source's mtime
 
     def test_no_media_sweeps_stale_temp_artifacts(self, tmp_path):
         # #48: the materialize (no-download) branch sweeps too.

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -736,6 +736,44 @@ class TestMediaDownload:
             # Verify media dir was created and passed
             assert mock_dl.call_args[0][2].name == ".media"
 
+    def test_sweeps_stale_temp_artifacts_before_download(self, tmp_path):
+        # #48: temps a hard-killed earlier run left in .media are swept at the
+        # start of the media phase. The run's own .rollback- snapshots are
+        # created right after the sweep, so they are never caught by it.
+        exporter, _, _ = _make_exporter(download_media=True)
+        att = Attachment(id="a1", title="img.png", file_size=100,
+                         download_link="/wiki/download/a1", page_id="p1")
+        page = _make_page()
+        cs = _make_cached_space(attachments={"p1": [att]})
+        media_dir = tmp_path / ".media"
+        media_dir.mkdir()
+        (media_dir / ".download-stale.tmp").write_bytes(b"x")
+        (media_dir / ".rollback-stale.tmp").write_bytes(b"x")
+
+        with patch("confluence_export.exporter.download_attachments") as mock_dl:
+            mock_dl.return_value = []
+            exporter._export_single_page(page, tmp_path, cs, "TEST")
+
+        assert not (media_dir / ".download-stale.tmp").exists()
+        assert not (media_dir / ".rollback-stale.tmp").exists()
+
+    def test_no_media_sweeps_stale_temp_artifacts(self, tmp_path):
+        # #48: the materialize (no-download) branch sweeps too.
+        exporter, _, _ = _make_exporter(download_media=False)
+        att = Attachment(id="att1", title="img.png", file_size=100, page_id="p1",
+                         download_link="/wiki/download/att1")
+        page = _make_page()
+        cs = _make_cached_space(attachments={"p1": [att]})
+        media_dir = tmp_path / ".media"
+        media_dir.mkdir()
+        stale = media_dir / ".preserve-stale"
+        stale.mkdir()
+        (stale / "0").write_bytes(b"x")
+
+        exporter._export_single_page(page, tmp_path, cs, "TEST")
+
+        assert not stale.exists()
+
     def test_no_media_materializes_planned_name_from_existing_manifest(self, tmp_path):
         exporter, _, _ = _make_exporter(download_media=False)
         moved = Attachment(

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path, PurePosixPath
 from unittest.mock import MagicMock, patch
 
+import pytest
 import yaml
 
 from confluence_export.exporter import (
@@ -736,6 +737,15 @@ class TestMediaDownload:
             # Verify media dir was created and passed
             assert mock_dl.call_args[0][2].name == ".media"
 
+    @staticmethod
+    def _backdate(p):
+        # Age past the sweep's min-age gate (young matches are spared as a
+        # possibly-concurrent run's live transaction files).
+        import time
+
+        old = time.time() - 7200
+        os.utime(p, (old, old), follow_symlinks=False)
+
     def test_sweeps_stale_temp_artifacts_before_download(self, tmp_path):
         # #48: temps a hard-killed earlier run left in .media are swept at the
         # start of the media phase. The run's own .rollback- snapshots are
@@ -749,6 +759,8 @@ class TestMediaDownload:
         media_dir.mkdir()
         (media_dir / ".download-stale.tmp").write_bytes(b"x")
         (media_dir / ".rollback-stale.tmp").write_bytes(b"x")
+        self._backdate(media_dir / ".download-stale.tmp")
+        self._backdate(media_dir / ".rollback-stale.tmp")
 
         with patch("confluence_export.exporter.download_attachments") as mock_dl:
             mock_dl.return_value = []
@@ -769,10 +781,47 @@ class TestMediaDownload:
         stale = media_dir / ".preserve-stale"
         stale.mkdir()
         (stale / "0").write_bytes(b"x")
+        self._backdate(stale)
 
         exporter._export_single_page(page, tmp_path, cs, "TEST")
 
         assert not stale.exists()
+
+    @pytest.mark.parametrize("download_media", [True, False])
+    def test_sweeps_even_when_page_has_no_attachments(self, tmp_path, download_media):
+        # #48: a page whose attachments were all since deleted upstream takes
+        # no media branch at all — stale temps from a hard-killed earlier run
+        # must still be swept (they are untracked, so the prune can't remove
+        # them either).
+        exporter, _, _ = _make_exporter(download_media=download_media)
+        page = _make_page()
+        cs = _make_cached_space(attachments={"p1": []})
+        media_dir = tmp_path / ".media"
+        media_dir.mkdir()
+        stale = media_dir / ".download-stale.tmp"
+        stale.write_bytes(b"x")
+        self._backdate(stale)
+
+        exporter._export_single_page(page, tmp_path, cs, "TEST")
+
+        assert not stale.exists()
+
+    def test_sweep_never_reaches_through_symlinked_media_dir(self, tmp_path):
+        # The sweep guard must not follow a symlinked .media into an arbitrary
+        # target tree — sweep_stale_media_temps unlinks/rmtrees its matches.
+        exporter, _, _ = _make_exporter(download_media=False)
+        page = _make_page()
+        cs = _make_cached_space(attachments={"p1": []})
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        bait = outside / ".download-x.tmp"
+        bait.write_bytes(b"x")
+        self._backdate(bait)
+        (tmp_path / ".media").symlink_to(outside, target_is_directory=True)
+
+        exporter._export_single_page(page, tmp_path, cs, "TEST")
+
+        assert bait.exists()  # never swept through the link
 
     def test_no_media_materializes_planned_name_from_existing_manifest(self, tmp_path):
         exporter, _, _ = _make_exporter(download_media=False)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1401,7 +1401,6 @@ class TestGitDefensiveBranches:
         # name: on macOS pytest's tmp_path contains an uppercase /T/ component,
         # which the probed nfc_casefold lowercases on the query side only.
         from confluence_export import git as G
-        from confluence_export.paths import nfc, nfc_casefold
         from confluence_export.protection import build_protected
 
         ensure_repo(tmp_path)
@@ -1411,7 +1410,9 @@ class TestGitDefensiveBranches:
         subprocess.run(["git", "commit", "-m", "i"], cwd=tmp_path, capture_output=True)
 
         (tmp_path / "page" / "page.md").unlink()  # tracked deletion under protection
-        fold = nfc_casefold if G._fs_is_case_insensitive(tmp_path) else nfc
+        # The SAME policy helper the fold=None fallback calls — never re-derive
+        # the fold inline (#44: one policy, no drift).
+        fold = G._fold_for(tmp_path)
         _, sub = build_protected(
             tmp_path, ProtectionSet(subtrees=(SubtreeProtection(tmp_path / "page"),)), fold
         )

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -574,6 +574,34 @@ class TestCommitExport:
         assert "Foo/.media/img.png" in ls  # committed media kept under case drift
         assert media.exists()
 
+    def test_case_only_recased_written_page_keeps_committed_media(self, tmp_path):
+        """#44 (keep-by-WRITE direction): committed media owned by a page that was
+        re-cased and re-written this run must be kept via the FOLDED written sets —
+        without the fold the owner dir misses its own written entry, no protection
+        applies, and the media is pruned. (_fs_is_case_insensitive forced so Linux
+        CI, where 'Foo' and 'FOO' are distinct dirs, exercises it deterministically.)"""
+        self._init_repo(tmp_path)
+        media = tmp_path / "Foo" / ".media" / "img.png"
+        media.parent.mkdir(parents=True)
+        media.write_bytes(b"\x89PNG")
+        (tmp_path / "Foo" / "Foo.md").write_text("# Foo")
+        subprocess.run(["git", "add", "-A"], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "first export"], cwd=tmp_path, capture_output=True)
+
+        # This run writes the page at the NEW case; no protection configured, so
+        # only the folded written_page_dirs can keep the committed media.
+        recased = tmp_path / "FOO"
+        recased.mkdir(exist_ok=True)  # same dir as Foo on a case-insensitive FS
+        (recased / "FOO.md").write_text("# recased")
+        with patch("confluence_export.git._fs_is_case_insensitive", return_value=True):
+            commit_export(
+                tmp_path, [recased / "FOO.md"], "TEST",
+                is_full=True, preserve_media=True, protection=_prot(),
+            )
+
+        ls = subprocess.run(["git", "ls-files"], cwd=tmp_path, capture_output=True, text=True).stdout
+        assert "Foo/.media/img.png" in ls  # kept via the folded written sets
+
     def test_page_exact_protection_not_child(self, tmp_path):
         """PageExactProtection is page-EXACT (e.g. an archived page whose precise
         target is known, M1-exact): it preserves the page's own files but NOT a

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1395,11 +1395,13 @@ class TestGitDefensiveBranches:
 
     def test_restore_protected_deletions_without_fold_probes_fs(self, tmp_path):
         # Covers the fold=None PROBE fallback in _restore_protected_deletions.
-        # Uses a fold-invariant (lowercase ASCII) name so the identity-built
-        # protection and the probed fold agree on either FS; the fold SEMANTICS are
-        # exercised by the FS-patched case-drift tests and the build_protected unit
-        # tests, not here.
+        # Per the build_protected contract, build with the same fold the consumer
+        # will use — here the probed FS fold, since the consumer gets fold=None.
+        # An identity-built protection is NOT enough even with a lowercase leaf
+        # name: on macOS pytest's tmp_path contains an uppercase /T/ component,
+        # which the probed nfc_casefold lowercases on the query side only.
         from confluence_export import git as G
+        from confluence_export.paths import nfc, nfc_casefold
         from confluence_export.protection import build_protected
 
         ensure_repo(tmp_path)
@@ -1409,8 +1411,9 @@ class TestGitDefensiveBranches:
         subprocess.run(["git", "commit", "-m", "i"], cwd=tmp_path, capture_output=True)
 
         (tmp_path / "page" / "page.md").unlink()  # tracked deletion under protection
+        fold = nfc_casefold if G._fs_is_case_insensitive(tmp_path) else nfc
         _, sub = build_protected(
-            tmp_path, ProtectionSet(subtrees=(SubtreeProtection(tmp_path / "page"),))
+            tmp_path, ProtectionSet(subtrees=(SubtreeProtection(tmp_path / "page"),)), fold
         )
         G._restore_protected_deletions(tmp_path, page_dirs=[], sub_dirs=sub)  # no fold
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -497,6 +497,83 @@ class TestCommitExport:
         assert (tmp_path / "P" / "P.md").exists()  # and still on disk
         assert "Gone/Gone.md" not in ls  # genuine upstream deletion still pruned
 
+    def test_case_only_recased_protected_page_survives_prune(self, tmp_path):
+        """#44: on a case-insensitive FS a page whose title changed only in case is
+        protected at the NEW case while its committed dir is still the OLD case. The
+        prune folds case for its staleness key but used to match protection
+        case-sensitively, so the protected page was silently git-rm'd. It must fold
+        protection too. (_fs_is_case_insensitive is forced so Linux CI exercises the
+        folded path deterministically.)"""
+        self._init_repo(tmp_path)
+        (tmp_path / "Foo").mkdir()
+        (tmp_path / "Foo" / "Foo.md").write_text("# Foo last-good")
+        (tmp_path / "Other").mkdir()
+        (tmp_path / "Other" / "Other.md").write_text("# Other")
+        subprocess.run(["git", "add", "-A"], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "first export"], cwd=tmp_path, capture_output=True)
+
+        with patch("confluence_export.git._fs_is_case_insensitive", return_value=True):
+            commit_export(
+                tmp_path, [tmp_path / "Other" / "Other.md"], "TEST",
+                is_full=True, protection=_prot(subtrees=[tmp_path / "FOO"]),
+            )
+
+        ls = subprocess.run(["git", "ls-files"], cwd=tmp_path, capture_output=True, text=True).stdout
+        assert "Foo/Foo.md" in ls  # protected despite case-only drift, not pruned
+        assert (tmp_path / "Foo" / "Foo.md").exists()  # and kept on disk
+        assert "Other/Other.md" in ls
+
+    def test_case_only_recased_protected_deletion_is_restored(self, tmp_path):
+        """#44: the restore folds case too, so a protected re-cased page whose
+        old-case file reconcile removed from disk is re-checked-out from HEAD
+        (RF-B heal), instead of being left a tracked deletion the next run drops."""
+        self._init_repo(tmp_path)
+        (tmp_path / "Foo").mkdir()
+        (tmp_path / "Foo" / "Foo.md").write_text("# Foo last-good")
+        (tmp_path / "Live").mkdir()
+        (tmp_path / "Live" / "Live.md").write_text("# Live")
+        subprocess.run(["git", "add", "-A"], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "first export"], cwd=tmp_path, capture_output=True)
+
+        # Simulate reconcile having removed the old-case file from disk.
+        (tmp_path / "Foo" / "Foo.md").unlink()
+
+        with patch("confluence_export.git._fs_is_case_insensitive", return_value=True):
+            commit_export(
+                tmp_path, [tmp_path / "Live" / "Live.md"], "TEST",
+                is_full=True, protection=_prot(subtrees=[tmp_path / "FOO"]),
+            )
+
+        assert (tmp_path / "Foo" / "Foo.md").exists()  # restored from HEAD
+        ls = subprocess.run(["git", "ls-files"], cwd=tmp_path, capture_output=True, text=True).stdout
+        assert "Foo/Foo.md" in ls
+
+    def test_case_only_recased_protected_media_kept_on_no_media_run(self, tmp_path):
+        """#44 (--no-media / RF-C): committed media under a re-cased protected page
+        must be kept, not pruned, when the protection's case differs from the
+        committed media path. Exercises the folded media-keep predicate."""
+        self._init_repo(tmp_path)
+        media = tmp_path / "Foo" / ".media" / "img.png"
+        media.parent.mkdir(parents=True)
+        media.write_bytes(b"\x89PNG")
+        (tmp_path / "Foo" / "Foo.md").write_text("# Foo")
+        (tmp_path / "Live").mkdir()
+        (tmp_path / "Live" / "Live.md").write_text("# Live")
+        subprocess.run(["git", "add", "-A"], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "first export"], cwd=tmp_path, capture_output=True)
+
+        # --no-media full export; Foo skipped & protected at the new (upper) case.
+        with patch("confluence_export.git._fs_is_case_insensitive", return_value=True):
+            commit_export(
+                tmp_path, [tmp_path / "Live" / "Live.md"], "TEST",
+                is_full=True, preserve_media=True,
+                protection=_prot(subtrees=[tmp_path / "FOO"]),
+            )
+
+        ls = subprocess.run(["git", "ls-files"], cwd=tmp_path, capture_output=True, text=True).stdout
+        assert "Foo/.media/img.png" in ls  # committed media kept under case drift
+        assert media.exists()
+
     def test_page_exact_protection_not_child(self, tmp_path):
         """PageExactProtection is page-EXACT (e.g. an archived page whose precise
         target is known, M1-exact): it preserves the page's own files but NOT a
@@ -1315,6 +1392,29 @@ class TestGitDefensiveBranches:
 
         monkeypatch.setattr(G, "_run_git", fake)
         G._remove_stale_files(tmp_path, [])  # hits the empty-index guard; no raise
+
+    def test_restore_protected_deletions_without_fold_probes_fs(self, tmp_path):
+        # Covers the fold=None PROBE fallback in _restore_protected_deletions.
+        # Uses a fold-invariant (lowercase ASCII) name so the identity-built
+        # protection and the probed fold agree on either FS; the fold SEMANTICS are
+        # exercised by the FS-patched case-drift tests and the build_protected unit
+        # tests, not here.
+        from confluence_export import git as G
+        from confluence_export.protection import build_protected
+
+        ensure_repo(tmp_path)
+        (tmp_path / "page").mkdir()
+        (tmp_path / "page" / "page.md").write_text("# page")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "i"], cwd=tmp_path, capture_output=True)
+
+        (tmp_path / "page" / "page.md").unlink()  # tracked deletion under protection
+        _, sub = build_protected(
+            tmp_path, ProtectionSet(subtrees=(SubtreeProtection(tmp_path / "page"),))
+        )
+        G._restore_protected_deletions(tmp_path, page_dirs=[], sub_dirs=sub)  # no fold
+
+        assert (tmp_path / "page" / "page.md").exists()  # restored from HEAD
 
     def test_remove_stale_files_warns_when_rm_fails(self, tmp_path, monkeypatch, capsys):
         from confluence_export import git as G

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1556,6 +1556,15 @@ class TestRecordDownloadWarning:
         assert "failed to download x.png" in capsys.readouterr().err
 
 
+def _backdate(p: Path) -> None:
+    """Age a temp artifact past the sweep's min-age gate (a young match is
+    treated as another live run's transaction file and spared)."""
+    import time
+
+    old = time.time() - 7200
+    os.utime(p, (old, old), follow_symlinks=False)
+
+
 class TestSweepStaleMediaTemps:
     """#48: leftover atomic-write/rollback temp artifacts from a hard-killed run
     are swept at the start of the next run's media phase."""
@@ -1565,13 +1574,15 @@ class TestSweepStaleMediaTemps:
 
         media = tmp_path / ".media"
         media.mkdir()
-        (media / ".download-abc123.tmp").write_bytes(b"x")
-        (media / ".copy-abc123.tmp").write_bytes(b"x")
-        (media / ".versions-abc123.tmp").write_bytes(b"x")
-        (media / ".rollback-abc123.tmp").write_bytes(b"x")
+        for name in (".download-abc123.tmp", ".copy-abc123.tmp",
+                     ".versions-abc123.tmp", ".rollback-abc123.tmp",
+                     ".drawio-abc123.png"):
+            (media / name).write_bytes(b"x")
+            _backdate(media / name)
         preserve = media / ".preserve-abc123"
         preserve.mkdir()
         (preserve / "0").write_bytes(b"snap")
+        _backdate(preserve)
         # The live manifest and real media files must survive.
         (media / _VERSIONS_FILE).write_text("{}")
         (media / "img.png").write_bytes(b"real")
@@ -1579,6 +1590,21 @@ class TestSweepStaleMediaTemps:
         sweep_stale_media_temps(media)
 
         assert sorted(p.name for p in media.iterdir()) == [_VERSIONS_FILE, "img.png"]
+
+    def test_young_artifact_spared_as_possibly_live(self, tmp_path):
+        # A matching artifact younger than the min-age gate may belong to a
+        # CONCURRENT run's in-flight transaction; sweeping it would corrupt
+        # that run's rollback/download. It must be spared.
+        from confluence_export.media import sweep_stale_media_temps
+
+        media = tmp_path / ".media"
+        media.mkdir()
+        live = media / ".rollback-live.tmp"
+        live.write_bytes(b"peer transaction")
+
+        sweep_stale_media_temps(media)
+
+        assert live.exists()
 
     def test_unremovable_entry_is_skipped_not_fatal(self, tmp_path):
         from pathlib import Path as _P
@@ -1588,6 +1614,7 @@ class TestSweepStaleMediaTemps:
         media = tmp_path / ".media"
         media.mkdir()
         (media / ".download-a.tmp").write_bytes(b"x")
+        _backdate(media / ".download-a.tmp")
         with patch.object(_P, "unlink", side_effect=OSError("busy")):
             sweep_stale_media_temps(media)  # best-effort: no raise
         assert (media / ".download-a.tmp").exists()
@@ -1601,6 +1628,7 @@ class TestSweepStaleMediaTemps:
         target.mkdir()
         (target / "keep.txt").write_text("keep")
         (media / ".preserve-link").symlink_to(target, target_is_directory=True)
+        _backdate(media / ".preserve-link")
 
         sweep_stale_media_temps(media)
 

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1554,3 +1554,74 @@ class TestRecordDownloadWarning:
         # The helper still prints when no collector is supplied.
         _record_download_warning(_att(title="x.png"), ValueError("nope"), None)
         assert "failed to download x.png" in capsys.readouterr().err
+
+
+class TestSweepStaleMediaTemps:
+    """#48: leftover atomic-write/rollback temp artifacts from a hard-killed run
+    are swept at the start of the next run's media phase."""
+
+    def test_removes_all_temp_artifact_kinds(self, tmp_path):
+        from confluence_export.media import sweep_stale_media_temps
+
+        media = tmp_path / ".media"
+        media.mkdir()
+        (media / ".download-abc123.tmp").write_bytes(b"x")
+        (media / ".copy-abc123.tmp").write_bytes(b"x")
+        (media / ".versions-abc123.tmp").write_bytes(b"x")
+        (media / ".rollback-abc123.tmp").write_bytes(b"x")
+        preserve = media / ".preserve-abc123"
+        preserve.mkdir()
+        (preserve / "0").write_bytes(b"snap")
+        # The live manifest and real media files must survive.
+        (media / _VERSIONS_FILE).write_text("{}")
+        (media / "img.png").write_bytes(b"real")
+
+        sweep_stale_media_temps(media)
+
+        assert sorted(p.name for p in media.iterdir()) == [_VERSIONS_FILE, "img.png"]
+
+    def test_unremovable_entry_is_skipped_not_fatal(self, tmp_path):
+        from pathlib import Path as _P
+
+        from confluence_export.media import sweep_stale_media_temps
+
+        media = tmp_path / ".media"
+        media.mkdir()
+        (media / ".download-a.tmp").write_bytes(b"x")
+        with patch.object(_P, "unlink", side_effect=OSError("busy")):
+            sweep_stale_media_temps(media)  # best-effort: no raise
+        assert (media / ".download-a.tmp").exists()
+
+    def test_symlinked_preserve_entry_unlinked_without_following(self, tmp_path):
+        from confluence_export.media import sweep_stale_media_temps
+
+        media = tmp_path / ".media"
+        media.mkdir()
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "keep.txt").write_text("keep")
+        (media / ".preserve-link").symlink_to(target, target_is_directory=True)
+
+        sweep_stale_media_temps(media)
+
+        assert not (media / ".preserve-link").is_symlink()
+        assert (target / "keep.txt").exists()  # never rmtree'd through the link
+
+    def test_mid_snapshot_failure_cleans_up_preserve_dir(self, tmp_path):
+        # #48: a copy2 raise happens before the caller binds tmp_dir to its
+        # try/finally, so without the internal cleanup the .preserve- dir
+        # lingered until GC.
+        from confluence_export.media import _manifest_entry, _snapshot_previous_owned_files
+
+        media = tmp_path / ".media"
+        media.mkdir()
+        att = _att(title="new.png")
+        versions = {"old.png": _manifest_entry(att)}
+        (media / "old.png").write_bytes(b"bytes")
+        name_plan = plan_attachment_names([att])
+
+        with patch("confluence_export.media.shutil.copy2", side_effect=OSError("disk full")):
+            with pytest.raises(OSError, match="disk full"):
+                _snapshot_previous_owned_files(versions, media, [att], name_plan, set())
+
+        assert list(media.glob(".preserve-*")) == []

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1561,7 +1561,9 @@ def _backdate(p: Path) -> None:
     treated as another live run's transaction file and spared)."""
     import time
 
-    old = time.time() - 7200
+    from confluence_export.media import _TEMP_ARTIFACT_MIN_AGE_S
+
+    old = time.time() - 2 * _TEMP_ARTIFACT_MIN_AGE_S
     os.utime(p, (old, old), follow_symlinks=False)
 
 
@@ -1590,6 +1592,39 @@ class TestSweepStaleMediaTemps:
         sweep_stale_media_temps(media)
 
         assert sorted(p.name for p in media.iterdir()) == [_VERSIONS_FILE, "img.png"]
+
+    def test_manifest_resolved_legacy_name_spared(self, tmp_path):
+        # A LEGACY (pre-sanitizer) attachment can carry a temp-pattern name on
+        # disk — _resolve_manifest_entry still honors it — so a manifest-keyed
+        # match is a real attachment, never litter.
+        from confluence_export.media import sweep_stale_media_temps
+
+        media = tmp_path / ".media"
+        media.mkdir()
+        legacy = media / ".drawio-arch.png"
+        legacy.write_bytes(b"\x89PNG real attachment")
+        _backdate(legacy)
+        (media / _VERSIONS_FILE).write_text('{".drawio-arch.png": {}}')
+
+        sweep_stale_media_temps(media)
+
+        assert legacy.exists()
+
+    def test_preserve_pattern_regular_file_spared(self, tmp_path):
+        # .preserve-* is the one suffix-less pattern; conex's snapshots there
+        # are always directories, so a REGULAR FILE with that name can only be
+        # a legacy-named real attachment (even without a manifest entry).
+        from confluence_export.media import sweep_stale_media_temps
+
+        media = tmp_path / ".media"
+        media.mkdir()
+        legacy = media / ".preserve-notes.txt"
+        legacy.write_bytes(b"real bytes")
+        _backdate(legacy)
+
+        sweep_stale_media_temps(media)
+
+        assert legacy.exists()
 
     def test_young_artifact_spared_as_possibly_live(self, tmp_path):
         # A matching artifact younger than the min-age gate may belong to a

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -144,6 +144,27 @@ class TestResolveFoldersMultilevel:
         client.get_folder_by_id.assert_not_called()
         assert len(result) == 2
 
+    def test_folder_with_explicit_nulls_coalesced(self):
+        """#47 class: the v2 dialect returns the RAW folder dict (no builder),
+        so explicit nulls reach this Page(...) construction directly — a None
+        title/position used to crash the layout planner / tree sort OUTSIDE
+        every per-page guard, aborting the whole export."""
+        pages = [_make_page("1", parent_id="f1")]
+
+        client = MagicMock()
+        client.get_folder_by_id.return_value = {
+            "id": "f1", "title": None, "spaceId": None, "parentId": None,
+            "parentType": None, "position": None,
+        }
+        result = CacheStore._resolve_folders(client, pages)
+
+        folder = next(p for p in result if p.id == "f1")
+        assert folder.title == ""
+        assert folder.space_id == ""   # not the truthy string "None"
+        assert folder.parent_id == ""
+        assert folder.parent_type == ""
+        assert folder.position == 0
+
 
 # ---------------------------------------------------------------------------
 # download_attachments – parallel error isolation

--- a/tests/test_protection.py
+++ b/tests/test_protection.py
@@ -9,6 +9,7 @@ instead of a buried end-to-end prune path. This file is that boundary.
 from pathlib import Path
 
 from confluence_export.media import MEDIA_DIR_NAME
+from confluence_export.paths import nfc_casefold
 from confluence_export.protection import (
     PageExactProtection,
     ProtectedDir,
@@ -89,6 +90,62 @@ class TestBuildProtected:
         assert d.resolved == outside.resolve()  # resolved follows the symlink
         assert d.lexical == link.absolute()  # lexical does not
         assert d.resolved != d.lexical
+
+
+class TestBuildProtectedCaseFold:
+    """#44: with a case/Unicode fold, a protected dir matches a committed path that
+    differs only in case — the prune folds its staleness key, so protection must
+    fold too or a re-cased page is silently pruned. Folding is applied PER FORM so
+    the resolved/lexical symlink dual is preserved. FS-independent (the fold is
+    passed explicitly, not probed)."""
+
+    @staticmethod
+    def _f(p: Path) -> Path:
+        return Path(nfc_casefold(str(p)))
+
+    def test_folded_subtree_matches_other_case_file(self, tmp_path):
+        out = tmp_path / "out"
+        out.mkdir()
+        _, sub = build_protected(
+            out, ProtectionSet(subtrees=(SubtreeProtection(out / "FOO"),)), fold=nfc_casefold
+        )
+        committed = out / "Foo" / "Foo.md"  # same dir, different case
+        assert sub[0].contains_subtree(
+            self._f(committed.resolve()), self._f(committed.absolute())
+        )
+
+    def test_folded_page_exact_matches_other_case_owned_file(self, tmp_path):
+        out = tmp_path / "out"
+        out.mkdir()
+        page, _ = build_protected(
+            out, ProtectionSet(page_exact=(PageExactProtection(out / "FOO"),)), fold=nfc_casefold
+        )
+        owned = out / "Foo" / "Foo.md"
+        assert page[0].owns_exactly(
+            self._f(owned.resolve()), self._f(owned.absolute())
+        )
+
+    def test_identity_fold_stays_case_sensitive(self, tmp_path):
+        # The identity default does no folding, so a different-case file does NOT
+        # match. (It is a test-only no-op — NOT the prune's case-sensitive-FS fold,
+        # which is `nfc` and still folds NFD→NFC; see build_protected's contract.)
+        out = tmp_path / "out"
+        out.mkdir()
+        _, sub = build_protected(out, ProtectionSet(subtrees=(SubtreeProtection(out / "FOO"),)))
+        other = out / "Foo" / "Foo.md"
+        assert not sub[0].contains_subtree(other.resolve(), other.absolute())
+
+    def test_fold_does_not_overmatch_sibling(self, tmp_path):
+        # Folding must not make 'Foo' protect 'Foobar' — distinct dirs stay distinct.
+        out = tmp_path / "out"
+        out.mkdir()
+        _, sub = build_protected(
+            out, ProtectionSet(subtrees=(SubtreeProtection(out / "Foo"),)), fold=nfc_casefold
+        )
+        sibling = out / "Foobar" / "x.md"
+        assert not sub[0].contains_subtree(
+            self._f(sibling.resolve()), self._f(sibling.absolute())
+        )
 
 
 class TestProtectedDirDualForm:

--- a/tests/test_protection.py
+++ b/tests/test_protection.py
@@ -356,3 +356,31 @@ class TestMediaOwnerDirsFromWrittenFiles:
         inside = out / "Page" / MEDIA_DIR_NAME / "b.png"
         owners = media_owner_dirs_from_written_files(out, [outside, inside])
         assert owners == frozenset({(out / "Page").resolve()})
+
+
+def test_folded_subtree_matches_nfd_committed_path_with_nfc_fold(tmp_path):
+    # The OTHER #44 axis: Unicode-form drift on a case-SENSITIVE filesystem,
+    # where the shared fold is plain nfc (no casefold). A protected dir
+    # registered in NFD must match a committed path in NFC form.
+    import unicodedata
+
+    from confluence_export.paths import nfc
+    from confluence_export.protection import (
+        ProtectionSet,
+        SubtreeProtection,
+        build_protected,
+    )
+
+    out = tmp_path / "out"
+    out.mkdir()
+    name_nfd = unicodedata.normalize("NFD", "Übersicht")
+    name_nfc = unicodedata.normalize("NFC", "Übersicht")
+    assert name_nfd != name_nfc
+
+    _, sub = build_protected(
+        out, ProtectionSet(subtrees=(SubtreeProtection(out / name_nfd),)), fold=nfc
+    )
+    committed = out / name_nfc / "x.md"
+    folded_resolved = Path(nfc(str(committed.resolve())))
+    folded_lexical = Path(nfc(str(committed.absolute())))
+    assert sub[0].contains_subtree(folded_resolved, folded_lexical)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -28,6 +28,21 @@ class TestSpace:
         assert s.homepage_id == "42"
         assert s.webui == "/wiki/spaces/TEST"
 
+    def test_from_api_null_links_coalesced(self):
+        # #47 class: an explicit null _links must not crash from_api.
+        s = Space.from_api({"id": "1", "key": "TEST", "_links": None})
+        assert s.webui == ""
+        assert s.base == ""
+
+    def test_from_api_explicit_nulls_coalesced_everywhere(self):
+        # #47 class: space.key/name feed directory naming; a None crashes it.
+        s = Space.from_api({"id": None, "key": None, "name": None,
+                            "type": None, "status": None, "homepageId": None})
+        assert s.id == ""        # not the truthy string "None"
+        assert s.key == ""
+        assert s.name == ""
+        assert s.homepage_id == ""
+
 
 class TestVersion:
     def test_from_api_none(self):
@@ -57,6 +72,32 @@ class TestPage:
         assert p.id == "42"
         assert p.body_storage == "<p>content</p>"
         assert p.webui == "/wiki/42"
+
+    def test_from_api_null_links_coalesced(self):
+        # #47 class: an explicit null _links must not crash from_api.
+        p = Page.from_api({"id": "42", "title": "Hello", "_links": None})
+        assert p.webui == ""
+        assert p.editui == ""
+        assert p.tinyui == ""
+
+    def test_from_api_explicit_nulls_coalesced_everywhere(self):
+        # #47 class: a null title used to abort the WHOLE space export in the
+        # layout planner — and to_dict round-tripped the None into the cache,
+        # so every --cached run crashed too until a refresh.
+        p = Page.from_api({
+            "id": "42", "title": None, "spaceId": None, "parentId": None,
+            "parentType": None, "position": None, "status": None,
+            "authorId": None, "createdAt": None,
+            "version": {"number": None, "createdAt": None},
+        })
+        assert p.title == ""
+        assert p.space_id == ""      # not the truthy string "None"
+        assert p.parent_id == ""
+        assert p.position == 0
+        assert p.version.number == 0
+        d = p.to_dict()
+        p2 = Page.from_dict(d)
+        assert p2.title == ""        # the cache round-trip stays clean
 
     def test_round_trip(self):
         p = Page(id="1", title="Test", space_id="s1", parent_id="p1",
@@ -105,6 +146,22 @@ class TestAttachment:
         assert a.title == ""
         assert a.media_type == ""
         assert a.media_type_description == ""
+
+    def test_from_api_null_links_coalesced(self):
+        # #47 class: an explicit null _links crashed from_api itself
+        # (links.get on None), one line above the fields #47 fixed.
+        a = Attachment.from_api({"id": "att1", "title": "f.png", "_links": None})
+        assert a.download_link == ""
+        assert a.webui == ""
+
+    def test_from_api_null_page_id_and_file_size_coalesced(self):
+        # str(None) is the TRUTHY string "None": a null pageId used to defeat
+        # the `if att.page_id` guard and build a /content/None/ download URL.
+        a = Attachment.from_api({"id": "a1", "title": "f.png",
+                                 "pageId": None, "fileSize": None, "comment": None})
+        assert a.page_id == ""
+        assert a.file_size == 0
+        assert a.comment == ""
 
     def test_round_trip(self):
         a = Attachment(id="a1", title="f.pdf", media_type="application/pdf",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -96,6 +96,16 @@ class TestAttachment:
         assert a.download_link == "/wiki/download/att1"
         assert a.file_size == 1024
 
+    def test_from_api_null_strings_coalesced(self):
+        # #47: the API/cache can carry an explicit null for these fields (the
+        # dict-key defaults only apply when the key is ABSENT); a None would
+        # crash every .casefold()/.endswith() consumer (the drawio matchers).
+        data = {"id": "att1", "title": None, "mediaType": None, "mediaTypeDescription": None}
+        a = Attachment.from_api(data)
+        assert a.title == ""
+        assert a.media_type == ""
+        assert a.media_type_description == ""
+
     def test_round_trip(self):
         a = Attachment(id="a1", title="f.pdf", media_type="application/pdf",
                        file_size=2048, page_id="p1",

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -99,6 +99,14 @@ class TestPage:
         p2 = Page.from_dict(d)
         assert p2.title == ""        # the cache round-trip stays clean
 
+    def test_from_api_null_body_storage_value_coalesced(self):
+        # #47 class: the one field the first coalescing pass missed. A None
+        # here reaches BeautifulSoup in convert_page (TypeError), so the page
+        # is warned and skipped on EVERY run instead of exporting empty.
+        p = Page.from_api({"id": "42", "title": "T",
+                           "body": {"storage": {"value": None}}})
+        assert p.body_storage == ""
+
     def test_round_trip(self):
         p = Page(id="1", title="Test", space_id="s1", parent_id="p1",
                  parent_type="page", position=2, status="current",


### PR DESCRIPTION
Closes #43, closes #44, closes #45, closes #46, closes #47, closes #48 — all open issues.

## #44 (high, data loss): fold case/Unicode in protection matching

On a case-insensitive filesystem (macOS), the git stale-prune folds its staleness key (NFC + casefold) but the **protection matchers compared case-sensitively**. A page whose title changed only in case — protected at the *new* case while its committed dir kept the *old* case — failed to match, was silently `git rm`'d, **and the restore failed to heal it**. Pre-existing on `main`, not a regression, but a high-severity silent data-loss path.

**Fix:** thread **one** `fold` (NFC+casefold on a case-insensitive FS, NFC otherwise) through the whole protection pipeline so matching agrees with the already-folded staleness key:
- `protection.build_protected` gains a `fold` param and stores each `ProtectedDir` form folded — **per form**, so the resolved/lexical symlink dual stays two independent values (never unioned; preserves the module's security note).
- `git.commit_export` probes the FS once and threads that fold to `build_protected`, `_remove_stale_files`, and `_restore_protected_deletions`.
- Prune and restore fold their queried file forms, and the `--no-media` media-keep predicate folds the owner + written/prune sets, with the same fold.

**Tests:** 3 integration tests (`_fs_is_case_insensitive` patched so Linux CI exercises the folded path deterministically): protect at `FOO` while the committed dir is `Foo` — each verified to **fail without** the protection-side fold. FS-independent unit tests incl. a no-overmatch guard (`Foo` must not protect `Foobar`).

**Adversarial review** (3 lenses: over-prune / symlink-invariant / fold-consistency) confirmed no over-prune and the symlink dual preserved; its one low finding (divergent `build_protected` identity default vs. the consumers' probe default — no production impact, `commit_export` is the sole caller and always threads one fold) was documented as an explicit same-fold caller contract.

That footgun then **manifested in our own probe-fallback test**: it passed on case-sensitive CI but failed deterministically on macOS, because pytest's tmp path contains an uppercase `/T/` component that only the query side folded. The test now builds protection with the probed fold, per the contract (`ce116a7`). Structural enforcement (required `fold`) stays deferred.

## All remaining open issues, one commit each

- **#45 (medium):** an *untitled* `panel`/`info`/`note`/`expand` looked its title up **recursively**, stealing a nested macro's `title` param — wrong header + the nested content duplicated. Both the title and `rich-text-body` lookups are now `recursive=False` (matching the `_convert_dynamic_macro_placeholder` precedent).
- **#46 (low):** the 429 branch of `_on_request_error` returned unconditionally, so a sustained 429 fell through to a generic `RuntimeError` — not a `RequestException`, escaping the CLI's network-error handler as a raw traceback. It now mirrors the 5xx branch and raises the typed `HTTPError` (status + Retry-After) on the final attempt. The end-of-loop `RuntimeError` lines remain as defensive backstops, covered via `max_retries=0`.
- **#47 (low):** `"mediaType": null` / `"title": null` in an attachment record bypassed the dict-key defaults and the `None` crashed `find_drawio_attachments` and the converter's `_is_drawio` (`.casefold()`); the exporter's per-page guard turned that into a silent page skip. `Attachment.from_api` now coalesces the nullable string fields to `""` at the source.
- **#48 (low):** a hard kill could leave `.download-/.copy-/.versions-/.rollback-*.tmp` files or a `.preserve-*` dir in `.media` (never staged or pruned — pure litter). Each page's media phase now best-effort sweeps them **before** creating its own temps/rollback snapshots (so only stale ones can match; `safe_attachment_name` rejects leading-dot titles, so no real attachment can collide, and the live `.versions.json` matches no pattern). Also: the `.preserve-*` `TemporaryDirectory` is cleaned up when a mid-snapshot copy raises before the caller binds it.
- **#43 (low):** the decision-list renderer's recursive item scan would emit a nested `decisionList`'s items twice. Items whose nearest enclosing list isn't the one being rendered are now skipped. (Shape not producible by real Confluence ADF — hardening.)

Every fix was written test-first (each regression test verified failing before the fix).

## Post-review follow-ups (landed on this PR after the six fixes)

Three further review rounds (4 specialists + red team + Claude/Codex adversarial, plus a post-commit Codex pass) hardened the branch — 7 commits:

- `08cc12c`/`3dfa300`/`f0ece68`/`d20efef`/`65e4366` — first full `/review`: `or`-coalescing on every `from_api`/`_*_from_v1` field, 429 window extended on exhaustion + Retry-After clamp (`inf`/huge headers), one innermost-first nestable-list pass (cross-type task/decision nesting), macro-owned body recovery on malformed storage, media temp sweep age gate + shared prefix constants, fold policy consolidation (`_fold_for`).
- `1c19dd2` — nulls coalesced at every CONSTRUCTION layer, not just builders: the raw v2 **folder** dict (`cache._resolve_folders` — a `"title"/"position": null` folder aborted the whole export outside every per-page guard; found independently by Claude red-team and Codex), `body.storage.value` (the one field the "every field" pass missed — page silently skipped every run), pagination envelopes; v1-builder null-shape parity tests; `_RETRY_AFTER_DEFAULT_S`.
- `90cbf17` — sweep age-gate mtime hole: `copy2` stamped the source's old mtime onto LIVE `.rollback-` snapshots, defeating the 1h gate (verified empirically); the sweep also now spares manifest-keyed legacy names and `.preserve-*` regular files (pre-sanitizer trees can hold real dot-named attachments).
- `c57ef23` — test for the #44 keep-by-WRITE fold direction (the one #44 arm without a behavioral test).
- `d88ba63` — 3+-level nested lists: recursive `find_all("ul")` extraction flattened "Mid > Inner" into siblings of Mid (post-commit Codex finding); only top-level rendered sublists are lifted now, at all three sites including the stray splice.

Every fix test-first (verified failing before the fix). Deferred findings are recorded in the repo's untracked `backlog.md` (items 1-23).

## Tests

940 passing, 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

